### PR TITLE
Support multiple live sessions per project

### DIFF
--- a/desktop/git-commit-message.cts
+++ b/desktop/git-commit-message.cts
@@ -4,7 +4,7 @@ import { mapAgentMessageToUiMessage } from "../shared/pi-message-mapper.ts";
 import { loadAppSettings } from "./app-settings.cts";
 import { getPiModule } from "./pi-module.cts";
 import type { CommitMessageContext } from "./project-git.cts";
-import { getRuntimeForRequest } from "./runtime/runtime-registry.cts";
+import { resolveComposerModel } from "./runtime/composer-state.cts";
 
 const MAX_FILE_SECTION_CHARS = 12_000;
 const MAX_PATCH_CHARS = 48_000;
@@ -205,11 +205,15 @@ async function getServices() {
 }
 
 async function resolveCommitMessageModel(request: ComposerStateRequest) {
-  const runtime = await getRuntimeForRequest(request);
   const selectedModel = loadAppSettings().gitCommitMessageModel;
 
+  const { AuthStorage, ModelRegistry, getAgentDir } = await getPiModule();
+  const agentDir = getAgentDir();
+  const authStorage = AuthStorage.create();
+  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+
   if (selectedModel) {
-    const availableModels = await runtime.session.modelRegistry.getAvailable();
+    const availableModels = await modelRegistry.getAvailable();
     const configuredModel = availableModels.find(
       (model) => model.provider === selectedModel.provider && model.id === selectedModel.id,
     );
@@ -219,7 +223,7 @@ async function resolveCommitMessageModel(request: ComposerStateRequest) {
     }
   }
 
-  return runtime.session.model ?? null;
+  return await resolveComposerModel(request);
 }
 
 export async function generateGitCommitMessage(

--- a/desktop/git-commit-message.cts
+++ b/desktop/git-commit-message.cts
@@ -4,7 +4,7 @@ import { mapAgentMessageToUiMessage } from "../shared/pi-message-mapper.ts";
 import { loadAppSettings } from "./app-settings.cts";
 import { getPiModule } from "./pi-module.cts";
 import type { CommitMessageContext } from "./project-git.cts";
-import { resolveComposerModel } from "./runtime/composer-state.cts";
+import { createComposerSnapshotSession } from "./runtime/composer-state.cts";
 
 const MAX_FILE_SECTION_CHARS = 12_000;
 const MAX_PATCH_CHARS = 48_000;
@@ -152,8 +152,6 @@ function getLastAssistantText(messages: AgentMessage[]) {
 
 async function createCommitMessageServices() {
   const {
-    AuthStorage,
-    ModelRegistry,
     SessionManager,
     SettingsManager,
     createAgentSession,
@@ -161,14 +159,10 @@ async function createCommitMessageServices() {
     getAgentDir,
   } = await getPiModule();
   const agentDir = getAgentDir();
-  const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
 
   return {
     agentDir,
-    authStorage,
     createAgentSession,
-    modelRegistry,
     resourceLoader: {
       getExtensions: () => ({
         extensions: [],
@@ -206,56 +200,71 @@ async function getServices() {
 
 async function resolveCommitMessageModel(request: ComposerStateRequest) {
   const selectedModel = loadAppSettings().gitCommitMessageModel;
+  const snapshot = await createComposerSnapshotSession(request);
 
-  const { AuthStorage, ModelRegistry, getAgentDir } = await getPiModule();
-  const agentDir = getAgentDir();
-  const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  try {
+    if (selectedModel) {
+      const availableModels = await snapshot.session.modelRegistry.getAvailable();
+      const configuredModel = availableModels.find(
+        (model) => model.provider === selectedModel.provider && model.id === selectedModel.id,
+      );
 
-  if (selectedModel) {
-    const availableModels = await modelRegistry.getAvailable();
-    const configuredModel = availableModels.find(
-      (model) => model.provider === selectedModel.provider && model.id === selectedModel.id,
-    );
-
-    if (configuredModel) {
-      return configuredModel;
+      if (configuredModel) {
+        return {
+          model: configuredModel,
+          modelRegistry: snapshot.session.modelRegistry,
+          dispose: () => snapshot.session.dispose(),
+        };
+      }
     }
-  }
 
-  return await resolveComposerModel(request);
+    return {
+      model: snapshot.session.model,
+      modelRegistry: snapshot.session.modelRegistry,
+      dispose: () => snapshot.session.dispose(),
+    };
+  } catch (error) {
+    snapshot.session.dispose();
+    throw error;
+  }
 }
 
 export async function generateGitCommitMessage(
   request: ComposerStateRequest,
   context: CommitMessageContext,
 ) {
-  const model = await resolveCommitMessageModel(request);
+  const resolvedModel = await resolveCommitMessageModel(request);
+  const model = resolvedModel.model;
   if (!model) {
+    resolvedModel.dispose();
     return null;
   }
 
   const services = await getServices();
-  const { session } = await services.createAgentSession({
-    cwd: context.projectId,
-    agentDir: services.agentDir,
-    model,
-    thinkingLevel: "off",
-    authStorage: services.authStorage,
-    modelRegistry: services.modelRegistry,
-    resourceLoader: services.resourceLoader,
-    tools: [],
-    sessionManager: services.SessionManager.inMemory(),
-    settingsManager: services.SettingsManager.inMemory(),
-  });
+  let session: Awaited<ReturnType<(typeof services)["createAgentSession"]>>["session"] | null =
+    null;
 
   try {
+    const createdSession = await services.createAgentSession({
+      cwd: context.projectId,
+      agentDir: services.agentDir,
+      model,
+      thinkingLevel: "off",
+      modelRegistry: resolvedModel.modelRegistry,
+      resourceLoader: services.resourceLoader,
+      tools: [],
+      sessionManager: services.SessionManager.inMemory(),
+      settingsManager: services.SettingsManager.inMemory(),
+    });
+    session = createdSession.session;
+
     await session.prompt(buildPrompt(context));
     const message = getLastAssistantText(session.messages as AgentMessage[]);
     return message.length > 0 ? message : null;
   } catch {
     return null;
   } finally {
-    session.dispose();
+    session?.dispose();
+    resolvedModel.dispose();
   }
 }

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -4,23 +4,40 @@ import type {
   ComposerStateRequest,
   ComposerThinkingLevel,
 } from "../../shared/desktop-contracts.ts";
+import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { prepareTurnDiffCapture } from "../diff/query.cts";
-import { upsertThreadSummary } from "../thread-state-db.cts";
+import { getPiModule } from "../pi-module.cts";
 import { buildComposerAttachmentPrompt } from "./attachments.cts";
-import { buildComposerState } from "./composer-state.cts";
-import { createFreshThreadIfNeeded, getRuntimeForRequest } from "./runtime-registry.cts";
-import { rememberSessionPath } from "./session-path-index.cts";
+import { buildComposerState, buildComposerStateSnapshot } from "./composer-state.cts";
+import {
+  createRuntimeForNewSession,
+  getCachedRuntimeForSessionPath,
+  getOrCreateRuntimeForSessionPath,
+  scheduleRuntimeDisposalForRuntime,
+} from "./runtime-registry.cts";
 import {
   getLiveThread,
   publishComposerUpdate,
-  publishThreadUpdate,
   subscribeDesktopEvents,
 } from "./thread-publisher.cts";
 
 async function emitComposerUpdate(request: ComposerStateRequest = {}) {
-  const runtime = await getRuntimeForRequest(request);
-  const composer = await buildComposerState(runtime);
-  publishComposerUpdate(composer);
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  const runtimePromise = persistedSessionPath
+    ? getCachedRuntimeForSessionPath(persistedSessionPath)
+    : null;
+  const runtime = runtimePromise ? await runtimePromise : null;
+  const composer = runtime
+    ? await buildComposerState(runtime)
+    : await buildComposerStateSnapshot({
+        ...request,
+        sessionPath: persistedSessionPath,
+      });
+
+  publishComposerUpdate(composer, {
+    projectId: request.projectId ?? null,
+    sessionPath: persistedSessionPath,
+  });
 
   return {
     composer,
@@ -28,14 +45,38 @@ async function emitComposerUpdate(request: ComposerStateRequest = {}) {
   };
 }
 
+async function setDraftComposerModel(cwd: string, provider: string, modelId: string) {
+  const { AuthStorage, ModelRegistry, SettingsManager, getAgentDir } = await getPiModule();
+  const agentDir = getAgentDir();
+  const authStorage = AuthStorage.create();
+  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  const model = modelRegistry.find(provider, modelId);
+
+  if (!model) {
+    throw new Error(`Unknown Pi model: ${provider}/${modelId}`);
+  }
+
+  SettingsManager.create(cwd, agentDir).setDefaultModelAndProvider(provider, modelId);
+}
+
+async function setDraftComposerThinkingLevel(cwd: string, level: ComposerThinkingLevel) {
+  const { SettingsManager, getAgentDir } = await getPiModule();
+  SettingsManager.create(cwd, getAgentDir()).setDefaultThinkingLevel(level);
+}
+
 export { getLiveThread, subscribeDesktopEvents };
 
 export async function getComposerState(request: ComposerStateRequest = {}): Promise<ComposerState> {
-  const runtime = await getRuntimeForRequest(request);
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  const runtimePromise = persistedSessionPath
+    ? getCachedRuntimeForSessionPath(persistedSessionPath)
+    : null;
 
   // Reads should reflect the current in-memory runtime state. Reloading or publishing here can
   // race with just-applied composer mutations and re-broadcast stale snapshots back into the UI.
-  return await buildComposerState(runtime);
+  return runtimePromise
+    ? await buildComposerState(await runtimePromise)
+    : await buildComposerStateSnapshot({ ...request, sessionPath: persistedSessionPath });
 }
 
 export async function setComposerModel(
@@ -43,7 +84,14 @@ export async function setComposerModel(
   provider: string,
   modelId: string,
 ) {
-  const runtime = await getRuntimeForRequest(request);
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+
+  if (!persistedSessionPath) {
+    await setDraftComposerModel(request.projectId ?? process.cwd(), provider, modelId);
+    return emitComposerUpdate({ ...request, sessionPath: null });
+  }
+
+  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath);
   const model = runtime.session.modelRegistry.find(provider, modelId);
 
   if (!model) {
@@ -51,26 +99,34 @@ export async function setComposerModel(
   }
 
   await runtime.session.setModel(model);
-  return emitComposerUpdate(request);
+  scheduleRuntimeDisposalForRuntime(runtime);
+  return emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
 }
 
 export async function setComposerThinkingLevel(
   request: ComposerStateRequest,
   level: ComposerThinkingLevel,
 ) {
-  const runtime = await getRuntimeForRequest(request);
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+
+  if (!persistedSessionPath) {
+    await setDraftComposerThinkingLevel(request.projectId ?? process.cwd(), level);
+    return emitComposerUpdate({ ...request, sessionPath: null });
+  }
+
+  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath);
   runtime.session.setThinkingLevel(level);
-  return emitComposerUpdate(request);
+  scheduleRuntimeDisposalForRuntime(runtime);
+  return emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
 }
 
 export async function sendComposerPrompt(
   request: ComposerStateRequest & { text: string; attachments?: ComposerAttachment[] },
 ): Promise<void> {
-  const runtime = await getRuntimeForRequest(request);
-  if (!request.sessionPath) {
-    await createFreshThreadIfNeeded(runtime);
-  }
-
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  const runtime = persistedSessionPath
+    ? await getOrCreateRuntimeForSessionPath(persistedSessionPath)
+    : await createRuntimeForNewSession(request.projectId ?? process.cwd());
   const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
   const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;
 
@@ -85,33 +141,23 @@ export async function sendComposerPrompt(
     await runtime.session.prompt(message);
   } catch (error) {
     runtime.pendingTurnCount = null;
+    scheduleRuntimeDisposalForRuntime(runtime);
     throw error;
   }
 }
 
 export async function startNewThread(request: ComposerStateRequest = {}) {
-  const runtime = await getRuntimeForRequest(request);
-  await runtime.session.newSession();
-  rememberSessionPath(runtime.session.sessionFile, runtime.cwd);
+  const projectId = request.projectId ?? process.cwd();
+  const composer = await buildComposerStateSnapshot({ projectId, sessionPath: null });
+  const draft = createLocalThreadDraft(projectId);
 
-  if (runtime.session.sessionFile) {
-    upsertThreadSummary({
-      id: runtime.session.sessionId,
-      cwd: runtime.cwd,
-      sessionPath: runtime.session.sessionFile,
-      title: "New thread",
-      lastModifiedMs: Date.now(),
-    });
-    await publishThreadUpdate(runtime, "start");
-  }
+  publishComposerUpdate(composer, { projectId, sessionPath: null });
 
-  const composer = await buildComposerState(runtime);
-  publishComposerUpdate(composer);
   return {
     composer,
-    projectId: runtime.cwd,
-    sessionPath: runtime.session.sessionFile,
-    threadId: runtime.session.sessionId,
+    projectId,
+    sessionPath: draft.sessionPath,
+    threadId: draft.threadId,
   };
 }
 
@@ -123,6 +169,9 @@ export async function selectProjectRuntime(
 }
 
 export async function openThreadRuntime(request: ComposerStateRequest): Promise<ComposerState> {
-  const { composer } = await emitComposerUpdate(request);
+  const { composer } = await emitComposerUpdate({
+    ...request,
+    sessionPath: getPersistedSessionPath(request.sessionPath),
+  });
   return composer;
 }

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -8,7 +8,12 @@ import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/se
 import { prepareTurnDiffCapture } from "../diff/query.cts";
 import { getPiModule } from "../pi-module.cts";
 import { buildComposerAttachmentPrompt } from "./attachments.cts";
-import { buildComposerState, buildComposerStateSnapshot } from "./composer-state.cts";
+import {
+  buildComposerState,
+  buildComposerStateSnapshot,
+  clampThinkingLevel,
+  getAvailableThinkingLevelsForModel,
+} from "./composer-state.cts";
 import {
   createRuntimeForNewSession,
   getCachedRuntimeForSessionPath,
@@ -56,12 +61,23 @@ async function setDraftComposerModel(cwd: string, provider: string, modelId: str
     throw new Error(`Unknown Pi model: ${provider}/${modelId}`);
   }
 
-  SettingsManager.create(cwd, agentDir).setDefaultModelAndProvider(provider, modelId);
+  const currentComposer = await buildComposerStateSnapshot({ projectId: cwd, sessionPath: null });
+  const nextThinkingLevel = clampThinkingLevel(
+    currentComposer.currentThinkingLevel,
+    getAvailableThinkingLevelsForModel(model),
+  );
+  const settingsManager = SettingsManager.create(cwd, agentDir);
+
+  settingsManager.setDefaultModelAndProvider(provider, modelId);
+  settingsManager.setDefaultThinkingLevel(nextThinkingLevel);
 }
 
 async function setDraftComposerThinkingLevel(cwd: string, level: ComposerThinkingLevel) {
   const { SettingsManager, getAgentDir } = await getPiModule();
-  SettingsManager.create(cwd, getAgentDir()).setDefaultThinkingLevel(level);
+  const currentComposer = await buildComposerStateSnapshot({ projectId: cwd, sessionPath: null });
+  SettingsManager.create(cwd, getAgentDir()).setDefaultThinkingLevel(
+    clampThinkingLevel(level, currentComposer.availableThinkingLevels),
+  );
 }
 
 export { getLiveThread, subscribeDesktopEvents };
@@ -91,7 +107,9 @@ export async function setComposerModel(
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
-  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath);
+  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+    suspendDisposal: true,
+  });
   const model = runtime.session.modelRegistry.find(provider, modelId);
 
   if (!model) {
@@ -114,7 +132,9 @@ export async function setComposerThinkingLevel(
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
-  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath);
+  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+    suspendDisposal: true,
+  });
   runtime.session.setThinkingLevel(level);
   scheduleRuntimeDisposalForRuntime(runtime);
   return emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
@@ -125,7 +145,7 @@ export async function sendComposerPrompt(
 ): Promise<void> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   const runtime = persistedSessionPath
-    ? await getOrCreateRuntimeForSessionPath(persistedSessionPath)
+    ? await getOrCreateRuntimeForSessionPath(persistedSessionPath, { suspendDisposal: true })
     : await createRuntimeForNewSession(request.projectId ?? process.cwd());
   const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
   const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -97,9 +97,41 @@ function resolveCurrentModel(
 }
 
 async function resolveComposerStateSnapshot(request: ComposerStateRequest = {}) {
+  const { cwd, session } = await createComposerSnapshotSession(request);
+
+  try {
+    const availableModels = (await session.modelRegistry.getAvailable()) as ComposerSourceModel[];
+    const currentModel = resolveCurrentModel(
+      availableModels,
+      session.model ? { provider: session.model.provider, id: session.model.id } : null,
+    );
+    const availableThinkingLevels = mapThinkingLevels(session.getAvailableThinkingLevels());
+
+    return {
+      cwd,
+      availableModels,
+      currentModel,
+      currentThinkingLevel: clampThinkingLevel(
+        session.thinkingLevel as ComposerThinkingLevel,
+        availableThinkingLevels,
+      ),
+      availableThinkingLevels,
+    };
+  } finally {
+    session.dispose();
+  }
+}
+
+export async function createComposerSnapshotSession(request: ComposerStateRequest = {}) {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
-  const { AuthStorage, ModelRegistry, SessionManager, SettingsManager, getAgentDir } =
-    await getPiModule();
+  const {
+    AuthStorage,
+    ModelRegistry,
+    SessionManager,
+    SettingsManager,
+    createAgentSession,
+    getAgentDir,
+  } = await getPiModule();
   const cwd = persistedSessionPath
     ? SessionManager.open(persistedSessionPath).getCwd()
     : (request.projectId ?? process.cwd());
@@ -107,43 +139,33 @@ async function resolveComposerStateSnapshot(request: ComposerStateRequest = {}) 
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(cwd, agentDir);
-  const availableModels = await modelRegistry.getAvailable();
-
-  let selectedModel: { provider: string; id: string } | null = null;
-  let selectedThinkingLevel: ComposerThinkingLevel | null = null;
-
-  if (persistedSessionPath) {
-    const sessionContext = SessionManager.open(persistedSessionPath).buildSessionContext();
-    selectedModel = sessionContext.model
-      ? { provider: sessionContext.model.provider, id: sessionContext.model.modelId }
-      : null;
-    selectedThinkingLevel = sessionContext.thinkingLevel as ComposerThinkingLevel;
-  } else {
-    const provider = settingsManager.getDefaultProvider();
-    const modelId = settingsManager.getDefaultModel();
-    selectedModel = provider && modelId ? { provider, id: modelId } : null;
-    selectedThinkingLevel =
-      (settingsManager.getDefaultThinkingLevel() as ComposerThinkingLevel | undefined) ??
-      DEFAULT_COMPOSER_THINKING_LEVEL;
-  }
-
-  const currentModel = resolveCurrentModel(availableModels, selectedModel);
-  const availableThinkingLevels = getAvailableThinkingLevelsForModel(currentModel);
+  const sessionManager = persistedSessionPath
+    ? SessionManager.open(persistedSessionPath)
+    : SessionManager.inMemory();
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir,
+    authStorage,
+    modelRegistry,
+    settingsManager,
+    sessionManager,
+    tools: [],
+  });
 
   return {
     cwd,
-    availableModels,
-    currentModel,
-    currentThinkingLevel: clampThinkingLevel(
-      selectedThinkingLevel ?? DEFAULT_COMPOSER_THINKING_LEVEL,
-      availableThinkingLevels,
-    ),
-    availableThinkingLevels,
+    session,
   };
 }
 
 export async function resolveComposerModel(request: ComposerStateRequest = {}) {
-  return (await resolveComposerStateSnapshot(request)).currentModel;
+  const { session } = await createComposerSnapshotSession(request);
+
+  try {
+    return (session.model as ComposerSourceModel | null | undefined) ?? null;
+  } finally {
+    session.dispose();
+  }
 }
 
 export async function buildComposerStateSnapshot(

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -1,13 +1,23 @@
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import { type Model, supportsXhigh } from "@mariozechner/pi-ai";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type {
   ComposerModel,
   ComposerState,
+  ComposerStateRequest,
   ComposerThinkingLevel,
 } from "../../shared/desktop-contracts.ts";
+import { getPersistedSessionPath } from "../../shared/session-paths.ts";
+import { getPiModule } from "../pi-module.cts";
 import type { PiRuntime } from "./types.cts";
 
-function mapComposerModel(model: AgentSession["model"]): ComposerModel | null {
+const DEFAULT_THINKING_LEVEL: ComposerThinkingLevel = "medium";
+
+type ComposerSourceModel = NonNullable<AgentSession["model"]>;
+
+function mapComposerModel(
+  model: AgentSession["model"] | ComposerSourceModel | null | undefined,
+): ComposerModel | null {
   if (!model) {
     return null;
   }
@@ -23,6 +33,136 @@ function mapComposerModel(model: AgentSession["model"]): ComposerModel | null {
 
 function mapThinkingLevels(levels: ThinkingLevel[]) {
   return levels as ComposerThinkingLevel[];
+}
+
+function getAvailableThinkingLevelsForModel(
+  model: ComposerSourceModel | null,
+): ComposerThinkingLevel[] {
+  if (!model?.reasoning) {
+    return ["off"];
+  }
+
+  return supportsXhigh(model)
+    ? (["off", "minimal", "low", "medium", "high", "xhigh"] as ComposerThinkingLevel[])
+    : (["off", "minimal", "low", "medium", "high"] as ComposerThinkingLevel[]);
+}
+
+function clampThinkingLevel(
+  level: ComposerThinkingLevel,
+  availableLevels: ComposerThinkingLevel[],
+): ComposerThinkingLevel {
+  if (availableLevels.includes(level)) {
+    return level;
+  }
+
+  const orderedLevels: ComposerThinkingLevel[] = [
+    "off",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+  ];
+  const requestedIndex = orderedLevels.indexOf(level);
+
+  if (requestedIndex === -1) {
+    return availableLevels[0] ?? "off";
+  }
+
+  for (let index = requestedIndex; index >= 0; index -= 1) {
+    const candidate = orderedLevels[index];
+    if (availableLevels.includes(candidate)) {
+      return candidate;
+    }
+  }
+
+  return availableLevels[0] ?? "off";
+}
+
+function resolveCurrentModel(
+  availableModels: ComposerSourceModel[],
+  selectedModel: { provider: string; id: string } | null,
+) {
+  if (selectedModel) {
+    const configuredModel = availableModels.find(
+      (model) => model.provider === selectedModel.provider && model.id === selectedModel.id,
+    );
+
+    if (configuredModel) {
+      return configuredModel;
+    }
+  }
+
+  return availableModels[0] ?? null;
+}
+
+async function resolveComposerStateSnapshot(request: ComposerStateRequest = {}) {
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  const { AuthStorage, ModelRegistry, SessionManager, SettingsManager, getAgentDir } =
+    await getPiModule();
+  const cwd = persistedSessionPath
+    ? SessionManager.open(persistedSessionPath).getCwd()
+    : (request.projectId ?? process.cwd());
+  const agentDir = getAgentDir();
+  const authStorage = AuthStorage.create();
+  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  const settingsManager = SettingsManager.create(cwd, agentDir);
+  const availableModels = await modelRegistry.getAvailable();
+
+  let selectedModel: { provider: string; id: string } | null = null;
+  let selectedThinkingLevel: ComposerThinkingLevel | null = null;
+
+  if (persistedSessionPath) {
+    const sessionContext = SessionManager.open(persistedSessionPath).buildSessionContext();
+    selectedModel = sessionContext.model
+      ? { provider: sessionContext.model.provider, id: sessionContext.model.modelId }
+      : null;
+    selectedThinkingLevel = sessionContext.thinkingLevel as ComposerThinkingLevel;
+  } else {
+    const provider = settingsManager.getDefaultProvider();
+    const modelId = settingsManager.getDefaultModel();
+    selectedModel = provider && modelId ? { provider, id: modelId } : null;
+    selectedThinkingLevel =
+      (settingsManager.getDefaultThinkingLevel() as ComposerThinkingLevel | undefined) ??
+      DEFAULT_THINKING_LEVEL;
+  }
+
+  const currentModel = resolveCurrentModel(availableModels, selectedModel);
+  const availableThinkingLevels = getAvailableThinkingLevelsForModel(currentModel);
+
+  return {
+    cwd,
+    availableModels,
+    currentModel,
+    currentThinkingLevel: clampThinkingLevel(
+      selectedThinkingLevel ?? DEFAULT_THINKING_LEVEL,
+      availableThinkingLevels,
+    ),
+    availableThinkingLevels,
+  };
+}
+
+export async function resolveComposerModel(request: ComposerStateRequest = {}) {
+  return (await resolveComposerStateSnapshot(request)).currentModel;
+}
+
+export async function buildComposerStateSnapshot(
+  request: ComposerStateRequest = {},
+): Promise<ComposerState> {
+  const snapshot = await resolveComposerStateSnapshot(request);
+
+  return {
+    currentModel: mapComposerModel(snapshot.currentModel),
+    availableModels: snapshot.availableModels.map((model) => ({
+      provider: model.provider,
+      id: model.id,
+      name: model.name ?? model.id,
+      reasoning: Boolean(model.reasoning),
+      input: (model.input ?? ["text"]) as Array<"text" | "image">,
+    })),
+    currentThinkingLevel: snapshot.currentThinkingLevel,
+    availableThinkingLevels: snapshot.availableThinkingLevels,
+  };
 }
 
 export async function buildComposerState(runtime: PiRuntime): Promise<ComposerState> {

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -11,7 +11,7 @@ import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import type { PiRuntime } from "./types.cts";
 
-const DEFAULT_THINKING_LEVEL: ComposerThinkingLevel = "medium";
+export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
 
 type ComposerSourceModel = NonNullable<AgentSession["model"]>;
 
@@ -35,7 +35,7 @@ function mapThinkingLevels(levels: ThinkingLevel[]) {
   return levels as ComposerThinkingLevel[];
 }
 
-function getAvailableThinkingLevelsForModel(
+export function getAvailableThinkingLevelsForModel(
   model: ComposerSourceModel | null,
 ): ComposerThinkingLevel[] {
   if (!model?.reasoning) {
@@ -47,7 +47,7 @@ function getAvailableThinkingLevelsForModel(
     : (["off", "minimal", "low", "medium", "high"] as ComposerThinkingLevel[]);
 }
 
-function clampThinkingLevel(
+export function clampThinkingLevel(
   level: ComposerThinkingLevel,
   availableLevels: ComposerThinkingLevel[],
 ): ComposerThinkingLevel {
@@ -124,7 +124,7 @@ async function resolveComposerStateSnapshot(request: ComposerStateRequest = {}) 
     selectedModel = provider && modelId ? { provider, id: modelId } : null;
     selectedThinkingLevel =
       (settingsManager.getDefaultThinkingLevel() as ComposerThinkingLevel | undefined) ??
-      DEFAULT_THINKING_LEVEL;
+      DEFAULT_COMPOSER_THINKING_LEVEL;
   }
 
   const currentModel = resolveCurrentModel(availableModels, selectedModel);
@@ -135,7 +135,7 @@ async function resolveComposerStateSnapshot(request: ComposerStateRequest = {}) 
     availableModels,
     currentModel,
     currentThinkingLevel: clampThinkingLevel(
-      selectedThinkingLevel ?? DEFAULT_THINKING_LEVEL,
+      selectedThinkingLevel ?? DEFAULT_COMPOSER_THINKING_LEVEL,
       availableThinkingLevels,
     ),
     availableThinkingLevels,

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -1,13 +1,71 @@
-import type { ComposerStateRequest } from "../../shared/desktop-contracts.ts";
+import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { captureCompletedTurnDiff } from "../diff/query.cts";
 import { getPiModule } from "../pi-module.cts";
-import { getMappedCwd, rememberSessionPath } from "./session-path-index.cts";
+import { rememberSessionPath } from "./session-path-index.cts";
 import { publishThreadUpdate } from "./thread-publisher.cts";
 import type { PiRuntime } from "./types.cts";
 
-const runtimePromises = new Map<string, Promise<PiRuntime>>();
+const RUNTIME_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
 
-async function createRuntime(cwd: string): Promise<PiRuntime> {
+type RuntimeRecord = {
+  runtimePromise: Promise<PiRuntime>;
+  disposeTimeout: ReturnType<typeof setTimeout> | null;
+};
+
+const runtimeRecords = new Map<string, RuntimeRecord>();
+
+function clearRuntimeDisposeTimeout(runtimeKey: string) {
+  const record = runtimeRecords.get(runtimeKey);
+  if (!record?.disposeTimeout) {
+    return;
+  }
+
+  clearTimeout(record.disposeTimeout);
+  record.disposeTimeout = null;
+}
+
+function touchRuntime(runtimeKey: string) {
+  clearRuntimeDisposeTimeout(runtimeKey);
+}
+
+function scheduleRuntimeDisposal(runtimeKey: string) {
+  const record = runtimeRecords.get(runtimeKey);
+  if (!record) {
+    return;
+  }
+
+  clearRuntimeDisposeTimeout(runtimeKey);
+
+  record.disposeTimeout = setTimeout(() => {
+    void (async () => {
+      const currentRecord = runtimeRecords.get(runtimeKey);
+      if (!currentRecord || currentRecord !== record) {
+        return;
+      }
+
+      try {
+        const runtime = await record.runtimePromise;
+        if (runtime.session.isStreaming) {
+          scheduleRuntimeDisposal(runtimeKey);
+          return;
+        }
+
+        runtime.session.dispose();
+      } catch {
+        // Ignore runtime disposal races after failed creation.
+      } finally {
+        if (runtimeRecords.get(runtimeKey) === record) {
+          runtimeRecords.delete(runtimeKey);
+        }
+      }
+    })();
+  }, RUNTIME_IDLE_TIMEOUT_MS);
+}
+
+async function createRuntime(options: {
+  cwd: string;
+  sessionManager?: PiRuntime["session"]["sessionManager"];
+}): Promise<PiRuntime> {
   const {
     AuthStorage,
     ModelRegistry,
@@ -19,26 +77,31 @@ async function createRuntime(cwd: string): Promise<PiRuntime> {
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
-  const settingsManager = SettingsManager.create(cwd, agentDir);
+  const settingsManager = SettingsManager.create(options.cwd, agentDir);
   const sessionDir = settingsManager.getSessionDir() ?? undefined;
   const { session } = await createAgentSession({
-    cwd,
+    cwd: options.cwd,
     agentDir,
     authStorage,
     modelRegistry,
     settingsManager,
-    sessionManager: SessionManager.create(cwd, sessionDir),
+    sessionManager: options.sessionManager ?? SessionManager.create(options.cwd, sessionDir),
   });
 
   const runtime = {
-    cwd,
+    cwd: options.cwd,
     session,
     pendingTurnCount: null,
-  };
+  } satisfies PiRuntime;
 
-  rememberSessionPath(session.sessionFile, cwd);
+  rememberSessionPath(session.sessionFile, options.cwd);
 
   session.subscribe((event) => {
+    const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+    if (runtimeKey) {
+      touchRuntime(runtimeKey);
+    }
+
     if (event.type === "message_end") {
       if (event.message.role === "user") {
         void publishThreadUpdate(runtime, "start");
@@ -54,6 +117,11 @@ async function createRuntime(cwd: string): Promise<PiRuntime> {
           await publishThreadUpdate(runtime, "end");
         })();
       }
+
+      if (runtimeKey) {
+        scheduleRuntimeDisposal(runtimeKey);
+      }
+
       return;
     }
 
@@ -65,53 +133,83 @@ async function createRuntime(cwd: string): Promise<PiRuntime> {
   return runtime;
 }
 
-async function getRuntime(cwd: string) {
-  const existingRuntime = runtimePromises.get(cwd);
-  if (existingRuntime) {
-    return existingRuntime;
+function registerRuntime(runtimeKey: string, runtimePromise: Promise<PiRuntime>) {
+  const record: RuntimeRecord = {
+    runtimePromise,
+    disposeTimeout: null,
+  };
+
+  runtimeRecords.set(runtimeKey, record);
+  touchRuntime(runtimeKey);
+  return record;
+}
+
+export function getCachedRuntimeForSessionPath(sessionPath: string) {
+  const persistedSessionPath = getPersistedSessionPath(sessionPath);
+  if (!persistedSessionPath) {
+    return null;
   }
 
-  const runtimePromise = createRuntime(cwd);
-  runtimePromises.set(cwd, runtimePromise);
+  const record = runtimeRecords.get(persistedSessionPath);
+  if (!record) {
+    return null;
+  }
+
+  touchRuntime(persistedSessionPath);
+  return record.runtimePromise;
+}
+
+export async function getOrCreateRuntimeForSessionPath(sessionPath: string) {
+  const persistedSessionPath = getPersistedSessionPath(sessionPath);
+  if (!persistedSessionPath) {
+    throw new Error("A persisted session path is required to open a live runtime.");
+  }
+
+  const existingRuntime = runtimeRecords.get(persistedSessionPath);
+  if (existingRuntime) {
+    touchRuntime(persistedSessionPath);
+    return existingRuntime.runtimePromise;
+  }
+
+  const { SessionManager } = await getPiModule();
+  const sessionManager = SessionManager.open(persistedSessionPath);
+  let record: RuntimeRecord | null = null;
+  const runtimePromise = createRuntime({
+    cwd: sessionManager.getCwd(),
+    sessionManager,
+  }).catch((error) => {
+    if (record && runtimeRecords.get(persistedSessionPath) === record) {
+      runtimeRecords.delete(persistedSessionPath);
+    }
+
+    throw error;
+  });
+
+  record = registerRuntime(persistedSessionPath, runtimePromise);
   return runtimePromise;
 }
 
-async function resolveCwd(request: ComposerStateRequest = {}) {
-  if (request.sessionPath) {
-    const mappedCwd = getMappedCwd(request.sessionPath);
-    if (mappedCwd) {
-      return mappedCwd;
+export async function createRuntimeForNewSession(cwd: string) {
+  const runtime = await createRuntime({ cwd });
+  const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+
+  if (runtimeKey) {
+    const existingRuntime = runtimeRecords.get(runtimeKey);
+    if (existingRuntime) {
+      touchRuntime(runtimeKey);
+      runtime.session.dispose();
+      return await existingRuntime.runtimePromise;
     }
 
-    const { SessionManager } = await getPiModule();
-    return SessionManager.open(request.sessionPath).getCwd();
-  }
-
-  if (request.projectId) {
-    return request.projectId;
-  }
-
-  return process.cwd();
-}
-
-async function activateSession(runtime: PiRuntime, request: ComposerStateRequest = {}) {
-  if (request.sessionPath && runtime.session.sessionFile !== request.sessionPath) {
-    await runtime.session.switchSession(request.sessionPath);
-    rememberSessionPath(runtime.session.sessionFile, runtime.cwd);
+    registerRuntime(runtimeKey, Promise.resolve(runtime));
   }
 
   return runtime;
 }
 
-export async function getRuntimeForRequest(request: ComposerStateRequest = {}) {
-  const cwd = await resolveCwd(request);
-  const runtime = await getRuntime(cwd);
-  return activateSession(runtime, request);
-}
-
-export async function createFreshThreadIfNeeded(runtime: PiRuntime) {
-  if (runtime.session.messages.length > 0) {
-    await runtime.session.newSession();
-    rememberSessionPath(runtime.session.sessionFile, runtime.cwd);
+export function scheduleRuntimeDisposalForRuntime(runtime: PiRuntime) {
+  const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+  if (runtimeKey) {
+    scheduleRuntimeDisposal(runtimeKey);
   }
 }

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -24,7 +24,7 @@ function clearRuntimeDisposeTimeout(runtimeKey: string) {
   record.disposeTimeout = null;
 }
 
-function touchRuntime(runtimeKey: string) {
+function suspendRuntimeDisposal(runtimeKey: string) {
   clearRuntimeDisposeTimeout(runtimeKey);
 }
 
@@ -99,7 +99,7 @@ async function createRuntime(options: {
   session.subscribe((event) => {
     const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
     if (runtimeKey) {
-      touchRuntime(runtimeKey);
+      suspendRuntimeDisposal(runtimeKey);
     }
 
     if (event.type === "message_end") {
@@ -140,7 +140,6 @@ function registerRuntime(runtimeKey: string, runtimePromise: Promise<PiRuntime>)
   };
 
   runtimeRecords.set(runtimeKey, record);
-  touchRuntime(runtimeKey);
   return record;
 }
 
@@ -155,11 +154,13 @@ export function getCachedRuntimeForSessionPath(sessionPath: string) {
     return null;
   }
 
-  touchRuntime(persistedSessionPath);
   return record.runtimePromise;
 }
 
-export async function getOrCreateRuntimeForSessionPath(sessionPath: string) {
+export async function getOrCreateRuntimeForSessionPath(
+  sessionPath: string,
+  options: { suspendDisposal?: boolean } = {},
+) {
   const persistedSessionPath = getPersistedSessionPath(sessionPath);
   if (!persistedSessionPath) {
     throw new Error("A persisted session path is required to open a live runtime.");
@@ -167,7 +168,10 @@ export async function getOrCreateRuntimeForSessionPath(sessionPath: string) {
 
   const existingRuntime = runtimeRecords.get(persistedSessionPath);
   if (existingRuntime) {
-    touchRuntime(persistedSessionPath);
+    if (options.suspendDisposal) {
+      suspendRuntimeDisposal(persistedSessionPath);
+    }
+
     return existingRuntime.runtimePromise;
   }
 
@@ -196,7 +200,7 @@ export async function createRuntimeForNewSession(cwd: string) {
   if (runtimeKey) {
     const existingRuntime = runtimeRecords.get(runtimeKey);
     if (existingRuntime) {
-      touchRuntime(runtimeKey);
+      suspendRuntimeDisposal(runtimeKey);
       runtime.session.dispose();
       return await existingRuntime.runtimePromise;
     }

--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -227,8 +227,16 @@ export async function publishExternalThreadUpdate({
   });
 }
 
-export function publishComposerUpdate(composer: ComposerState) {
-  emitDesktopEvent({ type: "composer-update", composer });
+export function publishComposerUpdate(
+  composer: ComposerState,
+  context: { projectId?: string | null; sessionPath?: string | null } = {},
+) {
+  emitDesktopEvent({
+    type: "composer-update",
+    composer,
+    projectId: context.projectId ?? null,
+    sessionPath: context.sessionPath ?? null,
+  });
 }
 
 export { getLiveThread, shouldSuppressExternalThreadUpdate, subscribeDesktopEvents };

--- a/desktop/skill-creator-session.cts
+++ b/desktop/skill-creator-session.cts
@@ -6,7 +6,7 @@ import type { Message, SkillCreatorSessionState } from "../shared/desktop-contra
 import { mapAgentMessagesToUiMessages } from "../shared/pi-message-mapper.ts";
 import { loadAppSettings } from "./app-settings.cts";
 import { getPiModule } from "./pi-module.cts";
-import { resolveComposerModel } from "./runtime/composer-state.cts";
+import { createComposerSnapshotSession } from "./runtime/composer-state.cts";
 import {
   getActiveGlobalSkillsRoot,
   getActiveProjectSkillsRoot,
@@ -141,20 +141,25 @@ async function createSkillCreatorSession(cwd: string, projectPath?: string | nul
   await resourceLoader.reload();
 
   const selectedModel = loadAppSettings().skillCreatorModel;
+  const snapshot = await createComposerSnapshotSession({ projectId: projectPath ?? cwd });
   let model = null as Awaited<ReturnType<typeof modelRegistry.getAvailable>>[number] | null;
 
-  if (selectedModel) {
-    const availableModels = await modelRegistry.getAvailable();
-    model =
-      availableModels.find(
-        (availableModel) =>
-          availableModel.provider === selectedModel.provider &&
-          availableModel.id === selectedModel.id,
-      ) ?? null;
-  }
+  try {
+    if (selectedModel) {
+      const availableModels = await snapshot.session.modelRegistry.getAvailable();
+      model =
+        availableModels.find(
+          (availableModel) =>
+            availableModel.provider === selectedModel.provider &&
+            availableModel.id === selectedModel.id,
+        ) ?? null;
+    }
 
-  if (!model) {
-    model = await resolveComposerModel(projectPath ? { projectId: projectPath } : {});
+    if (!model) {
+      model = snapshot.session.model ?? null;
+    }
+  } finally {
+    snapshot.session.dispose();
   }
 
   if (!model) {

--- a/desktop/skill-creator-session.cts
+++ b/desktop/skill-creator-session.cts
@@ -6,7 +6,7 @@ import type { Message, SkillCreatorSessionState } from "../shared/desktop-contra
 import { mapAgentMessagesToUiMessages } from "../shared/pi-message-mapper.ts";
 import { loadAppSettings } from "./app-settings.cts";
 import { getPiModule } from "./pi-module.cts";
-import { getRuntimeForRequest } from "./runtime/runtime-registry.cts";
+import { resolveComposerModel } from "./runtime/composer-state.cts";
 import {
   getActiveGlobalSkillsRoot,
   getActiveProjectSkillsRoot,
@@ -154,8 +154,7 @@ async function createSkillCreatorSession(cwd: string, projectPath?: string | nul
   }
 
   if (!model) {
-    const runtime = await getRuntimeForRequest(projectPath ? { projectId: projectPath } : {});
-    model = runtime.session.model ?? null;
+    model = await resolveComposerModel(projectPath ? { projectId: projectPath } : {});
   }
 
   if (!model) {

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -377,5 +377,7 @@ export type DesktopEvent =
     }
   | {
       type: "composer-update";
+      projectId: string | null;
+      sessionPath: string | null;
       composer: ComposerState;
     };

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -6,6 +6,7 @@ import type {
   DesktopActionPayloadInput,
   ModelSelection,
 } from "./desktop-contracts";
+import { getPersistedSessionPath } from "./session-paths";
 
 const composerThinkingLevels = new Set<ComposerThinkingLevel>([
   "off",
@@ -19,7 +20,9 @@ const composerThinkingLevels = new Set<ComposerThinkingLevel>([
 export function getComposerRequest(payload: DesktopActionPayloadInput): ComposerStateRequest {
   return {
     projectId: typeof payload.projectId === "string" ? payload.projectId : null,
-    sessionPath: typeof payload.sessionPath === "string" ? payload.sessionPath : null,
+    sessionPath: getPersistedSessionPath(
+      typeof payload.sessionPath === "string" ? payload.sessionPath : null,
+    ),
   };
 }
 

--- a/shared/session-paths.ts
+++ b/shared/session-paths.ts
@@ -1,5 +1,8 @@
 const LOCAL_SESSION_PREFIX = "local://";
-const DEFAULT_LOCAL_DRAFT_TOKEN = "new-thread";
+
+function buildLocalSessionToken() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
 
 export function isLocalSessionPath(sessionPath: string | null | undefined) {
   return typeof sessionPath === "string" && sessionPath.startsWith(LOCAL_SESSION_PREFIX);
@@ -13,7 +16,24 @@ export function getPersistedSessionPath(sessionPath: string | null | undefined) 
     : null;
 }
 
-export function createLocalThreadDraft(projectId: string, token = DEFAULT_LOCAL_DRAFT_TOKEN) {
+export function getLocalDraftProjectId(sessionPath: string | null | undefined) {
+  if (typeof sessionPath !== "string" || !isLocalSessionPath(sessionPath)) {
+    return null;
+  }
+
+  const encodedProjectId = sessionPath.slice(LOCAL_SESSION_PREFIX.length).split("/", 1)[0] ?? "";
+  if (encodedProjectId.length === 0) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(encodedProjectId);
+  } catch {
+    return null;
+  }
+}
+
+export function createLocalThreadDraft(projectId: string, token = buildLocalSessionToken()) {
   const encodedProjectId = encodeURIComponent(projectId);
 
   return {

--- a/shared/session-paths.ts
+++ b/shared/session-paths.ts
@@ -1,8 +1,5 @@
 const LOCAL_SESSION_PREFIX = "local://";
-
-function buildLocalSessionToken() {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
+const DEFAULT_LOCAL_DRAFT_TOKEN = "new-thread";
 
 export function isLocalSessionPath(sessionPath: string | null | undefined) {
   return typeof sessionPath === "string" && sessionPath.startsWith(LOCAL_SESSION_PREFIX);
@@ -16,7 +13,7 @@ export function getPersistedSessionPath(sessionPath: string | null | undefined) 
     : null;
 }
 
-export function createLocalThreadDraft(projectId: string, token = buildLocalSessionToken()) {
+export function createLocalThreadDraft(projectId: string, token = DEFAULT_LOCAL_DRAFT_TOKEN) {
   const encodedProjectId = encodeURIComponent(projectId);
 
   return {

--- a/shared/session-paths.ts
+++ b/shared/session-paths.ts
@@ -1,0 +1,27 @@
+const LOCAL_SESSION_PREFIX = "local://";
+
+function buildLocalSessionToken() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function isLocalSessionPath(sessionPath: string | null | undefined) {
+  return typeof sessionPath === "string" && sessionPath.startsWith(LOCAL_SESSION_PREFIX);
+}
+
+export function getPersistedSessionPath(sessionPath: string | null | undefined) {
+  return typeof sessionPath === "string" &&
+    sessionPath.length > 0 &&
+    !isLocalSessionPath(sessionPath)
+    ? sessionPath
+    : null;
+}
+
+export function createLocalThreadDraft(projectId: string, token = buildLocalSessionToken()) {
+  const encodedProjectId = encodeURIComponent(projectId);
+
+  return {
+    projectId,
+    threadId: `local-thread-${token}`,
+    sessionPath: `${LOCAL_SESSION_PREFIX}${encodedProjectId}/${token}`,
+  };
+}

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { Dispatch } from "react";
+import { createLocalThreadDraft } from "../../../shared/session-paths";
 import type { DesktopAction } from "../desktop/actions";
 import type {
   AnyDesktopActionPayload,
@@ -61,12 +62,7 @@ function hasElectrobunDesktopBridge() {
 }
 
 function buildLocalThreadFallback(projectId: string) {
-  const timestamp = Date.now();
-  return {
-    projectId,
-    threadId: `local-thread-${timestamp}`,
-    sessionPath: `local://${encodeURIComponent(projectId)}/${timestamp}`,
-  };
+  return createLocalThreadDraft(projectId);
 }
 
 export function getOptimisticallyUpdatedShellState(

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { Dispatch, SetStateAction } from "react";
+import { getPersistedSessionPath } from "../../../shared/session-paths";
 import type {
   ArchivedThread,
   ComposerState,
@@ -182,7 +183,9 @@ export function useAppShellEffects({
     }
 
     const watchedSessionPath =
-      workspaceState.activeView === "thread" ? (workspaceState.selectedSessionPath ?? null) : null;
+      workspaceState.activeView === "thread"
+        ? getPersistedSessionPath(workspaceState.selectedSessionPath)
+        : null;
 
     void window.piDesktop.watchSession(watchedSessionPath).catch((error) => {
       console.warn("Failed to update watched Pi session.", error);
@@ -196,14 +199,22 @@ export function useAppShellEffects({
 
     const visibleSessionPath =
       workspaceState.activeView === "thread"
-        ? (workspaceState.selectedSessionPath ?? null)
+        ? getPersistedSessionPath(workspaceState.selectedSessionPath)
         : workspaceState.activeView === "inbox"
           ? (workspaceState.selectedInboxSessionPath ?? null)
           : null;
 
     const unsubscribe = window.piDesktop.subscribe((event: DesktopEvent) => {
       if (event.type === "composer-update") {
-        setComposerState(event.composer);
+        const shouldApplyComposerUpdate = event.sessionPath
+          ? event.sessionPath === visibleSessionPath
+          : event.projectId === composerProjectId &&
+            (workspaceState.activeView !== "thread" || visibleSessionPath === null);
+
+        if (shouldApplyComposerUpdate) {
+          setComposerState(event.composer);
+        }
+
         return;
       }
 
@@ -212,7 +223,7 @@ export function useAppShellEffects({
         event.thread,
       );
 
-      if (event.composer) {
+      if (event.composer && event.sessionPath === visibleSessionPath) {
         setComposerState(event.composer);
       }
 
@@ -242,7 +253,12 @@ export function useAppShellEffects({
           });
       }
 
-      if (event.reason === "start" && workspaceState.activeView !== "inbox") {
+      const shouldAutoOpenStartedThread =
+        event.reason === "start" &&
+        (workspaceState.activeView === "code" ||
+          (workspaceState.activeView === "thread" && visibleSessionPath === null));
+
+      if (shouldAutoOpenStartedThread) {
         dispatch({
           type: "open-thread",
           projectId: event.projectId,

--- a/src/app/components/workspace/composer/composerDraftStore.ts
+++ b/src/app/components/workspace/composer/composerDraftStore.ts
@@ -1,4 +1,4 @@
-import { isLocalSessionPath } from "../../../../../shared/session-paths";
+import { getLocalDraftProjectId } from "../../../../../shared/session-paths";
 
 import type { ComposerAttachment } from "../../../desktop/types";
 
@@ -160,11 +160,7 @@ export function getComposerDraftThreadId({
   projectId: string;
   sessionPath: string | null;
 }) {
-  if (
-    typeof sessionPath === "string" &&
-    sessionPath.length > 0 &&
-    !isLocalSessionPath(sessionPath)
-  ) {
+  if (typeof sessionPath === "string" && sessionPath.length > 0) {
     return `session:${sessionPath}`;
   }
 
@@ -219,13 +215,38 @@ export function createComposerDraftStore({
     }, debounceMs);
   };
 
+  const getMirroredProjectDraftThreadId = (threadId: string) => {
+    if (!threadId.startsWith("session:")) {
+      return null;
+    }
+
+    const projectId = getLocalDraftProjectId(threadId.slice("session:".length));
+    return projectId ? `project:${projectId}:new-thread` : null;
+  };
+
+  const areDraftsEqual = (left: ComposerDraft | undefined, right: ComposerDraft | undefined) => {
+    if (!left || !right) {
+      return false;
+    }
+
+    return JSON.stringify(left) === JSON.stringify(right);
+  };
+
   const writeDraft = (threadId: string, nextDraft: ComposerDraft) => {
+    const mirroredThreadId = getMirroredProjectDraftThreadId(threadId);
+    const previousDraft = draftsByThreadId[threadId];
+
     if (nextDraft.prompt.length === 0 && nextDraft.attachments.length === 0) {
       delete draftsByThreadId[threadId];
+
+      if (mirroredThreadId && areDraftsEqual(draftsByThreadId[mirroredThreadId], previousDraft)) {
+        delete draftsByThreadId[mirroredThreadId];
+      }
     } else {
       draftsByThreadId = {
         ...draftsByThreadId,
         [threadId]: cloneDraft(nextDraft),
+        ...(mirroredThreadId ? { [mirroredThreadId]: cloneDraft(nextDraft) } : {}),
       };
     }
 
@@ -275,9 +296,18 @@ export function createComposerDraftStore({
         return;
       }
 
+      const mirroredThreadId = getMirroredProjectDraftThreadId(threadId);
+      const previousDraft = draftsByThreadId[threadId];
+
       draftsByThreadId = Object.fromEntries(
         Object.entries(draftsByThreadId).filter(
-          ([currentThreadId]) => currentThreadId !== threadId,
+          ([currentThreadId, currentDraft]) =>
+            currentThreadId !== threadId &&
+            !(
+              mirroredThreadId &&
+              currentThreadId === mirroredThreadId &&
+              areDraftsEqual(currentDraft, previousDraft)
+            ),
         ),
       );
       schedulePersist();

--- a/src/app/components/workspace/composer/composerDraftStore.ts
+++ b/src/app/components/workspace/composer/composerDraftStore.ts
@@ -1,3 +1,5 @@
+import { isLocalSessionPath } from "../../../../../shared/session-paths";
+
 import type { ComposerAttachment } from "../../../desktop/types";
 
 type ComposerDraft = {
@@ -158,7 +160,11 @@ export function getComposerDraftThreadId({
   projectId: string;
   sessionPath: string | null;
 }) {
-  if (typeof sessionPath === "string" && sessionPath.length > 0) {
+  if (
+    typeof sessionPath === "string" &&
+    sessionPath.length > 0 &&
+    !isLocalSessionPath(sessionPath)
+  ) {
     return `session:${sessionPath}`;
   }
 

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -1,6 +1,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
+import { getPersistedSessionPath } from "../../../../../shared/session-paths";
 import type { TerminalEvent } from "../../../desktop/types";
 import {
   closeDesktopTerminal,
@@ -77,6 +78,9 @@ export function TerminalViewport({
   const lastSizeRef = useRef<{ width: number; height: number; cols: number; rows: number } | null>(
     null,
   );
+  const persistedSessionPath = getPersistedSessionPath(sessionPath);
+  const effectiveLaunchMode =
+    launchMode === "pi-session" && !persistedSessionPath ? "shell" : launchMode;
 
   useEffect(() => {
     const mount = containerRef.current;
@@ -264,8 +268,8 @@ export function TerminalViewport({
       fitAddon.fit();
       const snapshot = await openDesktopTerminal({
         projectId,
-        sessionPath,
-        launchMode,
+        sessionPath: persistedSessionPath,
+        launchMode: effectiveLaunchMode,
         cols: Math.max(terminal.cols, 20),
         rows: Math.max(terminal.rows, 5),
       });
@@ -314,7 +318,7 @@ export function TerminalViewport({
         void closeDesktopTerminal({ sessionId });
       }
     };
-  }, [launchMode, preserveSessionOnUnmount, projectId, sessionPath]);
+  }, [effectiveLaunchMode, persistedSessionPath, preserveSessionOnUnmount, projectId]);
 
   return (
     <div

--- a/src/app/hooks/useDesktopThread.ts
+++ b/src/app/hooks/useDesktopThread.ts
@@ -20,7 +20,7 @@ export function useDesktopThread(
         : Promise.resolve(null),
     enabled: Boolean(persistedSessionPath),
     staleTime: Number.POSITIVE_INFINITY,
-    placeholderData: keepPreviousData,
+    placeholderData: persistedSessionPath ? keepPreviousData : undefined,
   });
 
   return query.data ?? null;

--- a/src/app/hooks/useDesktopThread.ts
+++ b/src/app/hooks/useDesktopThread.ts
@@ -1,4 +1,5 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { getPersistedSessionPath } from "../../../shared/session-paths";
 import type { ThreadData } from "../desktop/types";
 import { desktopQueryKeys, getThreadQuery } from "../query/desktop-query";
 
@@ -7,13 +8,17 @@ export function useDesktopThread(
   refreshKey = 0,
   historyCompactions = 0,
 ) {
+  const persistedSessionPath = getPersistedSessionPath(sessionPath);
+
   const query = useQuery<ThreadData | null>({
-    queryKey: sessionPath
-      ? desktopQueryKeys.thread(sessionPath, refreshKey, historyCompactions)
+    queryKey: persistedSessionPath
+      ? desktopQueryKeys.thread(persistedSessionPath, refreshKey, historyCompactions)
       : ["desktop", "thread", null, refreshKey, historyCompactions],
     queryFn: () =>
-      sessionPath ? getThreadQuery(sessionPath, historyCompactions) : Promise.resolve(null),
-    enabled: Boolean(sessionPath),
+      persistedSessionPath
+        ? getThreadQuery(persistedSessionPath, historyCompactions)
+        : Promise.resolve(null),
+    enabled: Boolean(persistedSessionPath),
     staleTime: Number.POSITIVE_INFINITY,
     placeholderData: keepPreviousData,
   });

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -1,3 +1,4 @@
+import { getPersistedSessionPath } from "../../../shared/session-paths";
 import type {
   ArchivedThread,
   ComposerAttachment,
@@ -35,7 +36,12 @@ export const desktopQueryKeys = {
   inboxThreads: () => ["desktop", "inboxThreads"] as const,
   archivedThreads: () => ["desktop", "archivedThreads"] as const,
   composerState: (request: ComposerStateRequest) =>
-    ["desktop", "composerState", request.projectId ?? null, request.sessionPath ?? null] as const,
+    [
+      "desktop",
+      "composerState",
+      request.projectId ?? null,
+      getPersistedSessionPath(request.sessionPath),
+    ] as const,
   projectGitState: (projectId: string) => ["desktop", "projectGitState", projectId] as const,
   projectDiffPrefix: (projectId: string) => ["desktop", "projectDiff", projectId] as const,
   projectDiff: (projectId: string, baseline: ProjectDiffBaseline | null = null) =>

--- a/src/test/composer-draft-store.test.ts
+++ b/src/test/composer-draft-store.test.ts
@@ -130,6 +130,9 @@ describe("composerDraftStore", () => {
     expect(getComposerDraftThreadId({ projectId: "/repo", sessionPath: "/repo/thread.json" })).toBe(
       "session:/repo/thread.json",
     );
+    expect(
+      getComposerDraftThreadId({ projectId: "/repo", sessionPath: "local://%2Frepo/new-thread" }),
+    ).toBe("project:/repo:new-thread");
     expect(getComposerDraftThreadId({ projectId: "/repo", sessionPath: null })).toBe(
       "project:/repo:new-thread",
     );

--- a/src/test/composer-draft-store.test.ts
+++ b/src/test/composer-draft-store.test.ts
@@ -132,11 +132,50 @@ describe("composerDraftStore", () => {
     );
     expect(
       getComposerDraftThreadId({ projectId: "/repo", sessionPath: "local://%2Frepo/new-thread" }),
-    ).toBe("project:/repo:new-thread");
+    ).toBe("session:local://%2Frepo/new-thread");
     expect(getComposerDraftThreadId({ projectId: "/repo", sessionPath: null })).toBe(
       "project:/repo:new-thread",
     );
     expect(getComposerDraftThreadId({ projectId: "", sessionPath: null })).toBeNull();
+  });
+
+  it("keeps local drafts separate while mirroring the latest project draft", () => {
+    const storage = createMemoryStorage();
+    const store = createComposerDraftStore({
+      storage,
+      storageKey: composerDraftStorageKey,
+      debounceMs: 300,
+      beforeUnloadTarget: null,
+    });
+
+    const firstLocalThreadId = "session:local://%2Frepo/first";
+    const secondLocalThreadId = "session:local://%2Frepo/second";
+    const projectDraftThreadId = "project:/repo:new-thread";
+
+    store.setDraft(firstLocalThreadId, { prompt: "first draft", attachments: [] });
+    store.setDraft(secondLocalThreadId, { prompt: "second draft", attachments: [] });
+
+    expect(store.getDraft(firstLocalThreadId)).toEqual({
+      prompt: "first draft",
+      attachments: [],
+    });
+    expect(store.getDraft(secondLocalThreadId)).toEqual({
+      prompt: "second draft",
+      attachments: [],
+    });
+    expect(store.getDraft(projectDraftThreadId)).toEqual({
+      prompt: "second draft",
+      attachments: [],
+    });
+
+    store.clearThreadDraft(firstLocalThreadId);
+    expect(store.getDraft(projectDraftThreadId)).toEqual({
+      prompt: "second draft",
+      attachments: [],
+    });
+
+    store.clearThreadDraft(secondLocalThreadId);
+    expect(store.getDraft(projectDraftThreadId)).toBeNull();
   });
 
   it("returns cloned drafts so callers cannot mutate store state", () => {


### PR DESCRIPTION
## Summary
- support multiple live Pi runtimes per project by keying runtimes per persisted session instead of per cwd
- make new threads start as local drafts and only create real Pi sessions on first send, while keeping draft behavior stable across reloads and fresh new-thread actions
- resolve cold composer, commit-message, and skill-creator models through extension-aware snapshot sessions and tighten runtime/draft lifecycle behavior

## Testing
- bun run lint
- bun run typecheck
- bun run test
- bun run build