### PR TITLE
Add persistent inbox for agent sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,5 +11,6 @@
 - UI updates must be optimistic; persist to the DB in the background.
 - Reuse established UI structure, components, and styling; avoid one-off patterns unless explicitly requested.
 - Keep UI self-explanatory; prefer strong visual cues over explanatory copy.
+- Default interactable UI controls to lucide icon affordances with hover/tooltip text rather than persistent button labels, unless the user explicitly asks for visible text.
 - UI must flow; popovers and transitions should stay aligned to their source element.
 - Editing a field must not change layout metrics; keep size, spacing, and typography stable unless asked otherwise.

--- a/desktop/pi-threads.cts
+++ b/desktop/pi-threads.cts
@@ -7,6 +7,7 @@ export {
 } from "./pi-packages/index.cts";
 export {
   loadArchivedThreadList,
+  loadInboxThreadList,
   loadProjectThreads,
   loadThread,
 } from "./pi-threads/thread-loader.cts";

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -13,6 +13,7 @@ import { getPiModule } from "../pi-module.cts";
 import { loadProjectDiff, loadProjectGitState } from "../project-git.cts";
 import { listProjects, syncSessionSummaries } from "../thread-state-db.cts";
 import { setWatchedSessionPath } from "./session-watch.cts";
+export { loadInboxThreadList } from "./thread-loader.cts";
 
 type SessionSummary = {
   id: string;

--- a/desktop/pi-threads/thread-actions.cts
+++ b/desktop/pi-threads/thread-actions.cts
@@ -1,12 +1,18 @@
 import { unlink } from "node:fs/promises";
 import type { DesktopAction } from "../../shared/desktop-actions.ts";
 import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts";
-import { getComposerRequest, getThreadId } from "../../shared/pi-thread-action-payloads.ts";
+import {
+  getComposerRequest,
+  getSessionPath,
+  getThreadId,
+} from "../../shared/pi-thread-action-payloads.ts";
 import { openThreadRuntime, startNewThread } from "../pi-desktop-runtime.cts";
 import {
   archiveThread,
   deleteThreadRecord,
+  dismissInboxThread,
   getThreadSessionPath,
+  markInboxThreadRead,
   restoreThread,
   toggleThreadPinned,
 } from "../thread-state-db.cts";
@@ -46,9 +52,14 @@ export async function handleThreadDesktopAction(
       return handledAction();
     }
 
-    case "thread.open":
+    case "thread.open": {
+      const sessionPath = getSessionPath(payload);
       await openThreadRuntime(getComposerRequest(payload));
+      if (sessionPath) {
+        markInboxThreadRead(sessionPath);
+      }
       return handledAction();
+    }
 
     case "thread.archive": {
       const threadId = getThreadId(payload);
@@ -76,6 +87,22 @@ export async function handleThreadDesktopAction(
 
     case "thread.new":
       return handledAction(await startNewThread(getComposerRequest(payload)));
+
+    case "inbox.mark-read": {
+      const sessionPath = getSessionPath(payload);
+      if (sessionPath) {
+        markInboxThreadRead(sessionPath);
+      }
+      return handledAction();
+    }
+
+    case "inbox.dismiss": {
+      const sessionPath = getSessionPath(payload);
+      if (sessionPath) {
+        dismissInboxThread(sessionPath);
+      }
+      return handledAction();
+    }
 
     default:
       return unhandledAction();

--- a/desktop/pi-threads/thread-loader.cts
+++ b/desktop/pi-threads/thread-loader.cts
@@ -1,5 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { ArchivedThread, Thread, ThreadData } from "../../shared/desktop-contracts.ts";
+import type {
+  ArchivedThread,
+  InboxThread,
+  Thread,
+  ThreadData,
+} from "../../shared/desktop-contracts.ts";
 import { getPreviousMessageCount } from "../../shared/pi-message-mapper.ts";
 import { buildThreadData } from "../../shared/thread-data.ts";
 import { type SessionPathEntry, buildThreadHistorySlice } from "../../shared/thread-history.ts";
@@ -8,8 +13,10 @@ import { getPiModule } from "../pi-module.cts";
 import {
   ensureProject,
   listArchivedThreads,
+  listInboxThreads,
   listProjectThreads,
   listTurnDiffSummaries,
+  upsertInboxThreadPrompt,
 } from "../thread-state-db.cts";
 
 export type LoadedThreadSnapshot = {
@@ -25,6 +32,36 @@ export async function loadProjectThreads(projectId: string): Promise<Thread[]> {
 
 export async function loadArchivedThreadList(): Promise<ArchivedThread[]> {
   return listArchivedThreads();
+}
+
+export async function loadInboxThreadList(): Promise<InboxThread[]> {
+  const threads = listInboxThreads();
+
+  return Promise.all(
+    threads.map(async (thread) => {
+      if (thread.prompt?.trim()) {
+        return thread;
+      }
+
+      const loadedThread = await loadThread(thread.sessionPath);
+      let prompt: string | null = null;
+
+      for (const message of [...loadedThread.messages].reverse()) {
+        if (message.role === "user") {
+          const nextPrompt = message.content.join("\n\n").trim();
+          prompt = nextPrompt.length > 0 ? nextPrompt : null;
+          break;
+        }
+      }
+
+      if (!prompt) {
+        return thread;
+      }
+
+      upsertInboxThreadPrompt(thread.sessionPath, prompt);
+      return { ...thread, prompt };
+    }),
+  );
 }
 
 export async function loadThreadSnapshot(

--- a/desktop/pi-threads/thread-loader.cts
+++ b/desktop/pi-threads/thread-loader.cts
@@ -39,27 +39,32 @@ export async function loadInboxThreadList(): Promise<InboxThread[]> {
 
   return Promise.all(
     threads.map(async (thread) => {
-      if (thread.prompt?.trim()) {
-        return thread;
-      }
-
-      const loadedThread = await loadThread(thread.sessionPath);
-      let prompt: string | null = null;
-
-      for (const message of [...loadedThread.messages].reverse()) {
-        if (message.role === "user") {
-          const nextPrompt = message.content.join("\n\n").trim();
-          prompt = nextPrompt.length > 0 ? nextPrompt : null;
-          break;
+      try {
+        if (thread.prompt?.trim()) {
+          return thread;
         }
-      }
 
-      if (!prompt) {
+        const loadedThread = await loadThread(thread.sessionPath);
+        let prompt: string | null = null;
+
+        for (const message of [...loadedThread.messages].reverse()) {
+          if (message.role === "user") {
+            const nextPrompt = message.content.join("\n\n").trim();
+            prompt = nextPrompt.length > 0 ? nextPrompt : null;
+            break;
+          }
+        }
+
+        if (!prompt) {
+          return thread;
+        }
+
+        upsertInboxThreadPrompt(thread.sessionPath, prompt);
+        return { ...thread, prompt };
+      } catch (error) {
+        console.warn(`Failed to backfill inbox prompt for ${thread.sessionPath}.`, error);
         return thread;
       }
-
-      upsertInboxThreadPrompt(thread.sessionPath, prompt);
-      return { ...thread, prompt };
     }),
   );
 }

--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -4,7 +4,14 @@ import type { ComposerState, ThreadData } from "../../shared/desktop-contracts.t
 import { getPreviousMessageCount } from "../../shared/pi-message-mapper.ts";
 import { buildThreadData } from "../../shared/thread-data.ts";
 import { getTurnDiffSummaries } from "../diff/query.cts";
-import { upsertThreadSummary } from "../thread-state-db.cts";
+import {
+  beginInboxThreadTurn,
+  getThreadAssistantSnapshot,
+  hasInboxItem,
+  setThreadRunningState,
+  upsertInboxThreadMessage,
+  upsertThreadSummary,
+} from "../thread-state-db.cts";
 import { buildComposerState } from "./composer-state.cts";
 import { emitDesktopEvent, subscribeDesktopEvents } from "./desktop-events.cts";
 import {
@@ -36,6 +43,66 @@ function buildLiveThreadData(runtime: PiRuntime) {
     isStreaming: runtime.session.isStreaming,
     turnDiffSummaries: getTurnDiffSummaries(sessionPath),
   });
+}
+
+function getLatestAssistantMessage(thread: ThreadData) {
+  const latestAssistantMessage = [...thread.messages]
+    .reverse()
+    .find((message) => message.role === "assistant");
+
+  if (!latestAssistantMessage || latestAssistantMessage.role !== "assistant") {
+    return null;
+  }
+
+  const content =
+    latestAssistantMessage.content.length > 0
+      ? latestAssistantMessage.content
+      : (latestAssistantMessage.thinkingContent ?? []);
+
+  if (content.length === 0) {
+    return null;
+  }
+
+  return {
+    content,
+    preview:
+      latestAssistantMessage.content[0] ??
+      latestAssistantMessage.thinkingHeaders?.[0] ??
+      latestAssistantMessage.thinkingContent?.[0] ??
+      null,
+  };
+}
+
+function hasAssistantMessageChanged(
+  sessionPath: string,
+  latestAssistantMessage: ReturnType<typeof getLatestAssistantMessage>,
+) {
+  if (!latestAssistantMessage) {
+    return false;
+  }
+
+  const storedAssistantSnapshot = getThreadAssistantSnapshot(sessionPath);
+  if (!storedAssistantSnapshot) {
+    return true;
+  }
+
+  return (
+    storedAssistantSnapshot.messageJson !== JSON.stringify(latestAssistantMessage.content) ||
+    storedAssistantSnapshot.preview !== latestAssistantMessage.preview
+  );
+}
+
+function getLatestUserPrompt(thread: ThreadData) {
+  const latestUserMessage = [...thread.messages]
+    .reverse()
+    .find((message) => message.role === "user");
+
+  if (!latestUserMessage || latestUserMessage.role !== "user") {
+    return null;
+  }
+
+  const prompt = latestUserMessage.content.join("\n\n").trim();
+  return prompt.length > 0 ? prompt : null;
 }
 
 export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThreadReason) {
@@ -74,6 +141,32 @@ export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThr
       title: thread.title,
       lastModifiedMs: timestamp,
     });
+
+    setThreadRunningState(
+      sessionPath,
+      reason === "update" || (reason === "start" && thread.messages.length > 0),
+    );
+
+    if (reason === "start") {
+      const latestUserPrompt = getLatestUserPrompt(thread);
+      if (latestUserPrompt || hasInboxItem(sessionPath)) {
+        beginInboxThreadTurn(sessionPath, latestUserPrompt);
+      }
+    }
+
+    if (reason === "end") {
+      const latestUserPrompt = getLatestUserPrompt(thread);
+      const latestAssistantMessage = getLatestAssistantMessage(thread);
+      if (latestAssistantMessage) {
+        upsertInboxThreadMessage({
+          sessionPath,
+          userPrompt: latestUserPrompt,
+          content: latestAssistantMessage.content,
+          preview: latestAssistantMessage.preview,
+          lastAssistantAtMs: timestamp,
+        });
+      }
+    }
   }
 
   emitDesktopEvent({
@@ -109,6 +202,19 @@ export async function publishExternalThreadUpdate({
     title: thread.title,
     lastModifiedMs,
   });
+  setThreadRunningState(sessionPath, false);
+
+  const latestAssistantMessage = getLatestAssistantMessage(thread);
+  if (latestAssistantMessage && hasAssistantMessageChanged(sessionPath, latestAssistantMessage)) {
+    const latestUserPrompt = getLatestUserPrompt(thread);
+    upsertInboxThreadMessage({
+      sessionPath,
+      userPrompt: latestUserPrompt,
+      content: latestAssistantMessage.content,
+      preview: latestAssistantMessage.preview,
+      lastAssistantAtMs: lastModifiedMs,
+    });
+  }
 
   emitDesktopEvent({
     type: "thread-update",

--- a/desktop/thread-state-db.cts
+++ b/desktop/thread-state-db.cts
@@ -1,8 +1,11 @@
 export type { SessionSummaryRecord } from "./thread-state-db/types.cts";
 export {
+  getThreadAssistantSnapshot,
   getLatestTurnDiffSummary,
   getThreadCwd,
   getThreadSessionPath,
+  hasInboxItem,
+  listInboxThreads,
   listArchivedThreads,
   listProjectThreads,
   listProjects,
@@ -11,10 +14,13 @@ export {
 export {
   archiveProjectThreads,
   archiveThread,
+  beginInboxThreadTurn,
   collapseAllProjects,
   deleteThreadRecord,
+  dismissInboxThread,
   ensureProject,
   hideProject,
+  markInboxThreadRead,
   moveProjectToTop,
   reorderProjects,
   renameProject,
@@ -22,8 +28,11 @@ export {
   setProjectRepoOrigin,
   setProjectCollapsed,
   syncSessionSummaries,
+  setThreadRunningState,
   toggleProjectPinned,
   toggleThreadPinned,
+  upsertInboxThreadPrompt,
+  upsertInboxThreadMessage,
   upsertThreadSummary,
   upsertTurnDiffSummary,
 } from "./thread-state-db/writes.cts";

--- a/desktop/thread-state-db/db.cts
+++ b/desktop/thread-state-db/db.cts
@@ -13,11 +13,10 @@ function getDatabasePath() {
 }
 
 export function getThreadStateDatabase() {
-  if (database) {
-    return database;
+  if (!database) {
+    database = new Database(getDatabasePath());
   }
 
-  database = new Database(getDatabasePath());
   ensureThreadStateSchema(database);
   return database;
 }

--- a/desktop/thread-state-db/mappers.cts
+++ b/desktop/thread-state-db/mappers.cts
@@ -13,6 +13,22 @@ import type {
   TurnDiffRow,
 } from "./types.cts";
 
+function parseStringArrayJson(value: string | null, context: string) {
+  if (!value) {
+    return [] as string[];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch (error) {
+    console.warn(`Failed to parse ${context}.`, error);
+    return [];
+  }
+}
+
 export function formatRelativeAge(lastModifiedMs: number) {
   const elapsedMs = Math.max(0, Date.now() - lastModifiedMs);
   const minute = 60 * 1000;
@@ -81,7 +97,7 @@ export function mapInboxThreadRow(row: InboxThreadRow): InboxThread {
     sessionPath: row.sessionPath,
     age: formatRelativeAge(row.lastActivityMs),
     prompt: row.lastUserPrompt,
-    content: row.lastAssistantMessageJson ? JSON.parse(row.lastAssistantMessageJson) : [],
+    content: parseStringArrayJson(row.lastAssistantMessageJson, `inbox thread ${row.sessionPath}`),
     preview: row.lastAssistantPreview,
     running: Boolean(row.running),
     unread: Boolean(row.unread),

--- a/desktop/thread-state-db/mappers.cts
+++ b/desktop/thread-state-db/mappers.cts
@@ -1,10 +1,17 @@
 import type {
   ArchivedThread,
+  InboxThread,
   Project,
   Thread,
   TurnDiffSummary,
 } from "../../shared/desktop-contracts.ts";
-import type { ArchivedThreadRow, ProjectRow, ThreadRow, TurnDiffRow } from "./types.cts";
+import type {
+  ArchivedThreadRow,
+  InboxThreadRow,
+  ProjectRow,
+  ThreadRow,
+  TurnDiffRow,
+} from "./types.cts";
 
 export function formatRelativeAge(lastModifiedMs: number) {
   const elapsedMs = Math.max(0, Date.now() - lastModifiedMs);
@@ -57,8 +64,27 @@ export function mapThreadRow(row: ThreadRow): Thread {
     id: row.id,
     title: row.title,
     age: formatRelativeAge(row.lastModifiedMs),
+    summary: row.summary ?? undefined,
+    running: Boolean(row.running),
+    unread: Boolean(row.unread),
     pinned: Boolean(row.pinned),
     sessionPath: row.sessionPath,
+  };
+}
+
+export function mapInboxThreadRow(row: InboxThreadRow): InboxThread {
+  return {
+    threadId: row.threadId,
+    title: row.title,
+    projectId: row.projectId,
+    projectName: row.projectName,
+    sessionPath: row.sessionPath,
+    age: formatRelativeAge(row.lastActivityMs),
+    prompt: row.lastUserPrompt,
+    content: row.lastAssistantMessageJson ? JSON.parse(row.lastAssistantMessageJson) : [],
+    preview: row.lastAssistantPreview,
+    running: Boolean(row.running),
+    unread: Boolean(row.unread),
   };
 }
 

--- a/desktop/thread-state-db/queries.cts
+++ b/desktop/thread-state-db/queries.cts
@@ -1,14 +1,24 @@
 import type {
   ArchivedThread,
+  InboxThread,
   Project,
   Thread,
   TurnDiffSummary,
 } from "../../shared/desktop-contracts.ts";
 import { getThreadStateDatabase } from "./db.cts";
-import { mapArchivedThreadRow, mapProjectRow, mapThreadRow, mapTurnDiffRow } from "./mappers.cts";
+import {
+  mapArchivedThreadRow,
+  mapInboxThreadRow,
+  mapProjectRow,
+  mapThreadRow,
+  mapTurnDiffRow,
+} from "./mappers.cts";
 import type {
   ArchivedThreadRow,
+  InboxPathRow,
+  InboxThreadRow,
   ProjectRow,
+  ThreadAssistantSnapshotRow,
   ThreadCwdRow,
   ThreadPathRow,
   ThreadRow,
@@ -64,19 +74,58 @@ export function listProjectThreads(projectId: string): Thread[] {
     .prepare(
       `
         SELECT
-          id,
-          title,
-          session_path AS sessionPath,
-          pinned,
-          last_modified_ms AS lastModifiedMs
+          threads.id AS id,
+          threads.title AS title,
+          threads.session_path AS sessionPath,
+          COALESCE(inbox_items.last_assistant_preview, threads.last_assistant_preview) AS summary,
+          threads.running AS running,
+          COALESCE(inbox_items.unread, 0) AS unread,
+          threads.pinned AS pinned,
+          threads.last_modified_ms AS lastModifiedMs
         FROM threads
-        WHERE cwd = ? AND archived = 0
-        ORDER BY pinned DESC, last_modified_ms DESC, title COLLATE NOCASE ASC
+        LEFT JOIN inbox_items ON inbox_items.session_path = threads.session_path
+        WHERE threads.cwd = ? AND threads.archived = 0
+        ORDER BY threads.pinned DESC, threads.last_modified_ms DESC, threads.title COLLATE NOCASE ASC
       `,
     )
     .all(projectId) as ThreadRow[];
 
   return rows.map(mapThreadRow);
+}
+
+export function listInboxThreads(): InboxThread[] {
+  const db = getThreadStateDatabase();
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          threads.id AS threadId,
+          threads.title AS title,
+          threads.cwd AS projectId,
+          COALESCE(projects.custom_name, projects.name) AS projectName,
+          threads.session_path AS sessionPath,
+          inbox_items.last_user_prompt AS lastUserPrompt,
+          inbox_items.last_assistant_message_json AS lastAssistantMessageJson,
+          inbox_items.last_assistant_preview AS lastAssistantPreview,
+          threads.running AS running,
+          inbox_items.unread AS unread,
+          COALESCE(inbox_items.last_assistant_at_ms, threads.last_modified_ms) AS lastActivityMs
+        FROM inbox_items
+        INNER JOIN threads ON threads.session_path = inbox_items.session_path
+        INNER JOIN projects ON projects.cwd = threads.cwd
+        WHERE
+          projects.hidden = 0
+          AND threads.archived = 0
+        ORDER BY
+          inbox_items.unread DESC,
+          threads.running DESC,
+          COALESCE(inbox_items.last_assistant_at_ms, threads.last_modified_ms) DESC,
+          threads.title COLLATE NOCASE ASC
+      `,
+    )
+    .all() as InboxThreadRow[];
+
+  return rows.map(mapInboxThreadRow);
 }
 
 export function listArchivedThreads(): ArchivedThread[] {
@@ -130,6 +179,42 @@ export function getThreadCwd(sessionPath: string) {
     .get(sessionPath) as ThreadCwdRow | undefined;
 
   return row?.cwd ?? null;
+}
+
+export function hasInboxItem(sessionPath: string) {
+  const db = getThreadStateDatabase();
+  const row = db
+    .prepare(
+      `
+        SELECT session_path AS sessionPath
+        FROM inbox_items
+        WHERE session_path = ?
+      `,
+    )
+    .get(sessionPath) as InboxPathRow | undefined;
+
+  return Boolean(row?.sessionPath);
+}
+
+export function getThreadAssistantSnapshot(sessionPath: string) {
+  const db = getThreadStateDatabase();
+  const row = db
+    .prepare(
+      `
+        SELECT
+          last_assistant_message_json AS messageJson,
+          last_assistant_preview AS preview
+        FROM threads
+        WHERE session_path = ?
+      `,
+    )
+    .get(sessionPath) as ThreadAssistantSnapshotRow | undefined;
+
+  if (!row?.messageJson) {
+    return null;
+  }
+
+  return row;
 }
 
 export function listTurnDiffSummaries(sessionPath: string): TurnDiffSummary[] {

--- a/desktop/thread-state-db/schema.cts
+++ b/desktop/thread-state-db/schema.cts
@@ -38,6 +38,10 @@ export function ensureThreadStateSchema(database: Database) {
       cwd TEXT NOT NULL,
       session_path TEXT NOT NULL UNIQUE,
       title TEXT NOT NULL,
+      last_assistant_message_json TEXT,
+      last_assistant_preview TEXT,
+      last_assistant_at_ms INTEGER,
+      running INTEGER NOT NULL DEFAULT 0,
       pinned INTEGER NOT NULL DEFAULT 0,
       archived INTEGER NOT NULL DEFAULT 0,
       last_modified_ms INTEGER NOT NULL,
@@ -61,6 +65,20 @@ export function ensureThreadStateSchema(database: Database) {
     );
 
     CREATE INDEX IF NOT EXISTS thread_turn_diffs_by_path_idx ON thread_turn_diffs(session_path, checkpoint_turn_count DESC);
+
+    CREATE TABLE IF NOT EXISTS inbox_items (
+      session_path TEXT PRIMARY KEY,
+      unread INTEGER NOT NULL DEFAULT 1,
+      last_user_prompt TEXT,
+      last_assistant_message_json TEXT,
+      last_assistant_preview TEXT,
+      last_assistant_at_ms INTEGER,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (session_path) REFERENCES threads(session_path) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS inbox_items_by_unread_idx ON inbox_items(unread DESC, last_assistant_at_ms DESC);
 
     CREATE TABLE IF NOT EXISTS app_preferences (
       key TEXT PRIMARY KEY,
@@ -91,6 +109,26 @@ export function ensureThreadStateSchema(database: Database) {
 
   if (!hasColumn(database, "projects", "repo_origin_checked")) {
     database.exec("ALTER TABLE projects ADD COLUMN repo_origin_checked INTEGER NOT NULL DEFAULT 0");
+  }
+
+  if (!hasColumn(database, "threads", "last_assistant_message_json")) {
+    database.exec("ALTER TABLE threads ADD COLUMN last_assistant_message_json TEXT");
+  }
+
+  if (!hasColumn(database, "threads", "last_assistant_preview")) {
+    database.exec("ALTER TABLE threads ADD COLUMN last_assistant_preview TEXT");
+  }
+
+  if (!hasColumn(database, "threads", "last_assistant_at_ms")) {
+    database.exec("ALTER TABLE threads ADD COLUMN last_assistant_at_ms INTEGER");
+  }
+
+  if (!hasColumn(database, "threads", "running")) {
+    database.exec("ALTER TABLE threads ADD COLUMN running INTEGER NOT NULL DEFAULT 0");
+  }
+
+  if (!hasColumn(database, "inbox_items", "last_user_prompt")) {
+    database.exec("ALTER TABLE inbox_items ADD COLUMN last_user_prompt TEXT");
   }
 
   schemaReady = true;

--- a/desktop/thread-state-db/types.cts
+++ b/desktop/thread-state-db/types.cts
@@ -28,8 +28,42 @@ export type ThreadRow = {
   id: string;
   title: string;
   sessionPath: string;
+  summary: string | null;
+  running: number;
+  unread: number;
   pinned: number;
   lastModifiedMs: number;
+};
+
+export type InboxThreadRow = {
+  threadId: string;
+  title: string;
+  projectId: string;
+  projectName: string;
+  sessionPath: string;
+  lastUserPrompt: string | null;
+  lastAssistantMessageJson: string | null;
+  lastAssistantPreview: string | null;
+  running: number;
+  unread: number;
+  lastActivityMs: number;
+};
+
+export type ThreadInboxMessageRecord = {
+  sessionPath: string;
+  userPrompt: string | null;
+  content: string[];
+  preview: string | null;
+  lastAssistantAtMs: number;
+};
+
+export type InboxPathRow = {
+  sessionPath: string;
+};
+
+export type ThreadAssistantSnapshotRow = {
+  messageJson: string | null;
+  preview: string | null;
 };
 
 export type ArchivedThreadRow = {

--- a/desktop/thread-state-db/writes.cts
+++ b/desktop/thread-state-db/writes.cts
@@ -92,9 +92,9 @@ export function setThreadRunningState(sessionPath: string, running: boolean) {
     `
       UPDATE threads
       SET running = ?, updated_at = CURRENT_TIMESTAMP
-      WHERE session_path = ?
+      WHERE session_path = ? AND running != ?
     `,
-  ).run(running ? 1 : 0, sessionPath);
+  ).run(running ? 1 : 0, sessionPath, running ? 1 : 0);
 }
 
 export function upsertInboxThreadPrompt(sessionPath: string, prompt: string | null) {

--- a/desktop/thread-state-db/writes.cts
+++ b/desktop/thread-state-db/writes.cts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { getThreadStateDatabase } from "./db.cts";
-import type { SessionSummaryRecord, TurnDiffSummaryRecord } from "./types.cts";
+import type {
+  SessionSummaryRecord,
+  ThreadInboxMessageRecord,
+  TurnDiffSummaryRecord,
+} from "./types.cts";
 
 export function ensureProject(cwd: string) {
   const db = getThreadStateDatabase();
@@ -36,6 +40,7 @@ export function syncSessionSummaries(cwd: string, sessions: SessionSummaryRecord
       ON CONFLICT(session_path) DO UPDATE SET
         id = excluded.id,
         cwd = excluded.cwd,
+        title = excluded.title,
         last_modified_ms = excluded.last_modified_ms,
         updated_at = CURRENT_TIMESTAMP
     `,
@@ -74,10 +79,127 @@ export function upsertThreadSummary(session: SessionSummaryRecord) {
       ON CONFLICT(session_path) DO UPDATE SET
         id = excluded.id,
         cwd = excluded.cwd,
+        title = excluded.title,
         last_modified_ms = excluded.last_modified_ms,
         updated_at = CURRENT_TIMESTAMP
     `,
   ).run(session.id, session.cwd, session.sessionPath, session.title, session.lastModifiedMs);
+}
+
+export function setThreadRunningState(sessionPath: string, running: boolean) {
+  const db = getThreadStateDatabase();
+  db.prepare(
+    `
+      UPDATE threads
+      SET running = ?, updated_at = CURRENT_TIMESTAMP
+      WHERE session_path = ?
+    `,
+  ).run(running ? 1 : 0, sessionPath);
+}
+
+export function upsertInboxThreadPrompt(sessionPath: string, prompt: string | null) {
+  const db = getThreadStateDatabase();
+  db.prepare(
+    `
+      INSERT INTO inbox_items (session_path, unread, last_user_prompt)
+      VALUES (?, 0, ?)
+      ON CONFLICT(session_path) DO UPDATE SET
+        last_user_prompt = excluded.last_user_prompt,
+        updated_at = CURRENT_TIMESTAMP
+    `,
+  ).run(sessionPath, prompt);
+}
+
+export function beginInboxThreadTurn(sessionPath: string, prompt: string | null) {
+  const db = getThreadStateDatabase();
+  db.prepare(
+    `
+      INSERT INTO inbox_items (
+        session_path,
+        unread,
+        last_user_prompt,
+        last_assistant_message_json,
+        last_assistant_preview,
+        last_assistant_at_ms
+      )
+      VALUES (?, 0, ?, NULL, NULL, NULL)
+      ON CONFLICT(session_path) DO UPDATE SET
+        unread = 0,
+        last_user_prompt = excluded.last_user_prompt,
+        last_assistant_message_json = NULL,
+        last_assistant_preview = NULL,
+        last_assistant_at_ms = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    `,
+  ).run(sessionPath, prompt);
+}
+
+export function markInboxThreadRead(sessionPath: string) {
+  const db = getThreadStateDatabase();
+  db.prepare(
+    `
+      UPDATE inbox_items
+      SET unread = 0, updated_at = CURRENT_TIMESTAMP
+      WHERE session_path = ?
+    `,
+  ).run(sessionPath);
+}
+
+export function dismissInboxThread(sessionPath: string) {
+  const db = getThreadStateDatabase();
+  db.prepare(
+    `
+      DELETE FROM inbox_items
+      WHERE session_path = ?
+    `,
+  ).run(sessionPath);
+}
+
+export function upsertInboxThreadMessage(record: ThreadInboxMessageRecord) {
+  const db = getThreadStateDatabase();
+  db.prepare(
+    `
+      INSERT INTO inbox_items (
+        session_path,
+        unread,
+        last_user_prompt,
+        last_assistant_message_json,
+        last_assistant_preview,
+        last_assistant_at_ms
+      )
+      VALUES (?, 1, ?, ?, ?, ?)
+      ON CONFLICT(session_path) DO UPDATE SET
+        unread = 1,
+        last_user_prompt = excluded.last_user_prompt,
+        last_assistant_message_json = excluded.last_assistant_message_json,
+        last_assistant_preview = excluded.last_assistant_preview,
+        last_assistant_at_ms = excluded.last_assistant_at_ms,
+        updated_at = CURRENT_TIMESTAMP
+    `,
+  ).run(
+    record.sessionPath,
+    record.userPrompt,
+    JSON.stringify(record.content),
+    record.preview,
+    record.lastAssistantAtMs,
+  );
+
+  db.prepare(
+    `
+      UPDATE threads
+      SET
+        last_assistant_message_json = ?,
+        last_assistant_preview = ?,
+        last_assistant_at_ms = ?,
+        updated_at = CURRENT_TIMESTAMP
+      WHERE session_path = ?
+    `,
+  ).run(
+    JSON.stringify(record.content),
+    record.preview,
+    record.lastAssistantAtMs,
+    record.sessionPath,
+  );
 }
 
 export function setProjectCollapsed(projectId: string, collapsed: boolean) {

--- a/desktop/thread-state-db/writes.cts
+++ b/desktop/thread-state-db/writes.cts
@@ -157,6 +157,8 @@ export function dismissInboxThread(sessionPath: string) {
 
 export function upsertInboxThreadMessage(record: ThreadInboxMessageRecord) {
   const db = getThreadStateDatabase();
+  const serializedContent = JSON.stringify(record.content);
+
   db.prepare(
     `
       INSERT INTO inbox_items (
@@ -179,7 +181,7 @@ export function upsertInboxThreadMessage(record: ThreadInboxMessageRecord) {
   ).run(
     record.sessionPath,
     record.userPrompt,
-    JSON.stringify(record.content),
+    serializedContent,
     record.preview,
     record.lastAssistantAtMs,
   );
@@ -194,12 +196,7 @@ export function upsertInboxThreadMessage(record: ThreadInboxMessageRecord) {
         updated_at = CURRENT_TIMESTAMP
       WHERE session_path = ?
     `,
-  ).run(
-    JSON.stringify(record.content),
-    record.preview,
-    record.lastAssistantAtMs,
-    record.sessionPath,
-  );
+  ).run(serializedContent, record.preview, record.lastAssistantAtMs, record.sessionPath);
 }
 
 export function setProjectCollapsed(projectId: string, collapsed: boolean) {

--- a/docs/implementation-todo.md
+++ b/docs/implementation-todo.md
@@ -157,6 +157,16 @@ Key files:
 - [ ] Replace mock plugin/automation/debug data or remove views
 - [ ] Add richer thread block renderers
 
+#### 7a. Thread naming from compaction summaries
+- [ ] Rename thread titles from compaction summaries instead of leaving them as first-user-message truncations
+- [ ] Trigger the rename only when a new compaction is detected so we avoid recomputing titles on ordinary thread updates
+- [ ] Keep the rename path lightweight; if needed, use a very short Pi prompt or a custom compaction extension/addon that emits a dedicated `thread name` string alongside the summary
+  - likely files: `shared/pi-message-mapper.ts`, `shared/thread-data.ts`, `desktop/runtime/thread-publisher.cts`, `desktop/pi-threads/thread-loader.cts`, and any future Pi extension/addon hook
+
+#### 7b. Inbox
+- [x] Ship the persisted inbox mailbox flow in the app shell
+- [ ] Finish the remaining supporting feature work around it; inbox itself is now functionally useful but still partial because it depends on surrounding thread/product features that are still in flight
+
 Key files:
 - `src/app/AppShell.tsx`
 - `src/app/app-shell/*`

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -111,6 +111,8 @@ export type DesktopActionPayloadMap = {
     text: string;
     attachments?: ComposerAttachment[];
   };
+  "inbox.mark-read": { sessionPath: string; projectId?: string | null };
+  "inbox.dismiss": { sessionPath: string; projectId?: string | null };
   "composer.host": EmptyActionPayload;
   "plugins.open-card": EmptyActionPayload;
   "automations.open-card": EmptyActionPayload;

--- a/shared/desktop-action-coverage.ts
+++ b/shared/desktop-action-coverage.ts
@@ -22,6 +22,8 @@ export const implementedDesktopActions = [
   "composer.model",
   "composer.thinking",
   "composer.send",
+  "inbox.mark-read",
+  "inbox.dismiss",
   "workspace.commit",
   "workspace.commit-options",
   "settings.update",

--- a/shared/desktop-actions.ts
+++ b/shared/desktop-actions.ts
@@ -37,6 +37,8 @@ export const desktopActions = [
   "composer.dictate",
   "composer.send",
   "composer.host",
+  "inbox.mark-read",
+  "inbox.dismiss",
   "plugins.open-card",
   "automations.open-card",
   "debug.open-card",

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -4,7 +4,23 @@ export type Thread = {
   age: string;
   sessionPath?: string;
   summary?: string;
+  running?: boolean;
+  unread?: boolean;
   pinned?: boolean;
+};
+
+export type InboxThread = {
+  threadId: string;
+  title: string;
+  projectId: string;
+  projectName: string;
+  sessionPath: string;
+  age: string;
+  prompt: string | null;
+  content: string[];
+  preview: string | null;
+  running: boolean;
+  unread: boolean;
 };
 
 export type Project = {

--- a/shared/electrobun-rpc.ts
+++ b/shared/electrobun-rpc.ts
@@ -10,6 +10,7 @@ import type {
   DesktopActionPayload,
   DesktopActionResult,
   DesktopEvent,
+  InboxThread,
   PiConfiguredPackage,
   PiConfiguredSkill,
   PiPackageCatalogPage,
@@ -98,6 +99,7 @@ export type PiDesktopRpc = {
       };
       getComposerState: { params: ComposerStateRequest; response: ComposerState };
       getProjectThreads: { params: { projectId: string }; response: Thread[] };
+      getInboxThreads: { params: Record<string, never>; response: InboxThread[] };
       getArchivedThreads: { params: Record<string, never>; response: ArchivedThread[] };
       getThread: {
         params: { sessionPath: string; historyCompactions?: number };

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -27,6 +27,10 @@ export function getProjectId(payload: DesktopActionPayloadInput) {
   return typeof payload.projectId === "string" ? payload.projectId : null;
 }
 
+export function getSessionPath(payload: DesktopActionPayloadInput) {
+  return typeof payload.sessionPath === "string" ? payload.sessionPath : null;
+}
+
 export function getThreadId(payload: DesktopActionPayloadInput) {
   return typeof payload.threadId === "string" ? payload.threadId : null;
 }

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -54,6 +54,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
         <div className="relative w-[300px] max-w-[calc(100vw-1rem)] min-w-0 shrink-0">
           <Sidebar
             projects={projects}
+            inboxThreads={controller.inboxThreads}
             appSettings={
               controller.shellState?.appSettings ?? {
                 gitCommitMessageModel: null,
@@ -66,6 +67,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               }
             }
             activeView={state.activeView}
+            selectedInboxSessionPath={state.selectedInboxSessionPath}
             selectedProjectId={state.selectedProjectId}
             selectedThreadId={state.selectedThreadId}
             settingsOpen={state.settingsOpen}
@@ -98,8 +100,10 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 handleToggleSettings();
               }
             }}
+            onDismissInboxThread={controller.handleDismissInboxThread}
             onProjectSelect={handleProjectSelect}
             onProjectReorder={handleProjectReorder}
+            onSelectInboxThread={controller.handleSelectInboxThread}
             onThreadOpen={handleThreadOpen}
             onToggleProjectCollapse={handleToggleProjectCollapse}
           />

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -275,6 +275,7 @@ type RunPostDesktopActionEffectsInput = {
   setArchivedThreads: (threads: ArchivedThread[]) => void;
   setComposerState: (state: ComposerState | null) => void;
   setProjectGitState: (state: ProjectGitState | null) => void;
+  queryClient: QueryClient;
 };
 
 export async function runPostDesktopActionEffects({
@@ -292,7 +293,11 @@ export async function runPostDesktopActionEffects({
   setArchivedThreads,
   setComposerState,
   setProjectGitState,
+  queryClient,
 }: RunPostDesktopActionEffectsInput) {
+  const invalidateInboxThreads = () =>
+    queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() });
+
   if (action === "thread.pin" || action === "thread.archive") {
     const projectId = getPayloadProjectId(contextualPayload);
     if (projectId) {
@@ -313,6 +318,8 @@ export async function runPostDesktopActionEffects({
     ) {
       dispatch({ type: "show-view", view: "code" });
     }
+
+    await invalidateInboxThreads();
   }
 
   if (action === "thread.restore" || action === "thread.delete") {
@@ -329,6 +336,18 @@ export async function runPostDesktopActionEffects({
     ) {
       dispatch({ type: "show-view", view: "code" });
     }
+
+    await invalidateInboxThreads();
+  }
+
+  if (action === "thread.open" || action === "inbox.mark-read" || action === "inbox.dismiss") {
+    const projectId = getPayloadProjectId(contextualPayload);
+
+    if (projectId) {
+      await loadProjectThreads(projectId);
+    }
+
+    await invalidateInboxThreads();
   }
 
   if (action === "project.edit-name") {
@@ -365,6 +384,8 @@ export async function runPostDesktopActionEffects({
     if (contextualPayload.projectId === workspaceState.selectedProjectId) {
       dispatch({ type: "show-view", view: "code" });
     }
+
+    await invalidateInboxThreads();
   }
 
   if (action === "project.remove-project") {
@@ -378,6 +399,8 @@ export async function runPostDesktopActionEffects({
       loadArchivedThreads,
       setArchivedThreads,
     });
+
+    await invalidateInboxThreads();
   }
 
   if (action === "settings.update") {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -159,6 +159,11 @@ export function useAppShellController() {
       (thread) => thread.sessionPath === state.selectedInboxSessionPath,
     );
 
+    const selectedInboxThread = hasSelectedInboxThread
+      ? (inboxThreads.find((thread) => thread.sessionPath === state.selectedInboxSessionPath) ??
+        null)
+      : null;
+
     if (!hasSelectedInboxThread) {
       const nextThread = inboxThreads[0] ?? null;
 
@@ -182,6 +187,24 @@ export function useAppShellController() {
             console.warn("Failed to auto-mark selected inbox thread read.", error);
           });
       }
+
+      return;
+    }
+
+    if (state.activeView === "inbox" && selectedInboxThread?.unread) {
+      void invokeDesktopAction("inbox.mark-read", {
+        projectId: selectedInboxThread.projectId,
+        sessionPath: selectedInboxThread.sessionPath,
+      })
+        .then(async () => {
+          await Promise.all([
+            loadProjectThreads(selectedInboxThread.projectId),
+            queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() }),
+          ]);
+        })
+        .catch((error) => {
+          console.warn("Failed to mark visible inbox thread read.", error);
+        });
     }
   }, [
     inboxThreads,

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -1,7 +1,14 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useReducer, useState } from "react";
-import type { ArchivedThread, ComposerState, ProjectGitState, ShellState } from "../desktop/types";
+import { useEffect, useMemo, useReducer, useState } from "react";
+import type {
+  ArchivedThread,
+  ComposerState,
+  InboxThread,
+  ProjectGitState,
+  ShellState,
+} from "../desktop/types";
 import { useDesktopBridge } from "../hooks/useDesktopBridge";
+import { useDesktopInbox } from "../hooks/useDesktopInbox";
 import { useDesktopShell } from "../hooks/useDesktopShell";
 import { useDesktopThread } from "../hooks/useDesktopThread";
 import { createInitialWorkspaceState, workspaceReducer } from "../state/workspace";
@@ -50,6 +57,12 @@ export function useAppShellController() {
     state.selectedSessionPath,
     threadRefreshKey,
     threadHistoryCompactions,
+  );
+  const inboxThreads = useDesktopInbox();
+  const selectedInboxThread = useMemo(
+    () =>
+      inboxThreads.find((thread) => thread.sessionPath === state.selectedInboxSessionPath) ?? null,
+    [inboxThreads, state.selectedInboxSessionPath],
   );
 
   const {
@@ -128,6 +141,26 @@ export function useAppShellController() {
     skillsProjectScopeActive,
   });
 
+  useEffect(() => {
+    if (inboxThreads.length === 0) {
+      if (state.selectedInboxSessionPath !== null) {
+        dispatch({ type: "select-inbox-thread", sessionPath: null });
+      }
+      return;
+    }
+
+    const hasSelectedInboxThread = inboxThreads.some(
+      (thread) => thread.sessionPath === state.selectedInboxSessionPath,
+    );
+
+    if (!hasSelectedInboxThread) {
+      dispatch({
+        type: "select-inbox-thread",
+        sessionPath: inboxThreads[0]?.sessionPath ?? null,
+      });
+    }
+  }, [inboxThreads, state.selectedInboxSessionPath]);
+
   const handleShowView = (view: View) => {
     dispatch({ type: "show-view", view });
   };
@@ -147,6 +180,24 @@ export function useAppShellController() {
     setThreadHistoryCompactions(0);
     dispatch({ type: "open-thread", projectId, threadId, sessionPath });
     void handleAction("thread.open", { projectId, threadId, sessionPath });
+  };
+
+  const handleSelectInboxThread = (thread: InboxThread) => {
+    dispatch({ type: "select-inbox-thread", sessionPath: thread.sessionPath });
+
+    if (thread.unread) {
+      void handleAction("inbox.mark-read", {
+        projectId: thread.projectId,
+        sessionPath: thread.sessionPath,
+      });
+    }
+  };
+
+  const handleDismissInboxThread = (thread: InboxThread) => {
+    void handleAction("inbox.dismiss", {
+      projectId: thread.projectId,
+      sessionPath: thread.sessionPath,
+    });
   };
 
   const handleLoadEarlierMessages = () => {
@@ -216,6 +267,8 @@ export function useAppShellController() {
     handleOpenDiffSelection,
     handleOpenWorktreeDiffFile,
     handleLoadEarlierMessages,
+    handleDismissInboxThread,
+    inboxThreads,
     handleProjectSelect: (projectId: string) =>
       dispatch({
         type: getProjectSelectionAction(state.activeView),
@@ -225,6 +278,7 @@ export function useAppShellController() {
     handleSetSkillsProjectScopeActive: setSkillsProjectScopeActive,
     handleSelectDiffTurn,
     handleShowView,
+    handleSelectInboxThread,
     handleThreadOpen,
     handleShowTakeoverTerminal: () => dispatch({ type: "show-takeover" }),
     handleToggleDiff: handleToggleDiffPanel,
@@ -241,6 +295,7 @@ export function useAppShellController() {
     shellState,
     skillsProjectScopeActive,
     state,
+    selectedInboxThread,
   };
 }
 

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -59,7 +59,8 @@ export function useAppShellController() {
     threadRefreshKey,
     threadHistoryCompactions,
   );
-  const inboxThreads = useDesktopInbox();
+  const inboxQuery = useDesktopInbox();
+  const inboxThreads = inboxQuery.data ?? [];
   const selectedInboxThread = useMemo(
     () =>
       inboxThreads.find((thread) => thread.sessionPath === state.selectedInboxSessionPath) ?? null,
@@ -143,6 +144,10 @@ export function useAppShellController() {
   });
 
   useEffect(() => {
+    if (!inboxQuery.isSuccess) {
+      return;
+    }
+
     if (inboxThreads.length === 0) {
       if (state.selectedInboxSessionPath !== null) {
         dispatch({ type: "select-inbox-thread", sessionPath: null });
@@ -185,6 +190,7 @@ export function useAppShellController() {
     queryClient,
     state.activeView,
     state.selectedInboxSessionPath,
+    inboxQuery.isSuccess,
   ]);
 
   const handleShowView = (view: View) => {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -11,6 +11,7 @@ import { useDesktopBridge } from "../hooks/useDesktopBridge";
 import { useDesktopInbox } from "../hooks/useDesktopInbox";
 import { useDesktopShell } from "../hooks/useDesktopShell";
 import { useDesktopThread } from "../hooks/useDesktopThread";
+import { desktopQueryKeys } from "../query/desktop-query";
 import { createInitialWorkspaceState, workspaceReducer } from "../state/workspace";
 import type { View } from "../types";
 import { deriveControllerViewModel } from "./controller-view-model";
@@ -154,12 +155,37 @@ export function useAppShellController() {
     );
 
     if (!hasSelectedInboxThread) {
+      const nextThread = inboxThreads[0] ?? null;
+
       dispatch({
         type: "select-inbox-thread",
-        sessionPath: inboxThreads[0]?.sessionPath ?? null,
+        sessionPath: nextThread?.sessionPath ?? null,
       });
+
+      if (state.activeView === "inbox" && nextThread?.unread) {
+        void invokeDesktopAction("inbox.mark-read", {
+          projectId: nextThread.projectId,
+          sessionPath: nextThread.sessionPath,
+        })
+          .then(async () => {
+            await Promise.all([
+              loadProjectThreads(nextThread.projectId),
+              queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() }),
+            ]);
+          })
+          .catch((error) => {
+            console.warn("Failed to auto-mark selected inbox thread read.", error);
+          });
+      }
     }
-  }, [inboxThreads, state.selectedInboxSessionPath]);
+  }, [
+    inboxThreads,
+    invokeDesktopAction,
+    loadProjectThreads,
+    queryClient,
+    state.activeView,
+    state.selectedInboxSessionPath,
+  ]);
 
   const handleShowView = (view: View) => {
     dispatch({ type: "show-view", view });

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -187,7 +187,29 @@ export function useAppShellEffects({
         setComposerState(event.composer);
       }
 
-      if (event.reason === "start") {
+      if (event.reason === "start" || event.reason === "end" || event.reason === "external") {
+        void loadProjectThreads(event.projectId);
+        void queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() });
+        scheduleShellStateRefresh();
+      }
+
+      if (
+        (event.reason === "end" || event.reason === "external") &&
+        workspaceState.activeView === "thread" &&
+        workspaceState.selectedSessionPath === event.sessionPath
+      ) {
+        void window.piDesktop
+          ?.invokeAction("inbox.mark-read", {
+            sessionPath: event.sessionPath,
+            projectId: event.projectId,
+          })
+          .then(() => queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() }))
+          .catch((error) => {
+            console.warn("Failed to keep active inbox thread marked read.", error);
+          });
+      }
+
+      if (event.reason === "start" && workspaceState.activeView !== "inbox") {
         dispatch({
           type: "open-thread",
           projectId: event.projectId,
@@ -197,7 +219,6 @@ export function useAppShellEffects({
       }
 
       if (event.reason === "end" || event.reason === "external") {
-        void loadProjectThreads(event.projectId);
         void queryClient.invalidateQueries({
           queryKey: desktopQueryKeys.projectDiff(event.projectId),
         });
@@ -207,8 +228,6 @@ export function useAppShellEffects({
             setProjectGitState(nextProjectGitState);
           });
         }
-
-        scheduleShellStateRefresh();
       }
     });
 
@@ -222,5 +241,7 @@ export function useAppShellEffects({
     scheduleShellStateRefresh,
     setComposerState,
     setProjectGitState,
+    workspaceState.activeView,
+    workspaceState.selectedSessionPath,
   ]);
 }

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -172,6 +172,13 @@ export function useAppShellEffects({
       return;
     }
 
+    const visibleSessionPath =
+      workspaceState.activeView === "thread"
+        ? (workspaceState.selectedSessionPath ?? null)
+        : workspaceState.activeView === "inbox"
+          ? (workspaceState.selectedInboxSessionPath ?? null)
+          : null;
+
     const unsubscribe = window.piDesktop.subscribe((event: DesktopEvent) => {
       if (event.type === "composer-update") {
         setComposerState(event.composer);
@@ -195,15 +202,19 @@ export function useAppShellEffects({
 
       if (
         (event.reason === "end" || event.reason === "external") &&
-        workspaceState.activeView === "thread" &&
-        workspaceState.selectedSessionPath === event.sessionPath
+        visibleSessionPath === event.sessionPath
       ) {
         void window.piDesktop
           ?.invokeAction("inbox.mark-read", {
             sessionPath: event.sessionPath,
             projectId: event.projectId,
           })
-          .then(() => queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() }))
+          .then(async () => {
+            await Promise.all([
+              loadProjectThreads(event.projectId),
+              queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() }),
+            ]);
+          })
           .catch((error) => {
             console.warn("Failed to keep active inbox thread marked read.", error);
           });
@@ -242,6 +253,7 @@ export function useAppShellEffects({
     setComposerState,
     setProjectGitState,
     workspaceState.activeView,
+    workspaceState.selectedInboxSessionPath,
     workspaceState.selectedSessionPath,
   ]);
 }

--- a/src/app/app-shell/useDesktopActionHandlers.ts
+++ b/src/app/app-shell/useDesktopActionHandlers.ts
@@ -102,6 +102,7 @@ export function useDesktopActionHandlers({
         setArchivedThreads,
         setComposerState,
         setProjectGitState,
+        queryClient,
       });
 
       return actionResult;
@@ -121,6 +122,7 @@ export function useDesktopActionHandlers({
       setComposerState,
       setProjectGitState,
       workspaceState,
+      queryClient,
     ],
   );
 

--- a/src/app/components/common/ActivitySpinner.tsx
+++ b/src/app/components/common/ActivitySpinner.tsx
@@ -1,0 +1,31 @@
+import { cn } from "../../utils/cn";
+
+type ActivitySpinnerProps = {
+  className?: string;
+};
+
+export function ActivitySpinner({ className }: ActivitySpinnerProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={cn("h-4 w-4 shrink-0 text-[color:var(--text)]", className)}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <style>
+        {
+          ".spinner_Wezc{transform-origin:center;animation:spinner_Oiah .75s step-end infinite}@keyframes spinner_Oiah{8.3%{transform:rotate(30deg)}16.6%{transform:rotate(60deg)}25%{transform:rotate(90deg)}33.3%{transform:rotate(120deg)}41.6%{transform:rotate(150deg)}50%{transform:rotate(180deg)}58.3%{transform:rotate(210deg)}66.6%{transform:rotate(240deg)}75%{transform:rotate(270deg)}83.3%{transform:rotate(300deg)}91.6%{transform:rotate(330deg)}100%{transform:rotate(360deg)}}"
+        }
+      </style>
+      <g className="spinner_Wezc" fill="currentColor">
+        <circle cx="12" cy="2.5" r="1.5" opacity=".14" />
+        <circle cx="16.75" cy="3.77" r="1.5" opacity=".29" />
+        <circle cx="20.23" cy="7.25" r="1.5" opacity=".43" />
+        <circle cx="21.5" cy="12" r="1.5" opacity=".57" />
+        <circle cx="20.23" cy="16.75" r="1.5" opacity=".71" />
+        <circle cx="16.75" cy="20.23" r="1.5" opacity=".86" />
+        <circle cx="12" cy="21.5" r="1.5" />
+      </g>
+    </svg>
+  );
+}

--- a/src/app/components/common/ActivitySpinner.tsx
+++ b/src/app/components/common/ActivitySpinner.tsx
@@ -12,12 +12,7 @@ export function ActivitySpinner({ className }: ActivitySpinnerProps) {
       className={cn("h-4 w-4 shrink-0 text-[color:var(--text)]", className)}
       xmlns="http://www.w3.org/2000/svg"
     >
-      <style>
-        {
-          ".spinner_Wezc{transform-origin:center;animation:spinner_Oiah .75s step-end infinite}@keyframes spinner_Oiah{8.3%{transform:rotate(30deg)}16.6%{transform:rotate(60deg)}25%{transform:rotate(90deg)}33.3%{transform:rotate(120deg)}41.6%{transform:rotate(150deg)}50%{transform:rotate(180deg)}58.3%{transform:rotate(210deg)}66.6%{transform:rotate(240deg)}75%{transform:rotate(270deg)}83.3%{transform:rotate(300deg)}91.6%{transform:rotate(330deg)}100%{transform:rotate(360deg)}}"
-        }
-      </style>
-      <g className="spinner_Wezc" fill="currentColor">
+      <g className="activity-spinner__rotor" fill="currentColor">
         <circle cx="12" cy="2.5" r="1.5" opacity=".14" />
         <circle cx="16.75" cy="3.77" r="1.5" opacity=".29" />
         <circle cx="20.23" cy="7.25" r="1.5" opacity=".43" />

--- a/src/app/components/sidebar/ProjectTree.tsx
+++ b/src/app/components/sidebar/ProjectTree.tsx
@@ -280,6 +280,8 @@ export function ProjectTree({
                                 key={thread.id}
                                 age={thread.age}
                                 pinned={Boolean(thread.pinned)}
+                                running={Boolean(thread.running)}
+                                unread={Boolean(thread.unread)}
                                 isSelected={isSelected}
                                 title={thread.title}
                                 onArchive={() =>

--- a/src/app/components/sidebar/Sidebar.tsx
+++ b/src/app/components/sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
-import { BriefcaseBusiness, Code2, MessageSquare, PawPrint, Settings } from "lucide-react";
+import { BriefcaseBusiness, Code2, Inbox, MessageSquare, PawPrint, Settings } from "lucide-react";
 import { useCallback, useRef } from "react";
-import type { AppSettings, DesktopActionInvoker } from "../../desktop/types";
+import type { AppSettings, DesktopActionInvoker, InboxThread } from "../../desktop/types";
 import { useAnimatedPresence } from "../../hooks/useAnimatedPresence";
 import { useDismissibleLayer } from "../../hooks/useDismissibleLayer";
 import type { Project, View } from "../../types";
@@ -8,12 +8,15 @@ import { cn } from "../../utils/cn";
 import { FeatureStatusBadge } from "../common/FeatureStatusBadge";
 import { NavButton } from "../common/NavButton";
 import { SettingsMenu } from "./SettingsMenu";
+import { SidebarInboxSection } from "./inbox/SidebarInboxSection";
 import { SidebarProjectsSection } from "./projects/SidebarProjectsSection";
 
 type SidebarProps = {
   projects: Project[];
+  inboxThreads: InboxThread[];
   appSettings: AppSettings;
   activeView: View;
+  selectedInboxSessionPath: string | null;
   selectedProjectId: string;
   selectedThreadId: string | null;
   settingsOpen: boolean;
@@ -26,16 +29,20 @@ type SidebarProps = {
   onOpenSkillsView: () => void;
   onOpenSettingsPanel: () => void;
   onOpenArchivedThreads: () => void;
+  onDismissInboxThread: (thread: InboxThread) => void;
   onProjectSelect: (projectId: string) => void;
   onProjectReorder: (projectIds: string[]) => void;
+  onSelectInboxThread: (thread: InboxThread) => void;
   onThreadOpen: (projectId: string, threadId: string, sessionPath: string) => void;
   onToggleProjectCollapse: (projectId: string) => void;
 };
 
 export function Sidebar({
   projects,
+  inboxThreads,
   appSettings,
   activeView,
+  selectedInboxSessionPath,
   selectedProjectId,
   selectedThreadId,
   settingsOpen,
@@ -48,8 +55,10 @@ export function Sidebar({
   onOpenSkillsView,
   onOpenSettingsPanel,
   onOpenArchivedThreads,
+  onDismissInboxThread,
   onProjectSelect,
   onProjectReorder,
+  onSelectInboxThread,
   onThreadOpen,
   onToggleProjectCollapse,
 }: SidebarProps) {
@@ -58,6 +67,7 @@ export function Sidebar({
   const settingsMenuId = "sidebar-settings-menu";
   const settingsMenuPresent = useAnimatedPresence(settingsOpen);
   const codeModeActive =
+    activeView === "inbox" ||
     activeView === "code" ||
     activeView === "thread" ||
     activeView === "settings" ||
@@ -84,6 +94,17 @@ export function Sidebar({
     >
       {showModeSelection ? (
         <nav className="grid gap-0.5" aria-label="Primary navigation">
+          <NavButton
+            icon={<Inbox size={16} />}
+            label={
+              <span className="inline-flex items-center gap-2">
+                <span>Inbox</span>
+                <FeatureStatusBadge statusId="feature:sidebar.inbox" />
+              </span>
+            }
+            active={activeView === "inbox"}
+            onClick={() => onShowView("inbox")}
+          />
           <NavButton
             icon={<MessageSquare size={16} />}
             label={
@@ -120,27 +141,36 @@ export function Sidebar({
           <NavButton
             icon={<Code2 size={16} />}
             label="Code"
-            active={codeModeActive}
+            active={codeModeActive && activeView !== "inbox"}
             onClick={() => onShowView("code")}
           />
         </nav>
       ) : null}
 
-      <SidebarProjectsSection
-        activeView={activeView}
-        appSettings={appSettings}
-        projectScopeLockActive={projectScopeLockActive}
-        projects={projects}
-        selectedProjectId={selectedProjectId}
-        selectedThreadId={selectedThreadId}
-        collapsedProjectIds={collapsedProjectIds}
-        onAction={onAction}
-        onOpenSettingsPanel={onOpenSettingsPanel}
-        onProjectSelect={onProjectSelect}
-        onProjectReorder={onProjectReorder}
-        onThreadOpen={onThreadOpen}
-        onToggleProjectCollapse={onToggleProjectCollapse}
-      />
+      {activeView === "inbox" ? (
+        <SidebarInboxSection
+          threads={inboxThreads}
+          selectedSessionPath={selectedInboxSessionPath}
+          onDismissThread={onDismissInboxThread}
+          onSelectThread={onSelectInboxThread}
+        />
+      ) : (
+        <SidebarProjectsSection
+          activeView={activeView}
+          appSettings={appSettings}
+          projectScopeLockActive={projectScopeLockActive}
+          projects={projects}
+          selectedProjectId={selectedProjectId}
+          selectedThreadId={selectedThreadId}
+          collapsedProjectIds={collapsedProjectIds}
+          onAction={onAction}
+          onOpenSettingsPanel={onOpenSettingsPanel}
+          onProjectSelect={onProjectSelect}
+          onProjectReorder={onProjectReorder}
+          onThreadOpen={onThreadOpen}
+          onToggleProjectCollapse={onToggleProjectCollapse}
+        />
+      )}
 
       <div className="relative mt-auto">
         <button

--- a/src/app/components/sidebar/inbox/InboxThreadRow.tsx
+++ b/src/app/components/sidebar/inbox/InboxThreadRow.tsx
@@ -1,0 +1,79 @@
+import { X } from "lucide-react";
+import { compactIconButtonClass, sidebarRowClass } from "../../../ui/classes";
+import { cn } from "../../../utils/cn";
+import { ActivitySpinner } from "../../common/ActivitySpinner";
+
+type InboxThreadRowProps = {
+  age: string;
+  preview: string | null;
+  projectName: string;
+  running: boolean;
+  selected: boolean;
+  title: string;
+  unread: boolean;
+  onDismiss: () => void;
+  onSelect: () => void;
+};
+
+export function InboxThreadRow({
+  age,
+  preview,
+  projectName,
+  running,
+  selected,
+  title,
+  unread,
+  onDismiss,
+  onSelect,
+}: InboxThreadRowProps) {
+  return (
+    <div
+      className={cn(
+        sidebarRowClass,
+        "group grid grid-cols-[16px_minmax(0,1fr)_18px] items-start gap-2 px-2 py-2",
+        selected && "bg-[rgba(183,186,245,0.12)] text-[color:var(--text)]",
+      )}
+    >
+      <div className="flex h-5 items-center justify-center pt-0.5">
+        {running ? (
+          <ActivitySpinner className="h-3.5 w-3.5 text-[color:var(--text)]" />
+        ) : unread ? (
+          <span className="h-2 w-2 rounded-full bg-[rgba(183,186,245,0.95)]" />
+        ) : null}
+      </div>
+
+      <button type="button" className="grid min-w-0 gap-1 text-left" onClick={onSelect}>
+        <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-[color:var(--muted-2)]">
+          <span className="truncate">{projectName}</span>
+          <span aria-hidden="true">•</span>
+          <span>{age}</span>
+        </div>
+        <div
+          className={cn(
+            "truncate text-[13px] leading-5 text-[color:var(--muted)] transition-colors duration-150 ease-out group-hover:text-[color:var(--text)]",
+            unread && "font-medium text-[color:var(--text)]",
+            selected && "text-[color:var(--text)]",
+          )}
+        >
+          {title}
+        </div>
+        <div className="line-clamp-2 text-[12px] leading-4.5 text-[color:var(--muted-2)]">
+          {preview ?? (running ? "Working…" : "No final message yet")}
+        </div>
+      </button>
+
+      <button
+        type="button"
+        className={cn(
+          compactIconButtonClass,
+          "mt-0.5 h-4 w-4 border-transparent bg-transparent opacity-0 hover:bg-transparent group-hover:opacity-100 group-focus-within:opacity-100",
+          selected && "opacity-100",
+        )}
+        onClick={onDismiss}
+        aria-label="Dismiss inbox item"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+}

--- a/src/app/components/sidebar/inbox/SidebarInboxSection.tsx
+++ b/src/app/components/sidebar/inbox/SidebarInboxSection.tsx
@@ -1,0 +1,101 @@
+import { ListFilter, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { InboxThread } from "../../../desktop/types";
+import { sidebarSearchFieldClass } from "../../../ui/classes";
+import { cn } from "../../../utils/cn";
+import { EmptyStateCard } from "../../common/EmptyStateCard";
+import { IconButton } from "../../common/IconButton";
+import { InboxThreadRow } from "./InboxThreadRow";
+
+type SidebarInboxSectionProps = {
+  threads: InboxThread[];
+  selectedSessionPath: string | null;
+  onDismissThread: (thread: InboxThread) => void;
+  onSelectThread: (thread: InboxThread) => void;
+};
+
+export function SidebarInboxSection({
+  threads,
+  selectedSessionPath,
+  onDismissThread,
+  onSelectThread,
+}: SidebarInboxSectionProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showUnreadOnly, setShowUnreadOnly] = useState(false);
+
+  const visibleThreads = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+
+    return threads.filter((thread) => {
+      if (showUnreadOnly && !thread.unread) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      return [thread.title, thread.projectName, thread.preview ?? ""]
+        .join(" ")
+        .toLowerCase()
+        .includes(normalizedQuery);
+    });
+  }, [searchQuery, showUnreadOnly, threads]);
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-2.5">
+      <div className="relative grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
+        <label
+          className={cn(
+            sidebarSearchFieldClass,
+            searchQuery.trim().length > 0 && "bg-[rgba(255,255,255,0.05)] text-[color:var(--text)]",
+          )}
+        >
+          <Search size={14} className="shrink-0 text-[color:var(--muted)]" />
+          <input
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search inbox"
+            className="w-full min-w-0 bg-transparent p-0 text-[13px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
+            aria-label="Search inbox"
+          />
+        </label>
+
+        <IconButton
+          label="Show unread only"
+          icon={<ListFilter size={15} />}
+          active={showUnreadOnly}
+          onClick={() => setShowUnreadOnly((current) => !current)}
+        />
+      </div>
+
+      {visibleThreads.length > 0 ? (
+        <div className="min-h-0 overflow-y-auto">
+          <div className="grid gap-1">
+            {visibleThreads.map((thread) => (
+              <InboxThreadRow
+                key={thread.sessionPath}
+                age={thread.age}
+                preview={thread.preview}
+                projectName={thread.projectName}
+                running={thread.running}
+                selected={selectedSessionPath === thread.sessionPath}
+                title={thread.title}
+                unread={thread.unread}
+                onDismiss={() => onDismissThread(thread)}
+                onSelect={() => onSelectThread(thread)}
+              />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <EmptyStateCard className="grid gap-1.5 px-3 py-4 text-center text-[12.5px] text-[color:var(--muted)]">
+          <div className="text-[13px] text-[color:var(--text)]">No inbox items</div>
+          <div>
+            {showUnreadOnly ? "No unread threads right now." : "Nothing to catch up on yet."}
+          </div>
+        </EmptyStateCard>
+      )}
+    </section>
+  );
+}

--- a/src/app/components/sidebar/project-tree/ThreadRow.tsx
+++ b/src/app/components/sidebar/project-tree/ThreadRow.tsx
@@ -1,10 +1,13 @@
 import { Archive, Star } from "lucide-react";
 import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
+import { ActivitySpinner } from "../../common/ActivitySpinner";
 
 type ThreadRowProps = {
   age: string;
   pinned?: boolean;
+  running?: boolean;
+  unread?: boolean;
   isSelected: boolean;
   title: string;
   onArchive: () => void;
@@ -15,6 +18,8 @@ type ThreadRowProps = {
 export function ThreadRow({
   age,
   pinned = false,
+  running = false,
+  unread = false,
   isSelected,
   title,
   onArchive,
@@ -29,26 +34,35 @@ export function ThreadRow({
           "bg-[rgba(183,186,245,0.12)] text-[color:var(--text)] shadow-[inset_0_0_0_1px_rgba(183,186,245,0.04)]",
       )}
     >
-      <button
-        type="button"
-        className={cn(
-          "relative inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-md text-[color:var(--muted)] transition-colors duration-150 ease-out hover:text-[color:var(--text)] group-hover:opacity-100 group-focus-within:opacity-100",
-          pinned ? "opacity-100 text-[color:var(--text)]" : "opacity-0",
-          isSelected && "opacity-100",
-        )}
-        onClick={onPin}
-        aria-label={pinned ? "Unmark favourite" : "Mark favourite"}
-        aria-pressed={pinned}
-      >
-        <Star size={12} className={cn("absolute inset-0 m-auto", pinned && "fill-current")} />
-      </button>
+      {running ? (
+        <span className="inline-flex h-4 w-4 items-center justify-center text-[color:var(--text)]">
+          <ActivitySpinner />
+        </span>
+      ) : (
+        <button
+          type="button"
+          className={cn(
+            "relative inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-md text-[color:var(--muted)] transition-colors duration-150 ease-out hover:text-[color:var(--text)] group-hover:opacity-100 group-focus-within:opacity-100",
+            pinned ? "opacity-100 text-[color:var(--text)]" : "opacity-0",
+            isSelected && "opacity-100",
+          )}
+          onClick={onPin}
+          aria-label={pinned ? "Unmark favourite" : "Mark favourite"}
+          aria-pressed={pinned}
+        >
+          <Star size={12} className={cn("absolute inset-0 m-auto", pinned && "fill-current")} />
+        </button>
+      )}
 
       <button
         type="button"
-        className="flex min-w-0 items-center py-1 text-left"
+        className="flex min-w-0 items-center gap-1.5 py-1 text-left"
         onClick={onOpen}
         aria-current={isSelected ? "page" : undefined}
       >
+        {unread ? (
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[rgba(183,186,245,0.95)]" />
+        ) : null}
         <span className="truncate">{title}</span>
       </button>
 

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -1,0 +1,93 @@
+import { ArrowUpRight, Send, X } from "lucide-react";
+import { compactIconButtonClass } from "../../../ui/classes";
+import { cn } from "../../../utils/cn";
+import { IconButton } from "../../common/IconButton";
+import { SurfacePanel } from "../../common/SurfacePanel";
+import { Tooltip } from "../../common/Tooltip";
+import { ComposerTextField } from "../composer/ComposerTextField";
+
+type InboxComposerProps = {
+  draft: string;
+  errorMessage: string | null;
+  isSending: boolean;
+  onChangeDraft: (value: string) => void;
+  onDismiss: () => void;
+  onOpenThread: () => void;
+  onSend: () => void;
+};
+
+export function InboxComposer({
+  draft,
+  errorMessage,
+  isSending,
+  onChangeDraft,
+  onDismiss,
+  onOpenThread,
+  onSend,
+}: InboxComposerProps) {
+  const canSend = draft.trim().length > 0 && !isSending;
+
+  return (
+    <SurfacePanel
+      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
+      aria-label="Inbox composer panel"
+    >
+      <div className="relative min-h-[148px]">
+        <div className="grid min-h-[148px] content-end px-4 pt-[24px] pb-3">
+          <div className="flex min-h-[82px] items-end justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <ComposerTextField
+                value={draft}
+                onChange={onChangeDraft}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && !event.shiftKey) {
+                    event.preventDefault();
+                    onSend();
+                  }
+                }}
+                ariaLabel="Inbox prompt composer"
+                placeholder="Reply to this thread…"
+              />
+            </div>
+
+            <div className="inline-flex h-8 items-center justify-end gap-2">
+              <button
+                type="button"
+                className={cn(
+                  compactIconButtonClass,
+                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
+                )}
+                onClick={onSend}
+                disabled={!canSend}
+                aria-label="Send"
+              >
+                <Send size={14} />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {errorMessage ? (
+        <output className="px-4 pb-2 text-[12px] text-[#f2a7a7]" aria-live="polite">
+          {errorMessage}
+        </output>
+      ) : null}
+
+      <div className="h-px bg-[rgba(169,178,215,0.07)]" />
+
+      <div className="flex items-center justify-end gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+        <Tooltip content="Dismiss">
+          <IconButton label="Dismiss" icon={<X size={14} />} onClick={onDismiss} />
+        </Tooltip>
+        <Tooltip content="Open thread">
+          <IconButton
+            label="Open thread"
+            icon={<ArrowUpRight size={14} />}
+            onClick={onOpenThread}
+          />
+        </Tooltip>
+      </div>
+    </SurfacePanel>
+  );
+}

--- a/src/app/desktop/electrobun-api.ts
+++ b/src/app/desktop/electrobun-api.ts
@@ -11,6 +11,7 @@ import type {
   DesktopActionPayload,
   DesktopActionResult,
   DesktopEvent,
+  InboxThread,
   PiConfiguredPackage,
   PiConfiguredSkill,
   PiPackageCatalogPage,
@@ -156,6 +157,8 @@ export const piDesktopApi = {
     (await getRpc()).request.getComposerState(request) as Promise<ComposerState>,
   getProjectThreads: async (projectId: string) =>
     (await getRpc()).request.getProjectThreads({ projectId }) as Promise<Thread[]>,
+  getInboxThreads: async () =>
+    (await getRpc()).request.getInboxThreads({}) as Promise<InboxThread[]>,
   getArchivedThreads: async () =>
     (await getRpc()).request.getArchivedThreads({}) as Promise<ArchivedThread[]>,
   getThread: async (sessionPath: string, historyCompactions = 0) =>

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -15,6 +15,7 @@ export type {
   DesktopActionPayload,
   DesktopActionResult,
   DesktopActionResultData,
+  InboxThread,
   ModelSelection,
   PiConfiguredPackage,
   PiConfiguredPackageType,

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -3,10 +3,11 @@ import type {
   AppSettings,
   ComposerModel,
   DesktopActionInvoker,
-  DesktopActionResult,
+  InboxThread,
   ThreadData,
 } from "../../desktop/types";
 import type { Project, View } from "../../types";
+import { InboxView } from "../../views/InboxView";
 import { LandingView } from "../../views/LandingView";
 import { SettingsView } from "../../views/SettingsView";
 import { ThreadView } from "../../views/ThreadView";
@@ -27,12 +28,15 @@ type CodeWorkspaceMainViewProps = {
   availableModels: ComposerModel[];
   currentModel: ComposerModel | null;
   currentProjectName: string;
+  selectedInboxThread: InboxThread | null;
   projects: Project[];
   selectedProjectId: string;
   workspaceContentClass: string;
   threadData: ThreadData | null;
   composerLayoutVersion: number;
   onAction: DesktopActionInvoker;
+  onDismissInboxThread: (thread: InboxThread) => void;
+  onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
   onOpenTurnDiff: (checkpointTurnCount: number, filePath?: string) => void;
   onLoadEarlierMessages: () => void;
   onSetExtensionsProjectScopeActive: (active: boolean) => void;
@@ -46,12 +50,15 @@ export function CodeWorkspaceMainView({
   availableModels,
   currentModel,
   currentProjectName,
+  selectedInboxThread,
   projects,
   selectedProjectId,
   workspaceContentClass,
   threadData,
   composerLayoutVersion,
   onAction,
+  onDismissInboxThread,
+  onOpenThread,
   onOpenTurnDiff,
   onLoadEarlierMessages,
   onSetExtensionsProjectScopeActive,
@@ -69,6 +76,18 @@ export function CodeWorkspaceMainView({
         composerLayoutVersion={composerLayoutVersion}
         onOpenTurnDiff={onOpenTurnDiff}
         onLoadEarlierMessages={onLoadEarlierMessages}
+      />
+    );
+  }
+
+  if (activeView === "inbox") {
+    return (
+      <InboxView
+        key={selectedInboxThread?.sessionPath ?? "inbox-empty"}
+        thread={selectedInboxThread}
+        onAction={onAction}
+        onDismissThread={onDismissInboxThread}
+        onOpenThread={onOpenThread}
       />
     );
   }

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -186,12 +186,15 @@ export function CodeWorkspaceView({
               availableModels={activeComposerState?.availableModels ?? []}
               currentModel={activeComposerState?.currentModel ?? null}
               currentProjectName={currentProjectName}
+              selectedInboxThread={controller.selectedInboxThread}
               projects={controller.projects}
               selectedProjectId={controller.state.selectedProjectId}
               workspaceContentClass={workspaceContentClass}
               threadData={activeThreadData}
               composerLayoutVersion={composerLayoutVersion}
               onAction={handleAction}
+              onDismissInboxThread={controller.handleDismissInboxThread}
+              onOpenThread={controller.handleThreadOpen}
               onLoadEarlierMessages={handleLoadEarlierMessages}
               onOpenTurnDiff={handleOpenDiffSelection}
               onSetExtensionsProjectScopeActive={controller.handleSetExtensionsProjectScopeActive}

--- a/src/app/features/feature-status.tsx
+++ b/src/app/features/feature-status.tsx
@@ -3,6 +3,7 @@ import { cn } from "../utils/cn";
 export type FeatureStatus = "mock" | "partial";
 
 export const featureStatusById = {
+  "feature:sidebar.inbox": { status: "partial", label: "Partial" },
   "feature:landing.project-switcher": { status: "mock", label: "Mock" },
   "feature:sidebar.plugins": { status: "mock", label: "Mock" },
   "feature:sidebar.automations": { status: "mock", label: "Mock" },

--- a/src/app/hooks/useDesktopInbox.ts
+++ b/src/app/hooks/useDesktopInbox.ts
@@ -3,11 +3,9 @@ import type { InboxThread } from "../desktop/types";
 import { desktopQueryKeys, getInboxThreadsQuery } from "../query/desktop-query";
 
 export function useDesktopInbox() {
-  const query = useQuery<InboxThread[]>({
+  return useQuery<InboxThread[]>({
     queryKey: desktopQueryKeys.inboxThreads(),
     queryFn: getInboxThreadsQuery,
     staleTime: Number.POSITIVE_INFINITY,
   });
-
-  return query.data ?? [];
 }

--- a/src/app/hooks/useDesktopInbox.ts
+++ b/src/app/hooks/useDesktopInbox.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import type { InboxThread } from "../desktop/types";
+import { desktopQueryKeys, getInboxThreadsQuery } from "../query/desktop-query";
+
+export function useDesktopInbox() {
+  const query = useQuery<InboxThread[]>({
+    queryKey: desktopQueryKeys.inboxThreads(),
+    queryFn: getInboxThreadsQuery,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  return query.data ?? [];
+}

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -4,6 +4,7 @@ import type {
   ComposerFilePickerState,
   ComposerState,
   ComposerStateRequest,
+  InboxThread,
   PiConfiguredPackage,
   PiConfiguredSkill,
   PiPackageCatalogPage,
@@ -27,6 +28,7 @@ export const desktopQueryKeys = {
   configuredPiSkills: (projectPath?: string | null) =>
     ["desktop", "piSkills", "configured", projectPath ?? null] as const,
   projectThreads: (projectId: string) => ["desktop", "projectThreads", projectId] as const,
+  inboxThreads: () => ["desktop", "inboxThreads"] as const,
   archivedThreads: () => ["desktop", "archivedThreads"] as const,
   composerState: (request: ComposerStateRequest) =>
     ["desktop", "composerState", request.projectId ?? null, request.sessionPath ?? null] as const,
@@ -42,6 +44,10 @@ export async function getShellStateQuery(): Promise<ShellState | null> {
 
 export async function getProjectThreadsQuery(projectId: string): Promise<Thread[]> {
   return (await window.piDesktop?.getProjectThreads?.(projectId)) ?? [];
+}
+
+export async function getInboxThreadsQuery(): Promise<InboxThread[]> {
+  return (await window.piDesktop?.getInboxThreads?.()) ?? [];
 }
 
 export async function getArchivedThreadsQuery(): Promise<ArchivedThread[]> {

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -3,6 +3,7 @@ import type { Project, Thread, View } from "../types";
 export type WorkspaceState = {
   activeView: View;
   selectedProjectId: string;
+  selectedInboxSessionPath: string | null;
   selectedThreadId: string | null;
   selectedSessionPath: string | null;
   terminalVisible: boolean;
@@ -19,6 +20,7 @@ export type WorkspaceState = {
 export type WorkspaceAction =
   | { type: "sync-projects"; projects: Project[] }
   | { type: "show-view"; view: View }
+  | { type: "select-inbox-thread"; sessionPath: string | null }
   | { type: "select-project"; projectId: string }
   | { type: "set-selected-project"; projectId: string }
   | { type: "open-thread"; projectId: string; threadId: string; sessionPath: string }
@@ -42,6 +44,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
   return {
     activeView: "code",
     selectedProjectId: firstProject?.id ?? "",
+    selectedInboxSessionPath: null,
     selectedThreadId: null,
     selectedSessionPath: null,
     terminalVisible: false,
@@ -101,6 +104,11 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedSessionPath: action.view === "thread" ? state.selectedSessionPath : null,
         selectedDiffTurnCount: action.view === "thread" ? state.selectedDiffTurnCount : null,
         selectedDiffFilePath: action.view === "thread" ? state.selectedDiffFilePath : null,
+      };
+    case "select-inbox-thread":
+      return {
+        ...state,
+        selectedInboxSessionPath: action.sessionPath,
       };
     case "select-project":
       return {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -9,6 +9,7 @@ export type {
 } from "../../shared/desktop-contracts.js";
 
 export type View =
+  | "inbox"
   | "code"
   | "thread"
   | "chat"

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { EmptyStateCard } from "../components/common/EmptyStateCard";
+import { MarkdownContent } from "../components/common/MarkdownContent";
+import { InboxComposer } from "../components/workspace/inbox/InboxComposer";
+import type { DesktopActionInvoker, InboxThread } from "../desktop/types";
+
+type InboxViewProps = {
+  thread: InboxThread | null;
+  onAction: DesktopActionInvoker;
+  onDismissThread: (thread: InboxThread) => void;
+  onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
+};
+
+export function InboxView({ thread, onAction, onDismissThread, onOpenThread }: InboxViewProps) {
+  const [draft, setDraft] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleSend = async () => {
+    const nextDraft = draft.trim();
+    if (!thread || !nextDraft || isSending) {
+      return;
+    }
+
+    setIsSending(true);
+    setErrorMessage(null);
+
+    const result = await onAction("composer.send", {
+      projectId: thread.projectId,
+      sessionPath: thread.sessionPath,
+      text: nextDraft,
+    });
+
+    setIsSending(false);
+
+    if (!result?.ok || result.result?.error) {
+      setErrorMessage(result?.result?.error ?? "Could not send follow-up.");
+      return;
+    }
+
+    setDraft("");
+    onDismissThread(thread);
+  };
+
+  if (!thread) {
+    return (
+      <div className="grid h-full min-h-0 px-5 pt-6 pb-4">
+        <div className="mx-auto grid h-full w-full max-w-[860px] content-start">
+          <EmptyStateCard className="grid gap-1.5 px-5 py-5 text-[14px] text-[color:var(--muted)]">
+            <div className="text-[15px] text-[color:var(--text)]">No thread selected</div>
+          </EmptyStateCard>
+        </div>
+      </div>
+    );
+  }
+
+  const prompt = thread.prompt?.trim() || thread.title;
+  const messageMarkdown = thread.content.join("\n\n").trim();
+
+  return (
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] px-5 pt-5 pb-4">
+      <div className="w-full pb-4">
+        <div className="w-full max-h-[calc(1.7em*5+2rem)] overflow-y-auto rounded-2xl border border-[color:var(--border)] bg-[rgba(43,47,62,0.92)] px-4 py-4 shadow-[var(--shadow)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <p className="m-0 whitespace-pre-wrap break-words leading-[1.7] text-[color:var(--muted)]">
+            {prompt}
+          </p>
+        </div>
+      </div>
+
+      <div className="min-h-0 overflow-y-auto">
+        <div className="grid h-full w-full content-start pb-4">
+          <div className="min-h-0">
+            {messageMarkdown ? (
+              <MarkdownContent markdown={messageMarkdown} className="gap-3 text-[15px]" />
+            ) : (
+              <div className="text-[14px] text-[color:var(--muted)]">
+                {thread.running ? "Still working…" : "No final assistant message yet."}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="pt-2">
+        <div className="w-full">
+          <InboxComposer
+            draft={draft}
+            errorMessage={errorMessage}
+            isSending={isSending}
+            onChangeDraft={setDraft}
+            onDismiss={() => onDismissThread(thread)}
+            onOpenThread={() => onOpenThread(thread.projectId, thread.threadId, thread.sessionPath)}
+            onSend={handleSend}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -25,13 +25,20 @@ export function InboxView({ thread, onAction, onDismissThread, onOpenThread }: I
     setIsSending(true);
     setErrorMessage(null);
 
-    const result = await onAction("composer.send", {
-      projectId: thread.projectId,
-      sessionPath: thread.sessionPath,
-      text: nextDraft,
-    });
+    let result: Awaited<ReturnType<DesktopActionInvoker>> | null = null;
 
-    setIsSending(false);
+    try {
+      result = await onAction("composer.send", {
+        projectId: thread.projectId,
+        sessionPath: thread.sessionPath,
+        text: nextDraft,
+      });
+    } catch {
+      setErrorMessage("Could not send follow-up.");
+      return;
+    } finally {
+      setIsSending(false);
+    }
 
     if (!result?.ok || result.result?.error) {
       setErrorMessage(result?.result?.error ?? "Could not send follow-up.");

--- a/src/bun/desktop-runtime-modules.ts
+++ b/src/bun/desktop-runtime-modules.ts
@@ -6,6 +6,7 @@ import type {
   ComposerStateRequest,
   DesktopActionResultData,
   DesktopEvent,
+  InboxThread,
   PiConfiguredPackage,
   PiConfiguredSkill,
   PiPackageCatalogPage,
@@ -32,6 +33,7 @@ export type PiThreadsModule = {
     payload: AnyDesktopActionPayload,
   ) => Promise<DesktopActionResultData | null | undefined>;
   loadArchivedThreadList: () => Promise<ArchivedThread[]>;
+  loadInboxThreadList: () => Promise<InboxThread[]>;
   loadComposerState: (request: ComposerStateRequest) => Promise<ComposerState>;
   searchPiPackages: (request?: {
     query?: string | null;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -8,6 +8,7 @@ import type {
   ComposerState,
   DesktopActionResult,
   DesktopEvent,
+  InboxThread,
   PiConfiguredPackage,
   PiConfiguredSkill,
   PiPackageCatalogPage,
@@ -92,6 +93,7 @@ const rpc = BrowserView.defineRPC<PiDesktopRpc>({
         piThreads.loadComposerState(request) as Promise<ComposerState>,
       getProjectThreads: async ({ projectId }) =>
         piThreads.loadProjectThreads(projectId) as Promise<Thread[]>,
+      getInboxThreads: async () => piThreads.loadInboxThreadList() as Promise<InboxThread[]>,
       getArchivedThreads: async () =>
         piThreads.loadArchivedThreadList() as Promise<ArchivedThread[]>,
       getThread: async ({ sessionPath, historyCompactions = 0 }) =>

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -5,6 +5,61 @@
   }
 }
 
+@keyframes activitySpinnerRotate {
+  8.3% {
+    transform: rotate(30deg);
+  }
+
+  16.6% {
+    transform: rotate(60deg);
+  }
+
+  25% {
+    transform: rotate(90deg);
+  }
+
+  33.3% {
+    transform: rotate(120deg);
+  }
+
+  41.6% {
+    transform: rotate(150deg);
+  }
+
+  50% {
+    transform: rotate(180deg);
+  }
+
+  58.3% {
+    transform: rotate(210deg);
+  }
+
+  66.6% {
+    transform: rotate(240deg);
+  }
+
+  75% {
+    transform: rotate(270deg);
+  }
+
+  83.3% {
+    transform: rotate(300deg);
+  }
+
+  91.6% {
+    transform: rotate(330deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.activity-spinner__rotor {
+  transform-origin: center;
+  animation: activitySpinnerRotate 0.75s step-end infinite;
+}
+
 .three-dots-spinner__dot {
   animation: threeDotsSpinnerPulse 0.8s linear infinite;
   animation-delay: -0.8s;

--- a/src/test/controller-view-model.test.ts
+++ b/src/test/controller-view-model.test.ts
@@ -24,6 +24,7 @@ describe("deriveControllerViewModel", () => {
       workspaceState: {
         activeView: "thread",
         selectedProjectId: "/repo",
+        selectedInboxSessionPath: null,
         selectedThreadId: "thread-1",
         selectedSessionPath: "/repo/session.json",
         terminalVisible: false,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,6 +9,7 @@ import type {
   DesktopActionPayload,
   DesktopActionResult,
   DesktopEvent,
+  InboxThread,
   PiConfiguredPackage,
   PiConfiguredSkill,
   PiPackageCatalogPage,
@@ -88,6 +89,7 @@ declare global {
       }) => Promise<ComposerFilePickerState>;
       getComposerState?: (request?: ComposerStateRequest) => Promise<ComposerState>;
       getProjectThreads?: (projectId: string) => Promise<Thread[]>;
+      getInboxThreads?: () => Promise<InboxThread[]>;
       getArchivedThreads?: () => Promise<ArchivedThread[]>;
       getThread?: (sessionPath: string, historyCompactions?: number) => Promise<ThreadData | null>;
       watchSession?: (sessionPath: string | null) => Promise<void>;


### PR DESCRIPTION
## Summary
- add a persisted inbox for session replies across projects, with sidebar inbox mode and reply/dismiss/open-thread actions
- show running state and unread state in the sidebar, plus a dedicated inbox detail view/composer
- harden inbox persistence and read/unread behavior around session starts, opens, live watching, and external updates

## Testing
- pre-commit checks
- bun run typecheck:web
- bun run typecheck:bun
- bun run typecheck:desktop
- vitest run
- vite build
- bun run build:desktop
- electrobun build