### PR TITLE
Replace mock sidebar views with coming soon roadmaps

### DIFF
--- a/src/app/app-shell/AppShellWorkspace.tsx
+++ b/src/app/app-shell/AppShellWorkspace.tsx
@@ -24,13 +24,13 @@ export function AppShellWorkspace({
   terminalSessionPath,
   workspaceContentClass,
 }: AppShellWorkspaceProps) {
-  const { handleAction, state } = controller;
+  const { state } = controller;
 
   if (state.activeView === "chat" || state.activeView === "claw" || state.activeView === "work") {
     return (
       <div className="relative min-h-0 flex-1 px-5 pt-1.5">
         <main className={mainPanelClass}>
-          <MainView activeView={state.activeView} onAction={handleAction} />
+          <MainView activeView={state.activeView} />
         </main>
       </div>
     );

--- a/src/app/components/common/NavButton.tsx
+++ b/src/app/components/common/NavButton.tsx
@@ -31,7 +31,7 @@ export function NavButton({
       {...buttonProps}
     >
       {icon}
-      <span>{label}</span>
+      <span className="flex min-w-0 flex-1">{label}</span>
     </button>
   );
 }

--- a/src/app/components/sidebar/Sidebar.tsx
+++ b/src/app/components/sidebar/Sidebar.tsx
@@ -37,6 +37,14 @@ type SidebarProps = {
   onToggleProjectCollapse: (projectId: string) => void;
 };
 
+function ComingSoonLabel() {
+  return (
+    <span className="shrink-0 text-[10px] font-medium uppercase tracking-[0.08em] text-[color:var(--muted-2)]">
+      Coming soon
+    </span>
+  );
+}
+
 export function Sidebar({
   projects,
   inboxThreads,
@@ -108,9 +116,9 @@ export function Sidebar({
           <NavButton
             icon={<MessageSquare size={16} />}
             label={
-              <span className="inline-flex items-center gap-2">
+              <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
                 <span>Chat</span>
-                <FeatureStatusBadge statusId="feature:sidebar.plugins" />
+                <ComingSoonLabel />
               </span>
             }
             active={activeView === "chat"}
@@ -119,9 +127,9 @@ export function Sidebar({
           <NavButton
             icon={<PawPrint size={16} />}
             label={
-              <span className="inline-flex items-center gap-2">
+              <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
                 <span>Claw</span>
-                <FeatureStatusBadge statusId="feature:sidebar.automations" />
+                <ComingSoonLabel />
               </span>
             }
             active={activeView === "claw"}
@@ -130,9 +138,9 @@ export function Sidebar({
           <NavButton
             icon={<BriefcaseBusiness size={16} />}
             label={
-              <span className="inline-flex items-center gap-2">
+              <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
                 <span>Work</span>
-                <FeatureStatusBadge statusId="feature:sidebar.debug" />
+                <ComingSoonLabel />
               </span>
             }
             active={activeView === "work"}

--- a/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
+++ b/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
@@ -8,7 +8,6 @@ import { cn } from "../../../utils/cn";
 import { IconButton } from "../../common/IconButton";
 import { ProjectTree } from "../ProjectTree";
 import { SidebarProjectsCreatePopover } from "./SidebarProjectsCreatePopover";
-import { SidebarProjectsPlaceholder } from "./SidebarProjectsPlaceholder";
 import {
   type SidebarProjectsFilterMode,
   getSidebarVisibleProjects,
@@ -144,6 +143,10 @@ export function SidebarProjectsSection({
     }
   };
 
+  if (!showProjects) {
+    return <section className="flex min-h-0 flex-1" aria-hidden="true" />;
+  }
+
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2.5">
       <div className="relative grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
@@ -223,33 +226,29 @@ export function SidebarProjectsSection({
         ) : null}
       </div>
 
-      {showProjects ? (
-        visibleProjects.length > 0 ? (
-          <ProjectTree
-            projects={visibleProjects}
-            selectedProjectId={selectedProjectId}
-            selectedThreadId={selectedThreadId}
-            activeView={activeView}
-            selectionModeActive={selectionModeActive}
-            collapsedProjectIds={effectiveCollapsedProjectIds}
-            onAction={onAction}
-            onProjectSelect={onProjectSelect}
-            onProjectReorder={onProjectReorder}
-            onThreadOpen={onThreadOpen}
-            onToggleProjectCollapse={onToggleProjectCollapse}
-          />
-        ) : (
-          <div
-            className={cn(
-              "px-2.5 py-2 text-[13px] text-[color:var(--muted-2)]",
-              searchQuery.trim().length > 0 || filterMode !== "all" ? "" : "hidden",
-            )}
-          >
-            No matching projects
-          </div>
-        )
+      {visibleProjects.length > 0 ? (
+        <ProjectTree
+          projects={visibleProjects}
+          selectedProjectId={selectedProjectId}
+          selectedThreadId={selectedThreadId}
+          activeView={activeView}
+          selectionModeActive={selectionModeActive}
+          collapsedProjectIds={effectiveCollapsedProjectIds}
+          onAction={onAction}
+          onProjectSelect={onProjectSelect}
+          onProjectReorder={onProjectReorder}
+          onThreadOpen={onThreadOpen}
+          onToggleProjectCollapse={onToggleProjectCollapse}
+        />
       ) : (
-        <SidebarProjectsPlaceholder />
+        <div
+          className={cn(
+            "px-2.5 py-2 text-[13px] text-[color:var(--muted-2)]",
+            searchQuery.trim().length > 0 || filterMode !== "all" ? "" : "hidden",
+          )}
+        >
+          No matching projects
+        </div>
       )}
     </section>
   );

--- a/src/app/views/MainView.tsx
+++ b/src/app/views/MainView.tsx
@@ -1,61 +1,27 @@
-import { automationCards, debugCards, pluginCards } from "../data/mock-data";
-import type { DesktopActionInvoker } from "../desktop/types";
+import { MarkdownContent } from "../components/common/MarkdownContent";
+import { ViewHeader } from "../components/common/ViewHeader";
+import { ViewShell } from "../components/common/ViewShell";
 import type { View } from "../types";
-import { CardGridView } from "./CardGridView";
+import { getComingSoonViewContent } from "./coming-soon-roadmaps";
 
 type MainViewProps = {
   activeView: View;
-  onAction: DesktopActionInvoker;
 };
 
-export function MainView({ activeView, onAction }: MainViewProps) {
-  if (activeView === "chat") {
-    return (
-      <div className="grid min-h-full content-start px-2 pt-8">
-        <CardGridView
-          eyebrow="Chat"
-          title="Chat surface"
-          description="Visual parity first: every major Codex-style action is represented as a desktop stub."
-          cards={pluginCards}
-          action="plugins.open-card"
-          statusId="feature:views.plugins"
-          onAction={onAction}
-        />
-      </div>
-    );
+export function MainView({ activeView }: MainViewProps) {
+  if (activeView !== "chat" && activeView !== "claw" && activeView !== "work") {
+    return null;
   }
 
-  if (activeView === "claw") {
-    return (
-      <div className="grid min-h-full content-start px-2 pt-8">
-        <CardGridView
-          eyebrow="Claw"
-          title="Claw surface"
-          description="These tiles are placeholder flows for eventual Pi feature parity."
-          cards={automationCards}
-          action="automations.open-card"
-          statusId="feature:views.automations"
-          onAction={onAction}
-        />
-      </div>
-    );
-  }
+  const content = getComingSoonViewContent(activeView);
 
-  if (activeView === "work") {
-    return (
-      <div className="grid min-h-full content-start px-2 pt-8">
-        <CardGridView
-          eyebrow="Work"
-          title="Work surface"
-          description="Everything here is wired as mock UI so we can swap in Pi SDK data later."
-          cards={debugCards}
-          action="debug.open-card"
-          statusId="feature:views.debug"
-          onAction={onAction}
-        />
-      </div>
-    );
-  }
+  return (
+    <ViewShell maxWidthClassName="max-w-[760px]">
+      <ViewHeader title={content.title} subtitle={content.subtitle} />
 
-  return null;
+      <section className="grid gap-4 rounded-[18px] border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] p-4">
+        <MarkdownContent markdown={content.markdown} className="gap-3 text-[15px]" />
+      </section>
+    </ViewShell>
+  );
 }

--- a/src/app/views/MainView.tsx
+++ b/src/app/views/MainView.tsx
@@ -19,9 +19,7 @@ export function MainView({ activeView }: MainViewProps) {
     <ViewShell maxWidthClassName="max-w-[760px]">
       <ViewHeader title={content.title} subtitle={content.subtitle} />
 
-      <section className="grid gap-4 rounded-[18px] border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] p-4">
-        <MarkdownContent markdown={content.markdown} className="gap-3 text-[15px]" />
-      </section>
+      <MarkdownContent markdown={content.markdown} className="gap-3 text-[15px]" />
     </ViewShell>
   );
 }

--- a/src/app/views/coming-soon-roadmaps.ts
+++ b/src/app/views/coming-soon-roadmaps.ts
@@ -1,0 +1,34 @@
+import type { View } from "../types";
+import chatRoadmapMarkdown from "./roadmaps/chat.md?raw";
+import clawRoadmapMarkdown from "./roadmaps/claw.md?raw";
+import workRoadmapMarkdown from "./roadmaps/work.md?raw";
+
+type ComingSoonView = Extract<View, "chat" | "claw" | "work">;
+
+type ComingSoonViewContent = {
+  title: string;
+  subtitle: string;
+  markdown: string;
+};
+
+const comingSoonViewContent: Record<ComingSoonView, ComingSoonViewContent> = {
+  chat: {
+    title: "Chat roadmap",
+    subtitle: "Coming soon. This surface will focus on a lighter, chat-first Pi experience.",
+    markdown: chatRoadmapMarkdown,
+  },
+  claw: {
+    title: "Claw roadmap",
+    subtitle: "Coming soon. This surface will grow into the automation and workflow lane.",
+    markdown: clawRoadmapMarkdown,
+  },
+  work: {
+    title: "Work roadmap",
+    subtitle: "Coming soon. This surface will become the deeper workspace and inspection lane.",
+    markdown: workRoadmapMarkdown,
+  },
+};
+
+export function getComingSoonViewContent(view: ComingSoonView) {
+  return comingSoonViewContent[view];
+}

--- a/src/app/views/coming-soon-roadmaps.ts
+++ b/src/app/views/coming-soon-roadmaps.ts
@@ -19,12 +19,12 @@ const comingSoonViewContent: Record<ComingSoonView, ComingSoonViewContent> = {
   },
   claw: {
     title: "Claw roadmap",
-    subtitle: "Coming soon. This surface will grow into the automation and workflow lane.",
+    subtitle: "Coming soon. This surface will grow into an OpenClaw-style personal assistant lane.",
     markdown: clawRoadmapMarkdown,
   },
   work: {
     title: "Work roadmap",
-    subtitle: "Coming soon. This surface will become the deeper workspace and inspection lane.",
+    subtitle: "Coming soon. This surface will become a Claude Cowork-style knowledge work lane.",
     markdown: workRoadmapMarkdown,
   },
 };

--- a/src/app/views/roadmaps/chat.md
+++ b/src/app/views/roadmaps/chat.md
@@ -1,0 +1,20 @@
+## What this view is for
+
+Chat is the lighter-weight Pi surface: quick conversations, recent threads, and model-driven work without the full project shell getting in the way.
+
+## First implementation slice
+
+- make chat-first entry feel intentional rather than like a placeholder
+- surface recent conversations and quick-start actions
+- keep thread continuity strong across reopen and revisit flows
+- expose the core model controls that matter for a fast conversation loop
+
+## Later follow-up
+
+- add better thread organisation and search
+- support a smoother handoff between chat-only work and project-backed work
+- tighten the inbox, thread, and composer relationship into one clear flow
+
+## Not the goal
+
+This view should not become a duplicate of the full code workspace. It should stay fast, focused, and conversation-first.

--- a/src/app/views/roadmaps/claw.md
+++ b/src/app/views/roadmaps/claw.md
@@ -1,20 +1,28 @@
 ## What this view is for
 
-Claw is the automation lane: reusable flows, multi-step actions, and task orchestration that go beyond a single manual prompt.
+Claw is the OpenClaw-inspired automation lane: a personal AI assistant that feels present across your devices, channels, and tools rather than trapped inside a single chat box.
+
+In practice, that means this view should grow toward:
+
+- a more always-on assistant posture
+- actions that can start from messages, skills, or device context
+- a strong notion of channels, tools, and automation working together
+- local-first control, with clear visibility into what the assistant can access and do
 
 ## First implementation slice
 
-- define what a real automation looks like in howcode
-- support a small set of trustworthy, repeatable workflows
-- show execution state clearly so the user always knows what is running and why
-- connect automation runs back to the relevant project, thread, and diff context
+- define the smallest useful OpenClaw-style loop for howcode
+- let the user trigger a few trustworthy assistant actions from one clear surface
+- connect those actions to skills, project context, and visible execution state
+- make each run feel like a real assistant action, not just a dressed-up prompt submit
 
 ## Later follow-up
 
-- add a browseable automation catalog
-- support saved inputs, presets, and reruns
-- introduce review or approval checkpoints where automation output needs confirmation
+- support channel-aware and context-aware triggers
+- add a real skills or automation catalog with installable capabilities
+- introduce richer device, tool, or external-system actions where they fit the product
+- make the assistant feel persistent and operational, not episodic
 
 ## Not the goal
 
-This view should not just be a pile of buttons. It needs a coherent automation model with clear inputs, outputs, and status.
+This view should not become a random automation dump. The point is a coherent personal-assistant surface with strong agency, clear permissions, and observable actions.

--- a/src/app/views/roadmaps/claw.md
+++ b/src/app/views/roadmaps/claw.md
@@ -1,0 +1,20 @@
+## What this view is for
+
+Claw is the automation lane: reusable flows, multi-step actions, and task orchestration that go beyond a single manual prompt.
+
+## First implementation slice
+
+- define what a real automation looks like in howcode
+- support a small set of trustworthy, repeatable workflows
+- show execution state clearly so the user always knows what is running and why
+- connect automation runs back to the relevant project, thread, and diff context
+
+## Later follow-up
+
+- add a browseable automation catalog
+- support saved inputs, presets, and reruns
+- introduce review or approval checkpoints where automation output needs confirmation
+
+## Not the goal
+
+This view should not just be a pile of buttons. It needs a coherent automation model with clear inputs, outputs, and status.

--- a/src/app/views/roadmaps/work.md
+++ b/src/app/views/roadmaps/work.md
@@ -1,20 +1,23 @@
 ## What this view is for
 
-Work is the heavier-duty workspace lane: inspection, project-level operations, and the deeper tooling around coding sessions.
+Work is the Claude Cowork-inspired workspace lane: agentic knowledge work over local files, with Claude-style multi-step execution that can research, prepare documents, and organise material on the user's behalf.
+
+This is not just another chat view. It should feel like a task execution surface for real work.
 
 ## First implementation slice
 
-- define the core workspace tools that belong here instead of in the main code view
-- bring together project diagnostics, execution history, and richer repository operations
-- make the value of this surface obvious through strong visual structure and clear status
-- connect the view to real project state rather than mock panels
+- focus the view on multi-step knowledge work rather than generic debug tools
+- let the agent work against local files with clear scope and visible progress
+- support a few strong workflows such as research synthesis, document preparation, and file organisation
+- make it obvious when the system is planning, reading, writing, and finishing work
 
 ## Later follow-up
 
-- expand into a serious inspector or devtools-style surface
-- add stronger review, debugging, or operational visibility where it genuinely helps
-- support deeper project-level workflows that do not fit the composer-first layout
+- support longer-running delegated tasks with resumable progress
+- add richer file and document workflows beyond the main coding surface
+- expose strong review checkpoints before important edits or final outputs
+- make the view feel like a true coworker for structured work, not a passive dashboard
 
 ## Not the goal
 
-This view should not stay a vague debug bucket. It needs a crisp product definition before more surface area is added.
+This view should not become a vague debug bucket or just another thread list. It should stay centered on agentic knowledge work over user-approved local context.

--- a/src/app/views/roadmaps/work.md
+++ b/src/app/views/roadmaps/work.md
@@ -1,0 +1,20 @@
+## What this view is for
+
+Work is the heavier-duty workspace lane: inspection, project-level operations, and the deeper tooling around coding sessions.
+
+## First implementation slice
+
+- define the core workspace tools that belong here instead of in the main code view
+- bring together project diagnostics, execution history, and richer repository operations
+- make the value of this surface obvious through strong visual structure and clear status
+- connect the view to real project state rather than mock panels
+
+## Later follow-up
+
+- expand into a serious inspector or devtools-style surface
+- add stronger review, debugging, or operational visibility where it genuinely helps
+- support deeper project-level workflows that do not fit the composer-first layout
+
+## Not the goal
+
+This view should not stay a vague debug bucket. It needs a crisp product definition before more surface area is added.

--- a/src/test/coming-soon-roadmaps.test.ts
+++ b/src/test/coming-soon-roadmaps.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getComingSoonViewContent } from "../app/views/coming-soon-roadmaps";
+
+describe("coming soon roadmaps", () => {
+  it("returns markdown-backed content for each upcoming sidebar view", () => {
+    expect(getComingSoonViewContent("chat")).toMatchObject({
+      title: "Chat roadmap",
+    });
+    expect(getComingSoonViewContent("chat").markdown).toContain("What this view is for");
+
+    expect(getComingSoonViewContent("claw")).toMatchObject({
+      title: "Claw roadmap",
+    });
+    expect(getComingSoonViewContent("claw").markdown).toContain("automation lane");
+
+    expect(getComingSoonViewContent("work")).toMatchObject({
+      title: "Work roadmap",
+    });
+    expect(getComingSoonViewContent("work").markdown).toContain("workspace lane");
+  });
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,3 +4,8 @@ declare module "*.css?raw" {
   const content: string;
   export default content;
 }
+
+declare module "*.md?raw" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- replace the Chat, Claw, and Work mock badges with inline "Coming soon" labels in the sidebar
- render roadmap markdown pages for those three views instead of the old mock card grids
- refine the Claw and Work roadmap copy around OpenClaw and Claude Cowork, and simplify the sidebar/body layout for those pages

Closes #9