### PR TITLE
Unify Pi takeover and decouple git ops into a dedicated view

### DIFF
--- a/desktop/app-settings.cts
+++ b/desktop/app-settings.cts
@@ -8,6 +8,7 @@ const projectImportStateKey = "projectImportState";
 const preferredProjectLocationKey = "preferredProjectLocation";
 const initializeGitOnProjectCreateKey = "initializeGitOnProjectCreate";
 const useAgentsSkillsPathsKey = "useAgentsSkillsPaths";
+const piTuiTakeoverKey = "piTuiTakeover";
 
 type PreferenceRow = {
   valueJson: string;
@@ -164,6 +165,15 @@ export function loadAppSettings(): AppSettings {
       `,
     )
     .get(useAgentsSkillsPathsKey) as PreferenceRow | undefined;
+  const piTuiTakeoverRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(piTuiTakeoverKey) as PreferenceRow | undefined;
 
   return {
     gitCommitMessageModel: parseModelSelection(modelRow?.valueJson),
@@ -174,6 +184,7 @@ export function loadAppSettings(): AppSettings {
     initializeGitOnProjectCreate:
       parseBooleanPreference(initializeGitOnProjectCreateRow?.valueJson) ?? false,
     useAgentsSkillsPaths: parseBooleanPreference(useAgentsSkillsPathsRow?.valueJson) ?? false,
+    piTuiTakeover: parseBooleanPreference(piTuiTakeoverRow?.valueJson) ?? false,
   };
 }
 
@@ -233,4 +244,8 @@ export function setInitializeGitOnProjectCreate(enabled: boolean) {
 
 export function setUseAgentsSkillsPaths(enabled: boolean) {
   writeAppPreference(useAgentsSkillsPathsKey, JSON.stringify(enabled));
+}
+
+export function setPiTuiTakeover(enabled: boolean) {
+  writeAppPreference(piTuiTakeoverKey, JSON.stringify(enabled));
 }

--- a/desktop/pi-threads/settings-actions.cts
+++ b/desktop/pi-threads/settings-actions.cts
@@ -13,6 +13,7 @@ import {
   setFavoriteFolders,
   setGitCommitMessageModelSelection,
   setInitializeGitOnProjectCreate,
+  setPiTuiTakeover,
   setPreferredProjectLocation,
   setProjectImportState,
   setSkillCreatorModelSelection,
@@ -46,6 +47,11 @@ export function handleSettingsDesktopAction(
 
   if (key === "useAgentsSkillsPaths") {
     setUseAgentsSkillsPaths(getSettingsBooleanValue(payload) ?? false);
+    return handledAction();
+  }
+
+  if (key === "piTuiTakeover") {
+    setPiTuiTakeover(getSettingsBooleanValue(payload) ?? false);
     return handledAction();
   }
 

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -46,7 +46,8 @@ export type DesktopSettingsUpdatePayload =
   | { key: "projectImportState"; imported: boolean | null }
   | { key: "preferredProjectLocation"; value: string | null }
   | { key: "initializeGitOnProjectCreate"; value: boolean }
-  | { key: "useAgentsSkillsPaths"; value: boolean };
+  | { key: "useAgentsSkillsPaths"; value: boolean }
+  | { key: "piTuiTakeover"; value: boolean };
 
 export type DesktopActionPayloadMap = {
   "threads.collapse-all": EmptyActionPayload;

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -246,6 +246,7 @@ export type AppSettings = {
   preferredProjectLocation: string | null;
   initializeGitOnProjectCreate: boolean;
   useAgentsSkillsPaths: boolean;
+  piTuiTakeover: boolean;
 };
 
 export type ComposerStateRequest = {

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -115,7 +115,8 @@ export function getSettingsKey(payload: DesktopActionPayloadInput) {
     payload.key === "projectImportState" ||
     payload.key === "preferredProjectLocation" ||
     payload.key === "initializeGitOnProjectCreate" ||
-    payload.key === "useAgentsSkillsPaths"
+    payload.key === "useAgentsSkillsPaths" ||
+    payload.key === "piTuiTakeover"
     ? (payload.key as keyof AppSettings)
     : null;
 }

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -1,6 +1,10 @@
+import { useEffect, useState } from "react";
 import { ArchivedThreadsPanel } from "../components/settings/ArchivedThreadsPanel";
 import { ProjectActionDialog } from "../components/sidebar/ProjectActionDialog";
 import { Sidebar } from "../components/sidebar/Sidebar";
+import type { ComposerSurface } from "../components/workspace/Composer";
+import { defaultDiffBaseline } from "../components/workspace/composer/diff-baseline";
+import type { ProjectDiffBaseline } from "../desktop/types";
 import { AppShellOverlays } from "./AppShellOverlays";
 import { AppShellWorkspace } from "./AppShellWorkspace";
 import type { AppShellController } from "./useAppShellController";
@@ -11,6 +15,14 @@ type AppShellLayoutProps = {
 };
 
 export function AppShellLayout({ controller }: AppShellLayoutProps) {
+  const [composerSurface, setComposerSurface] = useState<ComposerSurface>("prompt");
+  const [diffBaselineState, setDiffBaselineState] = useState<{
+    projectId: string;
+    baseline: ProjectDiffBaseline;
+  }>({
+    projectId: "",
+    baseline: defaultDiffBaseline,
+  });
   const {
     activeComposerState,
     activeThreadData,
@@ -43,10 +55,27 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
   const terminalSessionPath = state.activeView === "thread" ? state.selectedSessionPath : null;
   const takeoverVisible = state.takeoverVisible;
   const dockedTerminalVisible = state.terminalVisible;
+  const diffBaseline =
+    diffBaselineState.projectId === composerProjectId
+      ? diffBaselineState.baseline
+      : defaultDiffBaseline;
   const { mainSectionRef, takeoverPresent, desktopWorkspacePresent, workspaceContentClass } =
     useAppShellLayoutState({
       takeoverVisible,
     });
+
+  useEffect(() => {
+    setDiffBaselineState((current) => {
+      if (current.projectId === composerProjectId && current.baseline.kind === "head") {
+        return current;
+      }
+
+      return {
+        projectId: composerProjectId,
+        baseline: defaultDiffBaseline,
+      };
+    });
+  }, [composerProjectId]);
 
   return (
     <>
@@ -64,6 +93,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 preferredProjectLocation: null,
                 initializeGitOnProjectCreate: false,
                 useAgentsSkillsPaths: false,
+                piTuiTakeover: false,
               }
             }
             activeView={state.activeView}
@@ -124,10 +154,19 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                   activeComposerState={activeComposerState}
                   activeThreadData={activeThreadData}
                   composerProjectId={composerProjectId}
+                  composerSurface={composerSurface}
                   currentProjectName={currentProjectName}
+                  diffBaseline={diffBaseline}
                   dockedTerminalVisible={dockedTerminalVisible}
                   terminalSessionPath={terminalSessionPath}
                   workspaceContentClass={workspaceContentClass}
+                  onSetComposerSurface={setComposerSurface}
+                  onSetDiffBaseline={(baseline) => {
+                    setDiffBaselineState({
+                      projectId: composerProjectId,
+                      baseline,
+                    });
+                  }}
                 />
               </div>
             ) : null}
@@ -135,9 +174,20 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
             <AppShellOverlays
               controller={controller}
               composerProjectId={composerProjectId}
+              diffBaseline={diffBaseline}
               takeoverPresent={takeoverPresent}
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
+              onOpenGitOps={() => {
+                controller.handleCloseTakeoverTerminal();
+                setComposerSurface("git-ops");
+              }}
+              onSetDiffBaseline={(baseline) => {
+                setDiffBaselineState({
+                  projectId: composerProjectId,
+                  baseline,
+                });
+              }}
             />
           </div>
         </section>

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -179,11 +179,11 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
               onOpenGitOps={() => {
-                controller.handleCloseTakeoverTerminal();
                 setComposerSurface("git-ops");
                 if (!controller.state.diffVisible) {
                   controller.handleToggleDiff();
                 }
+                controller.handleCloseTakeoverTerminal();
               }}
               onSetDiffBaseline={(baseline) => {
                 setDiffBaselineState({

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { ArchivedThreadsPanel } from "../components/settings/ArchivedThreadsPanel";
 import { ProjectActionDialog } from "../components/sidebar/ProjectActionDialog";
 import { Sidebar } from "../components/sidebar/Sidebar";
-import type { ComposerSurface } from "../components/workspace/Composer";
 import { defaultDiffBaseline } from "../components/workspace/composer/diff-baseline";
 import type { ProjectDiffBaseline } from "../desktop/types";
 import { AppShellOverlays } from "./AppShellOverlays";
@@ -15,7 +14,6 @@ type AppShellLayoutProps = {
 };
 
 export function AppShellLayout({ controller }: AppShellLayoutProps) {
-  const [composerSurface, setComposerSurface] = useState<ComposerSurface>("prompt");
   const [diffBaselineState, setDiffBaselineState] = useState<{
     projectId: string;
     baseline: ProjectDiffBaseline;
@@ -154,13 +152,13 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                   activeComposerState={activeComposerState}
                   activeThreadData={activeThreadData}
                   composerProjectId={composerProjectId}
-                  composerSurface={composerSurface}
+                  composerSurface={state.composerSurface}
                   currentProjectName={currentProjectName}
                   diffBaseline={diffBaseline}
                   dockedTerminalVisible={dockedTerminalVisible}
                   terminalSessionPath={terminalSessionPath}
                   workspaceContentClass={workspaceContentClass}
-                  onSetComposerSurface={setComposerSurface}
+                  onSetComposerSurface={controller.handleSetComposerSurface}
                   onSetDiffBaseline={(baseline) => {
                     setDiffBaselineState({
                       projectId: composerProjectId,
@@ -179,7 +177,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
               onOpenGitOps={async () => {
-                setComposerSurface("git-ops");
+                controller.handleSetComposerSurface("git-ops");
                 if (!controller.state.diffVisible) {
                   controller.handleToggleDiff();
                 }

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -181,6 +181,9 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               onOpenGitOps={() => {
                 controller.handleCloseTakeoverTerminal();
                 setComposerSurface("git-ops");
+                if (!controller.state.diffVisible) {
+                  controller.handleToggleDiff();
+                }
               }}
               onSetDiffBaseline={(baseline) => {
                 setDiffBaselineState({

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -180,7 +180,10 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               workspaceContentClass={workspaceContentClass}
               onOpenGitOps={async () => {
                 controller.handleOpenGitOpsView();
-                await controller.handleCloseTakeoverTerminal();
+                await controller.handleCloseTakeoverTerminal({
+                  preserveSessionOverride: true,
+                  refreshThread: false,
+                });
               }}
               onSetDiffBaseline={(baseline) => {
                 setDiffBaselineState({

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -177,7 +177,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
               onOpenGitOps={async () => {
-                controller.handleOpenGitOpsSurface();
+                controller.handleSetComposerSurface("git-ops");
                 await controller.handleCloseTakeoverTerminal();
               }}
               onSetDiffBaseline={(baseline) => {

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -14,7 +14,6 @@ type AppShellLayoutProps = {
 };
 
 export function AppShellLayout({ controller }: AppShellLayoutProps) {
-  const [composerOpenGitOpsRequestKey, setComposerOpenGitOpsRequestKey] = useState(0);
   const [diffBaselineState, setDiffBaselineState] = useState<{
     projectId: string;
     baseline: ProjectDiffBaseline;
@@ -51,7 +50,10 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
     ? Object.fromEntries(projects.map((project) => [project.id, true]))
     : collapsedProjectIds;
 
-  const terminalSessionPath = state.activeView === "thread" ? state.selectedSessionPath : null;
+  const terminalSessionPath =
+    state.activeView === "thread" || state.activeView === "gitops"
+      ? state.selectedSessionPath
+      : null;
   const takeoverVisible = state.takeoverVisible;
   const dockedTerminalVisible = state.terminalVisible;
   const diffBaseline =
@@ -153,7 +155,6 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                   activeComposerState={activeComposerState}
                   activeThreadData={activeThreadData}
                   composerProjectId={composerProjectId}
-                  composerOpenGitOpsRequestKey={composerOpenGitOpsRequestKey}
                   currentProjectName={currentProjectName}
                   diffBaseline={diffBaseline}
                   dockedTerminalVisible={dockedTerminalVisible}
@@ -177,7 +178,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
               onOpenGitOps={async () => {
-                setComposerOpenGitOpsRequestKey((current) => current + 1);
+                controller.handleOpenGitOpsView();
                 await controller.handleCloseTakeoverTerminal();
               }}
               onSetDiffBaseline={(baseline) => {

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -177,6 +177,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverPresent={takeoverPresent}
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
+              workspaceContentClass={workspaceContentClass}
               onOpenGitOps={async () => {
                 controller.handleOpenGitOpsView();
                 await controller.handleCloseTakeoverTerminal();

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -14,6 +14,7 @@ type AppShellLayoutProps = {
 };
 
 export function AppShellLayout({ controller }: AppShellLayoutProps) {
+  const [composerOpenGitOpsRequestKey, setComposerOpenGitOpsRequestKey] = useState(0);
   const [diffBaselineState, setDiffBaselineState] = useState<{
     projectId: string;
     baseline: ProjectDiffBaseline;
@@ -152,13 +153,12 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                   activeComposerState={activeComposerState}
                   activeThreadData={activeThreadData}
                   composerProjectId={composerProjectId}
-                  composerSurface={state.composerSurface}
+                  composerOpenGitOpsRequestKey={composerOpenGitOpsRequestKey}
                   currentProjectName={currentProjectName}
                   diffBaseline={diffBaseline}
                   dockedTerminalVisible={dockedTerminalVisible}
                   terminalSessionPath={terminalSessionPath}
                   workspaceContentClass={workspaceContentClass}
-                  onSetComposerSurface={controller.handleSetComposerSurface}
                   onSetDiffBaseline={(baseline) => {
                     setDiffBaselineState({
                       projectId: composerProjectId,
@@ -177,7 +177,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
               onOpenGitOps={async () => {
-                controller.handleSetComposerSurface("git-ops");
+                setComposerOpenGitOpsRequestKey((current) => current + 1);
                 await controller.handleCloseTakeoverTerminal();
               }}
               onSetDiffBaseline={(baseline) => {

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -177,10 +177,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
               onOpenGitOps={async () => {
-                controller.handleSetComposerSurface("git-ops");
-                if (!controller.state.diffVisible) {
-                  controller.handleToggleDiff();
-                }
+                controller.handleOpenGitOpsSurface();
                 await controller.handleCloseTakeoverTerminal();
               }}
               onSetDiffBaseline={(baseline) => {

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -178,12 +178,12 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               takeoverPresent={takeoverPresent}
               takeoverVisible={takeoverVisible}
               terminalSessionPath={terminalSessionPath}
-              onOpenGitOps={() => {
+              onOpenGitOps={async () => {
                 setComposerSurface("git-ops");
                 if (!controller.state.diffVisible) {
                   controller.handleToggleDiff();
                 }
-                controller.handleCloseTakeoverTerminal();
+                await controller.handleCloseTakeoverTerminal();
               }}
               onSetDiffBaseline={(baseline) => {
                 setDiffBaselineState({

--- a/src/app/app-shell/AppShellOverlays.tsx
+++ b/src/app/app-shell/AppShellOverlays.tsx
@@ -33,7 +33,7 @@ export function AppShellOverlays({
       {takeoverPresent ? (
         <div
           data-open={takeoverVisible ? "true" : "false"}
-          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--workspace)] px-5 pt-1.5 pb-4"
+          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--terminal-bg)] px-5 pb-4"
         >
           <div className={`${workspaceContentClass} h-full min-h-0`}>
             <TerminalPanel

--- a/src/app/app-shell/AppShellOverlays.tsx
+++ b/src/app/app-shell/AppShellOverlays.tsx
@@ -33,7 +33,7 @@ export function AppShellOverlays({
       {takeoverPresent ? (
         <div
           data-open={takeoverVisible ? "true" : "false"}
-          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--workspace)] px-5 pb-4"
+          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--terminal-bg)] px-5 pb-4"
         >
           <div className={`${workspaceContentClass} h-full min-h-0`}>
             <TerminalPanel

--- a/src/app/app-shell/AppShellOverlays.tsx
+++ b/src/app/app-shell/AppShellOverlays.tsx
@@ -33,7 +33,7 @@ export function AppShellOverlays({
       {takeoverPresent ? (
         <div
           data-open={takeoverVisible ? "true" : "false"}
-          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--terminal-bg)] px-5 pb-4"
+          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--workspace)] px-5 pb-4"
         >
           <div className={`${workspaceContentClass} h-full min-h-0`}>
             <TerminalPanel

--- a/src/app/app-shell/AppShellOverlays.tsx
+++ b/src/app/app-shell/AppShellOverlays.tsx
@@ -1,6 +1,5 @@
 import { TerminalPanel } from "../components/workspace/TerminalPanel";
 import type { ProjectDiffBaseline } from "../desktop/types";
-import { WORKSPACE_CONTENT_MAX_WIDTH_CLASS } from "../ui/layout";
 import type { AppShellController } from "./useAppShellController";
 
 type AppShellOverlaysProps = {
@@ -10,6 +9,7 @@ type AppShellOverlaysProps = {
   takeoverPresent: boolean;
   takeoverVisible: boolean;
   terminalSessionPath: string | null;
+  workspaceContentClass: string;
   onOpenGitOps: () => void;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
 };
@@ -21,6 +21,7 @@ export function AppShellOverlays({
   takeoverPresent,
   takeoverVisible,
   terminalSessionPath,
+  workspaceContentClass,
   onOpenGitOps,
   onSetDiffBaseline,
 }: AppShellOverlaysProps) {
@@ -32,11 +33,9 @@ export function AppShellOverlays({
       {takeoverPresent ? (
         <div
           data-open={takeoverVisible ? "true" : "false"}
-          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--workspace)]"
+          className="motion-takeover-panel absolute inset-0 z-10 bg-[color:var(--workspace)] px-5 pt-1.5 pb-4"
         >
-          <div
-            className={`mx-auto min-h-0 h-full w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} overflow-hidden px-5 pt-1.5 pb-4`}
-          >
+          <div className={`${workspaceContentClass} h-full min-h-0`}>
             <TerminalPanel
               projectId={composerProjectId}
               sessionPath={terminalSessionPath}

--- a/src/app/app-shell/AppShellOverlays.tsx
+++ b/src/app/app-shell/AppShellOverlays.tsx
@@ -1,23 +1,31 @@
 import { TerminalPanel } from "../components/workspace/TerminalPanel";
+import type { ProjectDiffBaseline } from "../desktop/types";
 import { WORKSPACE_CONTENT_MAX_WIDTH_CLASS } from "../ui/layout";
 import type { AppShellController } from "./useAppShellController";
 
 type AppShellOverlaysProps = {
   controller: AppShellController;
   composerProjectId: string;
+  diffBaseline: ProjectDiffBaseline;
   takeoverPresent: boolean;
   takeoverVisible: boolean;
   terminalSessionPath: string | null;
+  onOpenGitOps: () => void;
+  onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
 };
 
 export function AppShellOverlays({
   controller,
   composerProjectId,
+  diffBaseline,
   takeoverPresent,
   takeoverVisible,
   terminalSessionPath,
+  onOpenGitOps,
+  onSetDiffBaseline,
 }: AppShellOverlaysProps) {
-  const { handleAction, handleCloseTakeoverTerminal, shellState } = controller;
+  const { handleCloseTakeoverTerminal, handleOpenDockedTerminalFromTakeover, projectGitState } =
+    controller;
 
   return (
     <>
@@ -33,9 +41,12 @@ export function AppShellOverlays({
               projectId={composerProjectId}
               sessionPath={terminalSessionPath}
               onClose={handleCloseTakeoverTerminal}
+              onOpenDockedTerminal={handleOpenDockedTerminalFromTakeover}
+              onOpenGitOps={onOpenGitOps}
               mode="takeover"
-              hostLabel={shellState?.availableHosts[0] ?? "Local"}
-              onAction={handleAction}
+              projectGitState={projectGitState}
+              diffBaseline={diffBaseline}
+              onSetDiffBaseline={onSetDiffBaseline}
             />
           </div>
         </div>

--- a/src/app/app-shell/AppShellWorkspace.tsx
+++ b/src/app/app-shell/AppShellWorkspace.tsx
@@ -1,3 +1,5 @@
+import type { ComposerSurface } from "../components/workspace/Composer";
+import type { ProjectDiffBaseline } from "../desktop/types";
 import { CodeWorkspaceView } from "../features/code/CodeWorkspaceView";
 import { mainPanelClass } from "../ui/classes";
 import { MainView } from "../views/MainView";
@@ -8,10 +10,14 @@ type AppShellWorkspaceProps = {
   activeComposerState: AppShellController["activeComposerState"];
   activeThreadData: AppShellController["activeThreadData"];
   composerProjectId: string;
+  composerSurface: ComposerSurface;
   currentProjectName: string;
+  diffBaseline: ProjectDiffBaseline;
   dockedTerminalVisible: boolean;
   terminalSessionPath: string | null;
   workspaceContentClass: string;
+  onSetComposerSurface: (surface: ComposerSurface) => void;
+  onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
 };
 
 export function AppShellWorkspace({
@@ -19,10 +25,14 @@ export function AppShellWorkspace({
   activeComposerState,
   activeThreadData,
   composerProjectId,
+  composerSurface,
   currentProjectName,
+  diffBaseline,
   dockedTerminalVisible,
   terminalSessionPath,
   workspaceContentClass,
+  onSetComposerSurface,
+  onSetDiffBaseline,
 }: AppShellWorkspaceProps) {
   const { state } = controller;
 
@@ -42,10 +52,14 @@ export function AppShellWorkspace({
       activeComposerState={activeComposerState}
       activeThreadData={activeThreadData}
       composerProjectId={composerProjectId}
+      composerSurface={composerSurface}
       currentProjectName={currentProjectName}
+      diffBaseline={diffBaseline}
       dockedTerminalVisible={dockedTerminalVisible}
       terminalSessionPath={terminalSessionPath}
       workspaceContentClass={workspaceContentClass}
+      onSetComposerSurface={onSetComposerSurface}
+      onSetDiffBaseline={onSetDiffBaseline}
     />
   );
 }

--- a/src/app/app-shell/AppShellWorkspace.tsx
+++ b/src/app/app-shell/AppShellWorkspace.tsx
@@ -9,7 +9,6 @@ type AppShellWorkspaceProps = {
   activeComposerState: AppShellController["activeComposerState"];
   activeThreadData: AppShellController["activeThreadData"];
   composerProjectId: string;
-  composerOpenGitOpsRequestKey: number;
   currentProjectName: string;
   diffBaseline: ProjectDiffBaseline;
   dockedTerminalVisible: boolean;
@@ -23,7 +22,6 @@ export function AppShellWorkspace({
   activeComposerState,
   activeThreadData,
   composerProjectId,
-  composerOpenGitOpsRequestKey,
   currentProjectName,
   diffBaseline,
   dockedTerminalVisible,
@@ -49,7 +47,6 @@ export function AppShellWorkspace({
       activeComposerState={activeComposerState}
       activeThreadData={activeThreadData}
       composerProjectId={composerProjectId}
-      composerOpenGitOpsRequestKey={composerOpenGitOpsRequestKey}
       currentProjectName={currentProjectName}
       diffBaseline={diffBaseline}
       dockedTerminalVisible={dockedTerminalVisible}

--- a/src/app/app-shell/AppShellWorkspace.tsx
+++ b/src/app/app-shell/AppShellWorkspace.tsx
@@ -1,4 +1,3 @@
-import type { ComposerSurface } from "../components/workspace/Composer";
 import type { ProjectDiffBaseline } from "../desktop/types";
 import { CodeWorkspaceView } from "../features/code/CodeWorkspaceView";
 import { mainPanelClass } from "../ui/classes";
@@ -10,13 +9,12 @@ type AppShellWorkspaceProps = {
   activeComposerState: AppShellController["activeComposerState"];
   activeThreadData: AppShellController["activeThreadData"];
   composerProjectId: string;
-  composerSurface: ComposerSurface;
+  composerOpenGitOpsRequestKey: number;
   currentProjectName: string;
   diffBaseline: ProjectDiffBaseline;
   dockedTerminalVisible: boolean;
   terminalSessionPath: string | null;
   workspaceContentClass: string;
-  onSetComposerSurface: (surface: ComposerSurface) => void;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
 };
 
@@ -25,13 +23,12 @@ export function AppShellWorkspace({
   activeComposerState,
   activeThreadData,
   composerProjectId,
-  composerSurface,
+  composerOpenGitOpsRequestKey,
   currentProjectName,
   diffBaseline,
   dockedTerminalVisible,
   terminalSessionPath,
   workspaceContentClass,
-  onSetComposerSurface,
   onSetDiffBaseline,
 }: AppShellWorkspaceProps) {
   const { state } = controller;
@@ -52,13 +49,12 @@ export function AppShellWorkspace({
       activeComposerState={activeComposerState}
       activeThreadData={activeThreadData}
       composerProjectId={composerProjectId}
-      composerSurface={composerSurface}
+      composerOpenGitOpsRequestKey={composerOpenGitOpsRequestKey}
       currentProjectName={currentProjectName}
       diffBaseline={diffBaseline}
       dockedTerminalVisible={dockedTerminalVisible}
       terminalSessionPath={terminalSessionPath}
       workspaceContentClass={workspaceContentClass}
-      onSetComposerSurface={onSetComposerSurface}
       onSetDiffBaseline={onSetDiffBaseline}
     />
   );

--- a/src/app/app-shell/controller-action-helpers.ts
+++ b/src/app/app-shell/controller-action-helpers.ts
@@ -24,7 +24,8 @@ export function buildContextualActionPayload({
     action === "workspace.commit-options"
     ? {
         projectId: composerProjectId,
-        sessionPath: activeView === "thread" ? selectedSessionPath : null,
+        sessionPath:
+          activeView === "thread" || activeView === "gitops" ? selectedSessionPath : null,
         ...payload,
       }
     : payload;

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -80,7 +80,8 @@ export function getOptimisticallyUpdatedShellState(
     payload.key !== "projectImportState" &&
     payload.key !== "preferredProjectLocation" &&
     payload.key !== "initializeGitOnProjectCreate" &&
-    payload.key !== "useAgentsSkillsPaths"
+    payload.key !== "useAgentsSkillsPaths" &&
+    payload.key !== "piTuiTakeover"
   ) {
     return currentState;
   }
@@ -138,6 +139,11 @@ export function getOptimisticallyUpdatedShellState(
       ? payload.value
       : currentState.appSettings.useAgentsSkillsPaths;
 
+  const nextPiTuiTakeover =
+    payload.key === "piTuiTakeover" && typeof payload.value === "boolean"
+      ? payload.value
+      : currentState.appSettings.piTuiTakeover;
+
   return {
     ...currentState,
     appSettings: {
@@ -149,6 +155,7 @@ export function getOptimisticallyUpdatedShellState(
       preferredProjectLocation: nextPreferredProjectLocation,
       initializeGitOnProjectCreate: nextInitializeGitOnProjectCreate,
       useAgentsSkillsPaths: nextUseAgentsSkillsPaths,
+      piTuiTakeover: nextPiTuiTakeover,
     },
   } satisfies ShellState;
 }

--- a/src/app/app-shell/controller-view-model.ts
+++ b/src/app/app-shell/controller-view-model.ts
@@ -1,5 +1,5 @@
 import type { ThreadData } from "../desktop/types";
-import { getProjectName, selectProject, selectThread } from "../state/workspace";
+import { getCurrentTitle, getProjectName, selectProject, selectThread } from "../state/workspace";
 import type { WorkspaceState } from "../state/workspace";
 import type { Project, Thread } from "../types";
 
@@ -65,7 +65,7 @@ export function deriveControllerViewModel({
     currentTitle:
       workspaceState.activeView === "thread"
         ? (activeThreadData?.title ?? selectedThread?.title ?? "New thread")
-        : "New thread",
+        : getCurrentTitle(workspaceState.activeView, selectedThread),
     currentProjectName: getProjectName(selectedProject),
     composerProjectId: selectedProject?.id ?? shellCwd ?? "",
     activeComposerState: composerState ?? shellComposerState ?? null,

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -323,6 +323,22 @@ export function useAppShellController() {
     scheduleShellStateRefresh();
   };
 
+  const handleOpenGitOpsSurface = () => {
+    dispatch({ type: "set-composer-surface", surface: "git-ops" });
+
+    if (!state.diffVisible) {
+      if (composerProjectId) {
+        resetProjectDiffCaches(composerProjectId);
+      }
+
+      dispatch({
+        type: "open-diff",
+        checkpointTurnCount: null,
+        filePath: null,
+      });
+    }
+  };
+
   const persistPiTuiTakeover = (visible: boolean) =>
     handleAction("settings.update", {
       key: "piTuiTakeover",
@@ -361,6 +377,7 @@ export function useAppShellController() {
     handleCloseArchivedThreads: () => dispatch({ type: "set-archived-threads-open", open: false }),
     handleCollapseAll,
     handleOpenArchivedThreads: () => dispatch({ type: "set-archived-threads-open", open: true }),
+    handleOpenGitOpsSurface,
     handleOpenSettingsPanel: () => dispatch({ type: "set-settings-panel-open", open: true }),
     handleConfirmProjectAction,
     handleCloseProjectActionDialog: () => setPendingProjectAction(null),

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useReducer, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import type {
   ArchivedThread,
   ComposerState,
@@ -14,6 +14,7 @@ import { useDesktopThread } from "../hooks/useDesktopThread";
 import { desktopQueryKeys } from "../query/desktop-query";
 import { createInitialWorkspaceState, workspaceReducer } from "../state/workspace";
 import type { View } from "../types";
+import { applyOptimisticSettingsUpdate } from "./controller-post-action-effects";
 import { deriveControllerViewModel } from "./controller-view-model";
 import { getProjectSelectionAction } from "./scoped-project-view";
 import { useAppShellEffects } from "./useAppShellEffects";
@@ -308,21 +309,39 @@ export function useAppShellController() {
     scheduleShellStateRefresh();
   };
 
-  const persistPiTuiTakeover = (visible: boolean) =>
-    handleAction("settings.update", {
+  const takeoverPreferenceWriteQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+  const persistPiTuiTakeover = (visible: boolean) => {
+    const payload = {
       key: "piTuiTakeover",
       value: visible,
-    });
+    } as const;
+
+    applyOptimisticSettingsUpdate(queryClient, payload);
+
+    const nextWrite = takeoverPreferenceWriteQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await runDesktopAction("settings.update", payload);
+        } catch (error) {
+          console.warn("Failed to persist Pi TUI takeover preference.", error);
+        }
+      });
+
+    takeoverPreferenceWriteQueueRef.current = nextWrite;
+    return nextWrite;
+  };
 
   const handleShowTakeoverTerminal = () => {
     dispatch({ type: "set-takeover-visible", visible: true });
     void persistPiTuiTakeover(true);
   };
 
-  const closeTakeover = async () => {
-    await persistPiTuiTakeover(false);
+  const closeTakeover = () => {
     dispatch({ type: "set-takeover-visible", visible: false });
     setThreadRefreshKey((current) => current + 1);
+    return persistPiTuiTakeover(false);
   };
 
   const handleOpenDockedTerminalFromTakeover = () => {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -229,7 +229,7 @@ export function useAppShellController() {
     inboxQuery.isSuccess,
   ]);
 
-  const handleShowView = (view: View) => {
+  const handleShowView = (view: Exclude<View, "gitops">) => {
     dispatch({ type: "show-view", view });
   };
 
@@ -272,49 +272,34 @@ export function useAppShellController() {
     setThreadHistoryCompactions((current) => current + 1);
   };
 
-  const handleOpenDiffSelection = (checkpointTurnCount: number, filePath?: string) => {
+  const handleOpenGitOpsView = (
+    options: { checkpointTurnCount?: number | null; filePath?: string | null } = {},
+  ) => {
     if (composerProjectId) {
       resetProjectDiffCaches(composerProjectId);
     }
 
     dispatch({
-      type: "open-diff",
-      checkpointTurnCount,
-      filePath: filePath ?? null,
+      type: "open-gitops",
+      checkpointTurnCount: options.checkpointTurnCount ?? null,
+      filePath: options.filePath ?? null,
     });
   };
 
-  const handleOpenWorktreeDiffFile = (filePath: string) => {
-    if (composerProjectId) {
-      resetProjectDiffCaches(composerProjectId);
-    }
+  const handleCloseGitOpsView = () => {
+    dispatch({ type: "close-gitops" });
+  };
 
-    dispatch({
-      type: "open-diff",
-      checkpointTurnCount: null,
-      filePath,
-    });
+  const handleOpenDiffSelection = (checkpointTurnCount: number, filePath?: string) => {
+    handleOpenGitOpsView({ checkpointTurnCount, filePath: filePath ?? null });
+  };
+
+  const handleOpenWorktreeDiffFile = (filePath: string) => {
+    handleOpenGitOpsView({ checkpointTurnCount: null, filePath });
   };
 
   const handleSelectDiffTurn = (checkpointTurnCount: number | null) => {
     dispatch({ type: "set-diff-turn", checkpointTurnCount });
-  };
-
-  const handleToggleDiffPanel = () => {
-    if (!state.diffVisible) {
-      if (composerProjectId) {
-        resetProjectDiffCaches(composerProjectId);
-      }
-
-      dispatch({
-        type: "open-diff",
-        checkpointTurnCount: null,
-        filePath: null,
-      });
-      return;
-    }
-
-    dispatch({ type: "toggle-diff" });
   };
 
   const handleProjectReorder = async (projectIds: string[]) => {
@@ -362,6 +347,7 @@ export function useAppShellController() {
     handleCloseProjectActionDialog: () => setPendingProjectAction(null),
     handleCloseSettingsPanel: () => dispatch({ type: "set-settings-panel-open", open: false }),
     handleCloseTakeoverTerminal: closeTakeover,
+    handleCloseGitOpsView,
     handleOpenDiffSelection,
     handleOpenWorktreeDiffFile,
     handleLoadEarlierMessages,
@@ -380,7 +366,7 @@ export function useAppShellController() {
     handleThreadOpen,
     handleShowTakeoverTerminal,
     handleOpenDockedTerminalFromTakeover,
-    handleToggleDiff: handleToggleDiffPanel,
+    handleOpenGitOpsView,
     handleToggleProjectCollapse,
     handleToggleSettings: () => dispatch({ type: "toggle-settings" }),
     handleToggleTerminal: () => dispatch({ type: "toggle-terminal" }),

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -14,7 +14,6 @@ import { useDesktopThread } from "../hooks/useDesktopThread";
 import { desktopQueryKeys } from "../query/desktop-query";
 import { createInitialWorkspaceState, workspaceReducer } from "../state/workspace";
 import type { View } from "../types";
-import { applyOptimisticSettingsUpdate } from "./controller-post-action-effects";
 import { deriveControllerViewModel } from "./controller-view-model";
 import { getProjectSelectionAction } from "./scoped-project-view";
 import { useAppShellEffects } from "./useAppShellEffects";
@@ -309,39 +308,29 @@ export function useAppShellController() {
     scheduleShellStateRefresh();
   };
 
-  const takeoverPreferenceWriteQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const setTakeoverOverrideForSelectedSession = (visible: boolean) => {
+    const sessionPath = state.selectedSessionPath;
+    if (!sessionPath) {
+      return;
+    }
 
-  const persistPiTuiTakeover = (visible: boolean) => {
-    const payload = {
-      key: "piTuiTakeover",
-      value: visible,
-    } as const;
-
-    applyOptimisticSettingsUpdate(queryClient, payload);
-
-    const nextWrite = takeoverPreferenceWriteQueueRef.current
-      .catch(() => undefined)
-      .then(async () => {
-        try {
-          await runDesktopAction("settings.update", payload);
-        } catch (error) {
-          console.warn("Failed to persist Pi TUI takeover preference.", error);
-        }
-      });
-
-    takeoverPreferenceWriteQueueRef.current = nextWrite;
-    return nextWrite;
+    const globalTakeoverVisible = shellState?.appSettings.piTuiTakeover ?? false;
+    dispatch({
+      type: "set-session-takeover-override",
+      sessionPath,
+      visible: visible === globalTakeoverVisible ? null : visible,
+    });
   };
 
   const handleShowTakeoverTerminal = () => {
     dispatch({ type: "set-takeover-visible", visible: true });
-    void persistPiTuiTakeover(true);
+    setTakeoverOverrideForSelectedSession(true);
   };
 
   const closeTakeover = () => {
     dispatch({ type: "set-takeover-visible", visible: false });
+    setTakeoverOverrideForSelectedSession(false);
     setThreadRefreshKey((current) => current + 1);
-    return persistPiTuiTakeover(false);
   };
 
   const handleOpenDockedTerminalFromTakeover = () => {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -323,22 +323,6 @@ export function useAppShellController() {
     scheduleShellStateRefresh();
   };
 
-  const handleOpenGitOpsSurface = () => {
-    dispatch({ type: "set-composer-surface", surface: "git-ops" });
-
-    if (!state.diffVisible) {
-      if (composerProjectId) {
-        resetProjectDiffCaches(composerProjectId);
-      }
-
-      dispatch({
-        type: "open-diff",
-        checkpointTurnCount: null,
-        filePath: null,
-      });
-    }
-  };
-
   const persistPiTuiTakeover = (visible: boolean) =>
     handleAction("settings.update", {
       key: "piTuiTakeover",
@@ -377,7 +361,6 @@ export function useAppShellController() {
     handleCloseArchivedThreads: () => dispatch({ type: "set-archived-threads-open", open: false }),
     handleCollapseAll,
     handleOpenArchivedThreads: () => dispatch({ type: "set-archived-threads-open", open: true }),
-    handleOpenGitOpsSurface,
     handleOpenSettingsPanel: () => dispatch({ type: "set-settings-panel-open", open: true }),
     handleConfirmProjectAction,
     handleCloseProjectActionDialog: () => setPendingProjectAction(null),

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -334,10 +334,6 @@ export function useAppShellController() {
     void persistPiTuiTakeover(true);
   };
 
-  const handleSetComposerSurface = (surface: "prompt" | "git-ops") => {
-    dispatch({ type: "set-composer-surface", surface });
-  };
-
   const closeTakeover = async () => {
     await persistPiTuiTakeover(false);
     dispatch({ type: "set-takeover-visible", visible: false });
@@ -383,7 +379,6 @@ export function useAppShellController() {
     handleSelectInboxThread,
     handleThreadOpen,
     handleShowTakeoverTerminal,
-    handleSetComposerSurface,
     handleOpenDockedTerminalFromTakeover,
     handleToggleDiff: handleToggleDiffPanel,
     handleToggleProjectCollapse,

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -93,6 +93,7 @@ export function useAppShellController() {
     workspaceState: state,
     composerProjectId,
     shellComposerState: shellState?.composer,
+    shellAppSettings: shellState?.appSettings,
     loadProjectThreads,
     loadArchivedThreads,
     loadComposerState,
@@ -322,6 +323,30 @@ export function useAppShellController() {
     scheduleShellStateRefresh();
   };
 
+  const persistPiTuiTakeover = (visible: boolean) =>
+    handleAction("settings.update", {
+      key: "piTuiTakeover",
+      value: visible,
+    });
+
+  const handleShowTakeoverTerminal = () => {
+    dispatch({ type: "set-takeover-visible", visible: true });
+    void persistPiTuiTakeover(true);
+  };
+
+  const closeTakeover = () => {
+    dispatch({ type: "set-takeover-visible", visible: false });
+    setThreadRefreshKey((current) => current + 1);
+    void persistPiTuiTakeover(false).then(() => {
+      void refreshShellState();
+    });
+  };
+
+  const handleOpenDockedTerminalFromTakeover = () => {
+    dispatch({ type: "set-terminal-visible", visible: true });
+    closeTakeover();
+  };
+
   return {
     activeComposerState,
     activeThreadData,
@@ -338,11 +363,7 @@ export function useAppShellController() {
     handleConfirmProjectAction,
     handleCloseProjectActionDialog: () => setPendingProjectAction(null),
     handleCloseSettingsPanel: () => dispatch({ type: "set-settings-panel-open", open: false }),
-    handleCloseTakeoverTerminal: () => {
-      dispatch({ type: "hide-takeover" });
-      setThreadRefreshKey((current) => current + 1);
-      void refreshShellState();
-    },
+    handleCloseTakeoverTerminal: closeTakeover,
     handleOpenDiffSelection,
     handleOpenWorktreeDiffFile,
     handleLoadEarlierMessages,
@@ -359,7 +380,8 @@ export function useAppShellController() {
     handleShowView,
     handleSelectInboxThread,
     handleThreadOpen,
-    handleShowTakeoverTerminal: () => dispatch({ type: "show-takeover" }),
+    handleShowTakeoverTerminal,
+    handleOpenDockedTerminalFromTakeover,
     handleToggleDiff: handleToggleDiffPanel,
     handleToggleProjectCollapse,
     handleToggleSettings: () => dispatch({ type: "toggle-settings" }),

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -310,11 +310,12 @@ export function useAppShellController() {
 
   const setTakeoverOverrideForSelectedSession = (visible: boolean) => {
     const sessionPath = state.selectedSessionPath;
-    if (!sessionPath) {
+    const globalTakeoverVisible = shellState?.appSettings?.piTuiTakeover;
+
+    if (!sessionPath || typeof globalTakeoverVisible !== "boolean") {
       return;
     }
 
-    const globalTakeoverVisible = shellState?.appSettings.piTuiTakeover ?? false;
     dispatch({
       type: "set-session-takeover-override",
       sessionPath,
@@ -327,10 +328,22 @@ export function useAppShellController() {
     setTakeoverOverrideForSelectedSession(true);
   };
 
-  const closeTakeover = () => {
+  const closeTakeover = ({
+    preserveSessionOverride = false,
+    refreshThread = true,
+  }: {
+    preserveSessionOverride?: boolean;
+    refreshThread?: boolean;
+  } = {}) => {
     dispatch({ type: "set-takeover-visible", visible: false });
-    setTakeoverOverrideForSelectedSession(false);
-    setThreadRefreshKey((current) => current + 1);
+
+    if (!preserveSessionOverride) {
+      setTakeoverOverrideForSelectedSession(false);
+    }
+
+    if (refreshThread) {
+      setThreadRefreshKey((current) => current + 1);
+    }
   };
 
   const handleOpenDockedTerminalFromTakeover = () => {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -334,17 +334,15 @@ export function useAppShellController() {
     void persistPiTuiTakeover(true);
   };
 
-  const closeTakeover = () => {
+  const closeTakeover = async () => {
+    await persistPiTuiTakeover(false);
     dispatch({ type: "set-takeover-visible", visible: false });
     setThreadRefreshKey((current) => current + 1);
-    void persistPiTuiTakeover(false).then(() => {
-      void refreshShellState();
-    });
   };
 
   const handleOpenDockedTerminalFromTakeover = () => {
     dispatch({ type: "set-terminal-visible", visible: true });
-    closeTakeover();
+    void closeTakeover();
   };
 
   return {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -334,6 +334,10 @@ export function useAppShellController() {
     void persistPiTuiTakeover(true);
   };
 
+  const handleSetComposerSurface = (surface: "prompt" | "git-ops") => {
+    dispatch({ type: "set-composer-surface", surface });
+  };
+
   const closeTakeover = async () => {
     await persistPiTuiTakeover(false);
     dispatch({ type: "set-takeover-visible", visible: false });
@@ -379,6 +383,7 @@ export function useAppShellController() {
     handleSelectInboxThread,
     handleThreadOpen,
     handleShowTakeoverTerminal,
+    handleSetComposerSurface,
     handleOpenDockedTerminalFromTakeover,
     handleToggleDiff: handleToggleDiffPanel,
     handleToggleProjectCollapse,

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -115,11 +115,13 @@ export function useAppShellEffects({
       return;
     }
 
-    if (lastAppliedThreadPreferenceKeyRef.current === visibleThreadKey) {
+    const visibleThreadPreferenceKey = `${visibleThreadKey}:${shellAppSettings?.piTuiTakeover ?? false}`;
+
+    if (lastAppliedThreadPreferenceKeyRef.current === visibleThreadPreferenceKey) {
       return;
     }
 
-    lastAppliedThreadPreferenceKeyRef.current = visibleThreadKey;
+    lastAppliedThreadPreferenceKeyRef.current = visibleThreadPreferenceKey;
     dispatch({
       type: "set-takeover-visible",
       visible: shellAppSettings?.piTuiTakeover ?? false,

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -142,7 +142,9 @@ export function useAppShellEffects({
       const nextComposerState = await loadComposerState({
         projectId: composerProjectId,
         sessionPath:
-          workspaceState.activeView === "thread" ? workspaceState.selectedSessionPath : null,
+          workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
+            ? workspaceState.selectedSessionPath
+            : null,
       });
 
       if (!cancelled && nextComposerState) {
@@ -188,7 +190,7 @@ export function useAppShellEffects({
   }, [composerProjectId, loadProjectGitState, setProjectGitState]);
 
   useEffect(() => {
-    if (!workspaceState.diffVisible || !composerProjectId) {
+    if (workspaceState.activeView !== "gitops" || !composerProjectId) {
       return;
     }
 
@@ -207,7 +209,7 @@ export function useAppShellEffects({
     return () => {
       cancelled = true;
     };
-  }, [composerProjectId, loadProjectGitState, setProjectGitState, workspaceState.diffVisible]);
+  }, [composerProjectId, loadProjectGitState, setProjectGitState, workspaceState.activeView]);
 
   useEffect(() => {
     if (!window.piDesktop?.watchSession) {
@@ -215,7 +217,7 @@ export function useAppShellEffects({
     }
 
     const watchedSessionPath =
-      workspaceState.activeView === "thread"
+      workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
         ? getPersistedSessionPath(workspaceState.selectedSessionPath)
         : null;
 
@@ -230,7 +232,7 @@ export function useAppShellEffects({
     }
 
     const visibleSessionPath =
-      workspaceState.activeView === "thread"
+      workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
         ? getPersistedSessionPath(workspaceState.selectedSessionPath)
         : workspaceState.activeView === "inbox"
           ? (workspaceState.selectedInboxSessionPath ?? null)
@@ -241,7 +243,8 @@ export function useAppShellEffects({
         const shouldApplyComposerUpdate = event.sessionPath
           ? event.sessionPath === visibleSessionPath
           : event.projectId === composerProjectId &&
-            (workspaceState.activeView !== "thread" || visibleSessionPath === null);
+            ((workspaceState.activeView !== "thread" && workspaceState.activeView !== "gitops") ||
+              visibleSessionPath === null);
 
         if (shouldApplyComposerUpdate) {
           setComposerState(event.composer);
@@ -300,7 +303,7 @@ export function useAppShellEffects({
       }
 
       if (event.reason === "end" || event.reason === "external") {
-        if (workspaceState.diffVisible) {
+        if (workspaceState.activeView === "gitops") {
           void queryClient.invalidateQueries({
             queryKey: desktopQueryKeys.projectDiffPrefix(event.projectId),
           });
@@ -333,7 +336,6 @@ export function useAppShellEffects({
     setComposerState,
     setProjectGitState,
     workspaceState.activeView,
-    workspaceState.diffVisible,
     workspaceState.selectedInboxSessionPath,
     workspaceState.selectedSessionPath,
   ]);

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { getPersistedSessionPath } from "../../../shared/session-paths";
 import type {
+  AppSettings,
   ArchivedThread,
   ComposerState,
   DesktopEvent,
@@ -22,6 +23,7 @@ export function useAppShellEffects({
   workspaceState,
   composerProjectId,
   shellComposerState,
+  shellAppSettings,
   loadProjectThreads,
   loadArchivedThreads,
   loadComposerState,
@@ -38,6 +40,7 @@ export function useAppShellEffects({
   workspaceState: WorkspaceState;
   composerProjectId: string;
   shellComposerState: ComposerState | null | undefined;
+  shellAppSettings: AppSettings | null | undefined;
   loadProjectThreads: (projectId: string) => Promise<unknown>;
   loadArchivedThreads: () => Promise<ArchivedThread[]>;
   loadComposerState: (request?: {
@@ -98,6 +101,22 @@ export function useAppShellEffects({
 
     setComposerState((current) => current ?? shellComposerState);
   }, [setComposerState, shellComposerState]);
+
+  useEffect(() => {
+    const shouldShowTakeover =
+      workspaceState.activeView === "thread" && (shellAppSettings?.piTuiTakeover ?? false);
+
+    if (workspaceState.takeoverVisible === shouldShowTakeover) {
+      return;
+    }
+
+    dispatch({ type: "set-takeover-visible", visible: shouldShowTakeover });
+  }, [
+    dispatch,
+    shellAppSettings?.piTuiTakeover,
+    workspaceState.activeView,
+    workspaceState.takeoverVisible,
+  ]);
 
   useEffect(() => {
     if (!composerProjectId) {

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { getPersistedSessionPath } from "../../../shared/session-paths";
 import type {
@@ -102,20 +102,33 @@ export function useAppShellEffects({
     setComposerState((current) => current ?? shellComposerState);
   }, [setComposerState, shellComposerState]);
 
-  useEffect(() => {
-    const shouldShowTakeover =
-      workspaceState.activeView === "thread" && (shellAppSettings?.piTuiTakeover ?? false);
+  const lastAppliedThreadPreferenceKeyRef = useRef<string | null>(null);
 
-    if (workspaceState.takeoverVisible === shouldShowTakeover) {
+  useEffect(() => {
+    const visibleThreadKey =
+      workspaceState.activeView === "thread" && workspaceState.selectedSessionPath
+        ? workspaceState.selectedSessionPath
+        : null;
+
+    if (!visibleThreadKey) {
+      lastAppliedThreadPreferenceKeyRef.current = null;
       return;
     }
 
-    dispatch({ type: "set-takeover-visible", visible: shouldShowTakeover });
+    if (lastAppliedThreadPreferenceKeyRef.current === visibleThreadKey) {
+      return;
+    }
+
+    lastAppliedThreadPreferenceKeyRef.current = visibleThreadKey;
+    dispatch({
+      type: "set-takeover-visible",
+      visible: shellAppSettings?.piTuiTakeover ?? false,
+    });
   }, [
     dispatch,
     shellAppSettings?.piTuiTakeover,
     workspaceState.activeView,
-    workspaceState.takeoverVisible,
+    workspaceState.selectedSessionPath,
   ]);
 
   useEffect(() => {

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -115,7 +115,10 @@ export function useAppShellEffects({
       return;
     }
 
-    const visibleThreadPreferenceKey = `${visibleThreadKey}:${shellAppSettings?.piTuiTakeover ?? false}`;
+    const globalTakeoverVisible = shellAppSettings?.piTuiTakeover ?? false;
+    const sessionOverrideVisible = workspaceState.takeoverOverrides[visibleThreadKey];
+    const effectiveTakeoverVisible = sessionOverrideVisible ?? globalTakeoverVisible;
+    const visibleThreadPreferenceKey = `${visibleThreadKey}:${effectiveTakeoverVisible}`;
 
     if (lastAppliedThreadPreferenceKeyRef.current === visibleThreadPreferenceKey) {
       return;
@@ -124,12 +127,13 @@ export function useAppShellEffects({
     lastAppliedThreadPreferenceKeyRef.current = visibleThreadPreferenceKey;
     dispatch({
       type: "set-takeover-visible",
-      visible: shellAppSettings?.piTuiTakeover ?? false,
+      visible: effectiveTakeoverVisible,
     });
   }, [
     dispatch,
     shellAppSettings?.piTuiTakeover,
     workspaceState.activeView,
+    workspaceState.takeoverOverrides,
     workspaceState.selectedSessionPath,
   ]);
 

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { getPersistedSessionPath } from "../../../shared/session-paths";
 import type {
@@ -104,7 +104,7 @@ export function useAppShellEffects({
 
   const lastAppliedThreadPreferenceKeyRef = useRef<string | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const visibleThreadKey =
       workspaceState.activeView === "thread" && workspaceState.selectedSessionPath
         ? workspaceState.selectedSessionPath

--- a/src/app/components/sidebar/ProjectTree.tsx
+++ b/src/app/components/sidebar/ProjectTree.tsx
@@ -304,7 +304,8 @@ export function ProjectTree({
                         {hasThreads ? (
                           project.threads.map((thread) => {
                             const isSelected =
-                              selectedThreadId === thread.id && activeView === "thread";
+                              selectedThreadId === thread.id &&
+                              (activeView === "thread" || activeView === "gitops");
 
                             return (
                               <ThreadRow

--- a/src/app/components/sidebar/Sidebar.tsx
+++ b/src/app/components/sidebar/Sidebar.tsx
@@ -4,6 +4,8 @@ import type { AppSettings, DesktopActionInvoker, InboxThread } from "../../deskt
 import { useAnimatedPresence } from "../../hooks/useAnimatedPresence";
 import { useDismissibleLayer } from "../../hooks/useDismissibleLayer";
 import type { Project, View } from "../../types";
+
+type SidebarNavigableView = Exclude<View, "gitops">;
 import { cn } from "../../utils/cn";
 import { FeatureStatusBadge } from "../common/FeatureStatusBadge";
 import { NavButton } from "../common/NavButton";
@@ -23,7 +25,7 @@ type SidebarProps = {
   projectScopeLockActive: boolean;
   collapsedProjectIds: Record<string, boolean>;
   onAction: DesktopActionInvoker;
-  onShowView: (view: View) => void;
+  onShowView: (view: SidebarNavigableView) => void;
   onToggleSettings: () => void;
   onOpenExtensionsView: () => void;
   onOpenSkillsView: () => void;
@@ -78,6 +80,7 @@ export function Sidebar({
     activeView === "inbox" ||
     activeView === "code" ||
     activeView === "thread" ||
+    activeView === "gitops" ||
     activeView === "settings" ||
     activeView === "extensions" ||
     activeView === "skills";

--- a/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
+++ b/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
@@ -47,6 +47,7 @@ export function SidebarProjectsSection({
   const showProjects =
     activeView === "code" ||
     activeView === "thread" ||
+    activeView === "gitops" ||
     activeView === "settings" ||
     activeView === "extensions" ||
     activeView === "skills";

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import type {
   ComposerAttachment,
   ComposerFilePickerState,
@@ -10,7 +10,6 @@ import type {
 } from "../../desktop/types";
 import type { View } from "../../types";
 import { SurfacePanel } from "../common/SurfacePanel";
-import { ComposerGitOpsSurface } from "./composer/ComposerGitOpsSurface";
 import { ComposerPromptSurface } from "./composer/ComposerPromptSurface";
 import type { SavedDiffComment } from "./diff/diffCommentStore";
 
@@ -26,8 +25,6 @@ export type ComposerProps = {
   diffBaseline: ProjectDiffBaseline;
   sessionPath: string | null;
   favoriteFolders: string[];
-  openGitOpsRequestKey: number;
-  onSetDiffPanelVisible: (visible: boolean) => void;
   diffRenderMode: "stacked" | "split";
   diffComments: SavedDiffComment[];
   diffCommentCount: number;
@@ -39,6 +36,7 @@ export type ComposerProps = {
   onSelectDiffComment: (filePath: string, commentId: string) => void;
   promptResetKey: number;
   onOpenTakeoverTerminal: () => void;
+  onOpenGitOpsView: () => void;
   onToggleTerminal: () => void;
   terminalVisible: boolean;
   onLayoutChange: () => void;
@@ -52,33 +50,7 @@ export type ComposerProps = {
 };
 
 export function Composer(props: ComposerProps) {
-  const [surface, setSurface] = useState<"prompt" | "git-ops">("prompt");
   const composerPanelRef = useRef<HTMLDivElement>(null);
-  const lastAppliedOpenGitOpsRequestKeyRef = useRef(0);
-
-  useEffect(() => {
-    if (props.promptResetKey < 0) {
-      return;
-    }
-
-    setSurface("prompt");
-  }, [props.promptResetKey]);
-
-  useEffect(() => {
-    if (
-      props.openGitOpsRequestKey <= 0 ||
-      props.openGitOpsRequestKey === lastAppliedOpenGitOpsRequestKeyRef.current
-    ) {
-      return;
-    }
-
-    lastAppliedOpenGitOpsRequestKeyRef.current = props.openGitOpsRequestKey;
-    setSurface("git-ops");
-  }, [props.openGitOpsRequestKey]);
-
-  useEffect(() => {
-    props.onSetDiffPanelVisible(surface === "git-ops");
-  }, [props.onSetDiffPanelVisible, surface]);
 
   return (
     <SurfacePanel
@@ -86,31 +58,11 @@ export function Composer(props: ComposerProps) {
       className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
       aria-label="Composer panel"
     >
-      {surface === "git-ops" ? (
-        <ComposerGitOpsSurface
-          composerPanelRef={composerPanelRef}
-          projectGitState={props.projectGitState}
-          diffBaseline={props.diffBaseline}
-          diffRenderMode={props.diffRenderMode}
-          diffComments={props.diffComments}
-          diffCommentCount={props.diffCommentCount}
-          diffCommentsSending={props.diffCommentsSending}
-          diffCommentError={props.diffCommentError}
-          onSetDiffBaseline={props.onSetDiffBaseline}
-          onSetDiffRenderMode={props.onSetDiffRenderMode}
-          onSendDiffComments={props.onSendDiffComments}
-          onSelectDiffComment={props.onSelectDiffComment}
-          onAction={props.onAction}
-          onLayoutChange={props.onLayoutChange}
-          onBack={() => setSurface("prompt")}
-        />
-      ) : (
-        <ComposerPromptSurface
-          {...props}
-          composerPanelRef={composerPanelRef}
-          onOpenGitOps={() => setSurface("git-ops")}
-        />
-      )}
+      <ComposerPromptSurface
+        {...props}
+        composerPanelRef={composerPanelRef}
+        onOpenGitOps={props.onOpenGitOpsView}
+      />
     </SurfacePanel>
   );
 }

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   ComposerAttachment,
   ComposerFilePickerState,
@@ -14,8 +14,6 @@ import { ComposerGitOpsSurface } from "./composer/ComposerGitOpsSurface";
 import { ComposerPromptSurface } from "./composer/ComposerPromptSurface";
 import type { SavedDiffComment } from "./diff/diffCommentStore";
 
-export type ComposerSurface = "prompt" | "git-ops";
-
 export type ComposerProps = {
   activeView: View;
   hostLabel: string;
@@ -28,7 +26,7 @@ export type ComposerProps = {
   diffBaseline: ProjectDiffBaseline;
   sessionPath: string | null;
   favoriteFolders: string[];
-  surface: ComposerSurface;
+  openGitOpsRequestKey: number;
   onSetDiffPanelVisible: (visible: boolean) => void;
   diffRenderMode: "stacked" | "split";
   diffComments: SavedDiffComment[];
@@ -51,29 +49,36 @@ export type ComposerProps = {
     rootPath?: string | null;
   }) => Promise<ComposerFilePickerState | null>;
   onAction: DesktopActionInvoker;
-  onSetSurface: (surface: ComposerSurface) => void;
 };
 
 export function Composer(props: ComposerProps) {
+  const [surface, setSurface] = useState<"prompt" | "git-ops">("prompt");
   const composerPanelRef = useRef<HTMLDivElement>(null);
-  const hasMountedRef = useRef(false);
+  const lastAppliedOpenGitOpsRequestKeyRef = useRef(0);
 
   useEffect(() => {
-    if (!hasMountedRef.current) {
-      hasMountedRef.current = true;
-      return;
-    }
-
     if (props.promptResetKey < 0) {
       return;
     }
 
-    props.onSetSurface("prompt");
-  }, [props.onSetSurface, props.promptResetKey]);
+    setSurface("prompt");
+  }, [props.promptResetKey]);
 
   useEffect(() => {
-    props.onSetDiffPanelVisible(props.surface === "git-ops");
-  }, [props.onSetDiffPanelVisible, props.surface]);
+    if (
+      props.openGitOpsRequestKey <= 0 ||
+      props.openGitOpsRequestKey === lastAppliedOpenGitOpsRequestKeyRef.current
+    ) {
+      return;
+    }
+
+    lastAppliedOpenGitOpsRequestKeyRef.current = props.openGitOpsRequestKey;
+    setSurface("git-ops");
+  }, [props.openGitOpsRequestKey]);
+
+  useEffect(() => {
+    props.onSetDiffPanelVisible(surface === "git-ops");
+  }, [props.onSetDiffPanelVisible, surface]);
 
   return (
     <SurfacePanel
@@ -81,7 +86,7 @@ export function Composer(props: ComposerProps) {
       className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
       aria-label="Composer panel"
     >
-      {props.surface === "git-ops" ? (
+      {surface === "git-ops" ? (
         <ComposerGitOpsSurface
           composerPanelRef={composerPanelRef}
           projectGitState={props.projectGitState}
@@ -97,13 +102,13 @@ export function Composer(props: ComposerProps) {
           onSelectDiffComment={props.onSelectDiffComment}
           onAction={props.onAction}
           onLayoutChange={props.onLayoutChange}
-          onBack={() => props.onSetSurface("prompt")}
+          onBack={() => setSurface("prompt")}
         />
       ) : (
         <ComposerPromptSurface
           {...props}
           composerPanelRef={composerPanelRef}
-          onOpenGitOps={() => props.onSetSurface("git-ops")}
+          onOpenGitOps={() => setSurface("git-ops")}
         />
       )}
     </SurfacePanel>

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -51,6 +51,7 @@ export type ComposerProps = {
     rootPath?: string | null;
   }) => Promise<ComposerFilePickerState | null>;
   onAction: DesktopActionInvoker;
+  onOpenGitOpsSurface: () => void;
   onSetSurface: (surface: ComposerSurface) => void;
 };
 
@@ -103,7 +104,7 @@ export function Composer(props: ComposerProps) {
         <ComposerPromptSurface
           {...props}
           composerPanelRef={composerPanelRef}
-          onOpenGitOps={() => props.onSetSurface("git-ops")}
+          onOpenGitOps={props.onOpenGitOpsSurface}
         />
       )}
     </SurfacePanel>

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -56,8 +56,14 @@ export type ComposerProps = {
 
 export function Composer(props: ComposerProps) {
   const composerPanelRef = useRef<HTMLDivElement>(null);
+  const hasMountedRef = useRef(false);
 
   useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
     if (props.promptResetKey < 0) {
       return;
     }

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -51,7 +51,6 @@ export type ComposerProps = {
     rootPath?: string | null;
   }) => Promise<ComposerFilePickerState | null>;
   onAction: DesktopActionInvoker;
-  onOpenGitOpsSurface: () => void;
   onSetSurface: (surface: ComposerSurface) => void;
 };
 
@@ -104,7 +103,7 @@ export function Composer(props: ComposerProps) {
         <ComposerPromptSurface
           {...props}
           composerPanelRef={composerPanelRef}
-          onOpenGitOps={props.onOpenGitOpsSurface}
+          onOpenGitOps={() => props.onSetSurface("git-ops")}
         />
       )}
     </SurfacePanel>

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import type {
   ComposerAttachment,
   ComposerFilePickerState,
@@ -14,6 +14,8 @@ import { ComposerGitOpsSurface } from "./composer/ComposerGitOpsSurface";
 import { ComposerPromptSurface } from "./composer/ComposerPromptSurface";
 import type { SavedDiffComment } from "./diff/diffCommentStore";
 
+export type ComposerSurface = "prompt" | "git-ops";
+
 export type ComposerProps = {
   activeView: View;
   hostLabel: string;
@@ -26,6 +28,7 @@ export type ComposerProps = {
   diffBaseline: ProjectDiffBaseline;
   sessionPath: string | null;
   favoriteFolders: string[];
+  surface: ComposerSurface;
   onSetDiffPanelVisible: (visible: boolean) => void;
   diffRenderMode: "stacked" | "split";
   diffComments: SavedDiffComment[];
@@ -48,10 +51,10 @@ export type ComposerProps = {
     rootPath?: string | null;
   }) => Promise<ComposerFilePickerState | null>;
   onAction: DesktopActionInvoker;
+  onSetSurface: (surface: ComposerSurface) => void;
 };
 
 export function Composer(props: ComposerProps) {
-  const [surface, setSurface] = useState<"prompt" | "git-ops">("prompt");
   const composerPanelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -59,12 +62,12 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    setSurface("prompt");
-  }, [props.promptResetKey]);
+    props.onSetSurface("prompt");
+  }, [props.onSetSurface, props.promptResetKey]);
 
   useEffect(() => {
-    props.onSetDiffPanelVisible(surface === "git-ops");
-  }, [props.onSetDiffPanelVisible, surface]);
+    props.onSetDiffPanelVisible(props.surface === "git-ops");
+  }, [props.onSetDiffPanelVisible, props.surface]);
 
   return (
     <SurfacePanel
@@ -72,7 +75,7 @@ export function Composer(props: ComposerProps) {
       className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
       aria-label="Composer panel"
     >
-      {surface === "git-ops" ? (
+      {props.surface === "git-ops" ? (
         <ComposerGitOpsSurface
           composerPanelRef={composerPanelRef}
           projectGitState={props.projectGitState}
@@ -88,13 +91,13 @@ export function Composer(props: ComposerProps) {
           onSelectDiffComment={props.onSelectDiffComment}
           onAction={props.onAction}
           onLayoutChange={props.onLayoutChange}
-          onBack={() => setSurface("prompt")}
+          onBack={() => props.onSetSurface("prompt")}
         />
       ) : (
         <ComposerPromptSurface
           {...props}
           composerPanelRef={composerPanelRef}
-          onOpenGitOps={() => setSurface("git-ops")}
+          onOpenGitOps={() => props.onSetSurface("git-ops")}
         />
       )}
     </SurfacePanel>

--- a/src/app/components/workspace/GitOpsComposerPanel.tsx
+++ b/src/app/components/workspace/GitOpsComposerPanel.tsx
@@ -1,0 +1,71 @@
+import { useRef } from "react";
+import type {
+  DesktopActionInvoker,
+  ProjectDiffBaseline,
+  ProjectGitState,
+} from "../../desktop/types";
+import { SurfacePanel } from "../common/SurfacePanel";
+import { ComposerGitOpsSurface } from "./composer/ComposerGitOpsSurface";
+import type { SavedDiffComment } from "./diff/diffCommentStore";
+
+type GitOpsComposerPanelProps = {
+  projectGitState: ProjectGitState | null;
+  diffBaseline: ProjectDiffBaseline;
+  diffRenderMode: "stacked" | "split";
+  diffComments: SavedDiffComment[];
+  diffCommentCount: number;
+  diffCommentsSending: boolean;
+  diffCommentError: string | null;
+  onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
+  onSetDiffRenderMode: (mode: "stacked" | "split") => void;
+  onSendDiffComments: (message?: string | null) => void;
+  onSelectDiffComment: (filePath: string, commentId: string) => void;
+  onAction: DesktopActionInvoker;
+  onLayoutChange: () => void;
+  onBack: () => void;
+};
+
+export function GitOpsComposerPanel({
+  projectGitState,
+  diffBaseline,
+  diffRenderMode,
+  diffComments,
+  diffCommentCount,
+  diffCommentsSending,
+  diffCommentError,
+  onSetDiffBaseline,
+  onSetDiffRenderMode,
+  onSendDiffComments,
+  onSelectDiffComment,
+  onAction,
+  onLayoutChange,
+  onBack,
+}: GitOpsComposerPanelProps) {
+  const composerPanelRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <SurfacePanel
+      ref={composerPanelRef}
+      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
+      aria-label="Git ops composer panel"
+    >
+      <ComposerGitOpsSurface
+        composerPanelRef={composerPanelRef}
+        projectGitState={projectGitState}
+        diffBaseline={diffBaseline}
+        diffRenderMode={diffRenderMode}
+        diffComments={diffComments}
+        diffCommentCount={diffCommentCount}
+        diffCommentsSending={diffCommentsSending}
+        diffCommentError={diffCommentError}
+        onSetDiffBaseline={onSetDiffBaseline}
+        onSetDiffRenderMode={onSetDiffRenderMode}
+        onSendDiffComments={onSendDiffComments}
+        onSelectDiffComment={onSelectDiffComment}
+        onAction={onAction}
+        onLayoutChange={onLayoutChange}
+        onBack={onBack}
+      />
+    </SurfacePanel>
+  );
+}

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -83,18 +83,6 @@ export function TerminalPanel({
             onClick={onOpenDockedTerminal}
           />
           <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
-            {projectGitState?.isGitRepo ? (
-              <div
-                className={cn(
-                  compactCardClass,
-                  "inline-flex items-center gap-1 px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
-                )}
-                title={projectGitState.branch ?? "Detached"}
-              >
-                <GitBranch size={12} />
-                <span>{projectGitState.branch ?? "Detached"}</span>
-              </div>
-            ) : null}
             {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
               <ComposerDiffBaselineSelector
                 composerPanelRef={panelRef}
@@ -103,6 +91,17 @@ export function TerminalPanel({
                 selectedBaseline={diffBaseline}
                 onSelectBaseline={onSetDiffBaseline}
               />
+            ) : null}
+            {projectGitState?.isGitRepo ? (
+              <div
+                className={cn(
+                  compactCardClass,
+                  "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+                )}
+                title={projectGitState.branch ?? "Detached"}
+              >
+                <span>{projectGitState.branch ?? "Detached"}</span>
+              </div>
             ) : null}
             <button
               type="button"

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -5,7 +5,12 @@ import {
   type FeatureStatusId,
   getFeatureStatusDataAttributes,
 } from "../../features/feature-status";
-import { compactIconButtonClass, iconButtonClass, panelChromeClass } from "../../ui/classes";
+import {
+  compactCardClass,
+  compactIconButtonClass,
+  iconButtonClass,
+  panelChromeClass,
+} from "../../ui/classes";
 import { cn } from "../../utils/cn";
 import { FeatureStatusBadge } from "../common/FeatureStatusBadge";
 import { PiLogoMark } from "../common/PiLogoMark";
@@ -15,7 +20,7 @@ import { ComposerDiffBaselineSelector } from "./composer/ComposerDiffBaselineSel
 import { getGitOpsEntryButtonClass } from "./composer/git-ops";
 import { TerminalViewport } from "./terminal/TerminalViewport";
 
-const PI_TUI_KEEP_ALIVE_MS = 30_000;
+const PI_TUI_KEEP_ALIVE_MS = 300_000;
 
 type TerminalPanelProps = {
   projectId: string;
@@ -78,6 +83,18 @@ export function TerminalPanel({
             onClick={onOpenDockedTerminal}
           />
           <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+            {projectGitState?.isGitRepo ? (
+              <div
+                className={cn(
+                  compactCardClass,
+                  "inline-flex items-center gap-1 px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+                )}
+                title={projectGitState.branch ?? "Detached"}
+              >
+                <GitBranch size={12} />
+                <span>{projectGitState.branch ?? "Detached"}</span>
+              </div>
+            ) : null}
             {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
               <ComposerDiffBaselineSelector
                 composerPanelRef={panelRef}

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -95,11 +95,11 @@ export function TerminalPanel({
                 <div
                   className={cn(
                     compactCardClass,
-                    "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+                    "inline-flex max-w-[12rem] px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
                   )}
                   title={projectGitState.branch ?? "Detached"}
                 >
-                  <span>{projectGitState.branch ?? "Detached"}</span>
+                  <span className="truncate">{projectGitState.branch ?? "Detached"}</span>
                 </div>
               ) : null}
               <button

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -67,50 +67,47 @@ export function TerminalPanel({
           keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
           className="terminal-viewport--flush min-h-0 rounded-none bg-[color:var(--terminal-bg)]"
         />
-        <div className="overflow-hidden rounded-b-[20px] border-x border-b border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none">
-          <div className="h-px bg-[rgba(169,178,215,0.07)]" />
-          <div className="flex items-center gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
-            <ToolbarButton
-              label="Desktop"
-              icon={<PiLogoMark className="h-[14px] w-[14px]" />}
-              onClick={onClose}
-            />
-            <ToolbarButton
-              label="Terminal"
-              icon={<SquareTerminal size={14} />}
-              onClick={onOpenDockedTerminal}
-            />
-            <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
-              {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
-                <ComposerDiffBaselineSelector
-                  composerPanelRef={panelRef}
-                  projectId={projectId}
-                  projectGitState={projectGitState}
-                  selectedBaseline={diffBaseline}
-                  onSelectBaseline={onSetDiffBaseline}
-                />
-              ) : null}
-              {projectGitState?.isGitRepo ? (
-                <div
-                  className={cn(
-                    compactCardClass,
-                    "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
-                  )}
-                  title={projectGitState.branch ?? "Detached"}
-                >
-                  <span>{projectGitState.branch ?? "Detached"}</span>
-                </div>
-              ) : null}
-              <button
-                type="button"
-                className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
-                onClick={onOpenGitOps}
-                aria-label="Open desktop git ops"
-                title="Open desktop git ops"
+        <div className="flex items-center gap-1.5 bg-[rgba(39,42,57,0.94)] px-4 pt-2 pb-3 text-[color:var(--muted)] backdrop-blur-[18px] max-md:flex-wrap">
+          <ToolbarButton
+            label="Desktop"
+            icon={<PiLogoMark className="h-[14px] w-[14px]" />}
+            onClick={onClose}
+          />
+          <ToolbarButton
+            label="Terminal"
+            icon={<SquareTerminal size={14} />}
+            onClick={onOpenDockedTerminal}
+          />
+          <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+            {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
+              <ComposerDiffBaselineSelector
+                composerPanelRef={panelRef}
+                projectId={projectId}
+                projectGitState={projectGitState}
+                selectedBaseline={diffBaseline}
+                onSelectBaseline={onSetDiffBaseline}
+              />
+            ) : null}
+            {projectGitState?.isGitRepo ? (
+              <div
+                className={cn(
+                  compactCardClass,
+                  "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+                )}
+                title={projectGitState.branch ?? "Detached"}
               >
-                <GitBranch size={14} />
-              </button>
-            </div>
+                <span>{projectGitState.branch ?? "Detached"}</span>
+              </div>
+            ) : null}
+            <button
+              type="button"
+              className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
+              onClick={onOpenGitOps}
+              aria-label="Open desktop git ops"
+              title="Open desktop git ops"
+            >
+              <GitBranch size={14} />
+            </button>
           </div>
         </div>
       </div>

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -14,7 +14,6 @@ import {
 import { cn } from "../../utils/cn";
 import { FeatureStatusBadge } from "../common/FeatureStatusBadge";
 import { PiLogoMark } from "../common/PiLogoMark";
-import { SurfacePanel } from "../common/SurfacePanel";
 import { ToolbarButton } from "../common/ToolbarButton";
 import { ComposerDiffBaselineSelector } from "./composer/ComposerDiffBaselineSelector";
 import { getGitOpsEntryButtonClass } from "./composer/git-ops";
@@ -55,23 +54,20 @@ export function TerminalPanel({
 
   if (mode === "takeover") {
     return (
-      <SurfacePanel
+      <div
         ref={panelRef}
         aria-label="Pi terminal panel"
-        className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] gap-0 overflow-hidden border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
+        className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] overflow-hidden bg-[color:var(--terminal-bg)]"
         {...getFeatureStatusDataAttributes(statusId)}
       >
-        <div className="min-h-0 px-4 pt-4 pb-3">
-          <TerminalViewport
-            projectId={projectId}
-            sessionPath={sessionPath}
-            launchMode="pi-session"
-            keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
-            className="min-h-0 rounded-[16px] bg-[color:var(--terminal-bg)]"
-          />
-        </div>
-        <div className="h-px bg-[rgba(169,178,215,0.07)]" />
-        <div className="flex items-center gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+        <TerminalViewport
+          projectId={projectId}
+          sessionPath={sessionPath}
+          launchMode="pi-session"
+          keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
+          className="terminal-viewport--flush min-h-0 rounded-none bg-[color:var(--terminal-bg)]"
+        />
+        <div className="flex items-center gap-1.5 bg-[rgba(31,34,48,0.94)] px-4 pt-2 pb-3 text-[color:var(--muted)] backdrop-blur-[18px] max-md:flex-wrap">
           <ToolbarButton
             label="Desktop"
             icon={<PiLogoMark className="h-[14px] w-[14px]" />}
@@ -114,7 +110,7 @@ export function TerminalPanel({
             </button>
           </div>
         </div>
-      </SurfacePanel>
+      </div>
     );
   }
 

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -1,70 +1,98 @@
-import { SquareTerminal, X } from "lucide-react";
-import type { DesktopActionInvoker } from "../../desktop/types";
+import { GitBranch, SquareTerminal, X } from "lucide-react";
+import { useRef } from "react";
+import type { ProjectDiffBaseline, ProjectGitState } from "../../desktop/types";
 import {
   type FeatureStatusId,
   getFeatureStatusDataAttributes,
 } from "../../features/feature-status";
-import { iconButtonClass, panelChromeClass } from "../../ui/classes";
+import { compactIconButtonClass, iconButtonClass, panelChromeClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
 import { FeatureStatusBadge } from "../common/FeatureStatusBadge";
+import { PiLogoMark } from "../common/PiLogoMark";
 import { SurfacePanel } from "../common/SurfacePanel";
 import { ToolbarButton } from "../common/ToolbarButton";
+import { ComposerDiffBaselineSelector } from "./composer/ComposerDiffBaselineSelector";
+import { getGitOpsEntryButtonClass } from "./composer/git-ops";
 import { TerminalViewport } from "./terminal/TerminalViewport";
 
 type TerminalPanelProps = {
   projectId: string;
   sessionPath: string | null;
   onClose: () => void;
+  onOpenDockedTerminal?: () => void;
+  onOpenGitOps?: () => void;
   mode?: "docked" | "takeover";
-  hostLabel?: string;
-  onAction?: DesktopActionInvoker;
+  projectGitState?: ProjectGitState | null;
+  diffBaseline?: ProjectDiffBaseline;
+  onSetDiffBaseline?: (baseline: ProjectDiffBaseline) => void;
 };
 
 export function TerminalPanel({
   projectId,
   sessionPath,
   onClose,
+  onOpenDockedTerminal,
+  onOpenGitOps,
   mode = "docked",
-  hostLabel = "Local",
-  onAction,
+  projectGitState = null,
+  diffBaseline,
+  onSetDiffBaseline,
 }: TerminalPanelProps) {
   const statusId: FeatureStatusId = "feature:terminal.panel";
+  const panelRef = useRef<HTMLDivElement>(null);
+  const gitVisualMode = !projectGitState?.isGitRepo
+    ? "not-git"
+    : projectGitState.fileCount > 0
+      ? "dirty"
+      : "clean";
 
   if (mode === "takeover") {
     return (
       <SurfacePanel
+        ref={panelRef}
         aria-label="Pi terminal panel"
-        className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] gap-0 overflow-hidden rounded-2xl border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
+        className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] gap-0 overflow-hidden border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
         {...getFeatureStatusDataAttributes(statusId)}
       >
-        <div className="flex min-h-0 min-w-0 overflow-hidden px-2.5 pt-2.5">
-          <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-t-2xl rounded-b-none bg-[color:var(--terminal-bg)]">
-            <TerminalViewport
-              projectId={projectId}
-              sessionPath={sessionPath}
-              launchMode="pi-session"
-              className="terminal-viewport--flush min-h-0 rounded-none border-0 bg-transparent"
-            />
-          </div>
+        <div className="min-h-0 px-4 pt-4 pb-3">
+          <TerminalViewport
+            projectId={projectId}
+            sessionPath={sessionPath}
+            launchMode="pi-session"
+            className="min-h-0 rounded-[16px] border-[rgba(137,146,183,0.08)] bg-[rgba(23,25,35,0.98)]"
+          />
         </div>
+        <div className="h-px bg-[rgba(169,178,215,0.07)]" />
         <div className="flex items-center gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
-          <div className="flex items-center gap-1.5 text-[color:var(--muted)] max-md:flex-wrap">
-            <ToolbarButton
-              label={
-                <span className="inline-flex items-center gap-2">
-                  <span>Pi desktop</span>
-                  <FeatureStatusBadge statusId={statusId} />
-                </span>
-              }
-              icon={<SquareTerminal size={14} />}
-              onClick={onClose}
-            />
-            <ToolbarButton
-              label={hostLabel}
-              icon={<SquareTerminal size={14} />}
-              onClick={() => void onAction?.("composer.host")}
-              trailing
-            />
+          <ToolbarButton
+            label="Desktop"
+            icon={<PiLogoMark className="h-[14px] w-[14px]" />}
+            onClick={onClose}
+          />
+          <ToolbarButton
+            label="Terminal"
+            icon={<SquareTerminal size={14} />}
+            onClick={onOpenDockedTerminal}
+          />
+          <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+            {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
+              <ComposerDiffBaselineSelector
+                composerPanelRef={panelRef}
+                projectId={projectId}
+                projectGitState={projectGitState}
+                selectedBaseline={diffBaseline}
+                onSelectBaseline={onSetDiffBaseline}
+              />
+            ) : null}
+            <button
+              type="button"
+              className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
+              onClick={onOpenGitOps}
+              aria-label="Open desktop git ops"
+              title="Open desktop git ops"
+            >
+              <GitBranch size={14} />
+            </button>
           </div>
         </div>
       </SurfacePanel>

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -67,7 +67,7 @@ export function TerminalPanel({
             sessionPath={sessionPath}
             launchMode="pi-session"
             keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
-            className="min-h-0 rounded-[16px] border-[rgba(137,146,183,0.08)] bg-[rgba(23,25,35,0.98)]"
+            className="min-h-0 rounded-[16px] bg-[color:var(--terminal-bg)]"
           />
         </div>
         <div className="h-px bg-[rgba(169,178,215,0.07)]" />
@@ -142,12 +142,13 @@ export function TerminalPanel({
           <X size={14} />
         </button>
       </div>
-      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-[rgba(137,146,183,0.06)] bg-[rgba(23,25,35,0.98)] p-1">
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl bg-[color:var(--terminal-bg)]">
         <TerminalViewport
           projectId={projectId}
           sessionPath={sessionPath}
           launchMode="shell"
           preserveSessionOnUnmount
+          className="bg-[color:var(--terminal-bg)]"
         />
       </div>
     </section>

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -57,7 +57,7 @@ export function TerminalPanel({
       <div
         ref={panelRef}
         aria-label="Pi terminal panel"
-        className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] overflow-hidden bg-[color:var(--terminal-bg)]"
+        className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] bg-transparent"
         {...getFeatureStatusDataAttributes(statusId)}
       >
         <TerminalViewport
@@ -67,47 +67,50 @@ export function TerminalPanel({
           keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
           className="terminal-viewport--flush min-h-0 rounded-none bg-[color:var(--terminal-bg)]"
         />
-        <div className="flex items-center gap-1.5 bg-[rgba(31,34,48,0.94)] px-4 pt-2 pb-3 text-[color:var(--muted)] backdrop-blur-[18px] max-md:flex-wrap">
-          <ToolbarButton
-            label="Desktop"
-            icon={<PiLogoMark className="h-[14px] w-[14px]" />}
-            onClick={onClose}
-          />
-          <ToolbarButton
-            label="Terminal"
-            icon={<SquareTerminal size={14} />}
-            onClick={onOpenDockedTerminal}
-          />
-          <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
-            {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
-              <ComposerDiffBaselineSelector
-                composerPanelRef={panelRef}
-                projectId={projectId}
-                projectGitState={projectGitState}
-                selectedBaseline={diffBaseline}
-                onSelectBaseline={onSetDiffBaseline}
-              />
-            ) : null}
-            {projectGitState?.isGitRepo ? (
-              <div
-                className={cn(
-                  compactCardClass,
-                  "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
-                )}
-                title={projectGitState.branch ?? "Detached"}
+        <div className="overflow-hidden rounded-b-[20px] border-x border-b border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none">
+          <div className="h-px bg-[rgba(169,178,215,0.07)]" />
+          <div className="flex items-center gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+            <ToolbarButton
+              label="Desktop"
+              icon={<PiLogoMark className="h-[14px] w-[14px]" />}
+              onClick={onClose}
+            />
+            <ToolbarButton
+              label="Terminal"
+              icon={<SquareTerminal size={14} />}
+              onClick={onOpenDockedTerminal}
+            />
+            <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+              {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
+                <ComposerDiffBaselineSelector
+                  composerPanelRef={panelRef}
+                  projectId={projectId}
+                  projectGitState={projectGitState}
+                  selectedBaseline={diffBaseline}
+                  onSelectBaseline={onSetDiffBaseline}
+                />
+              ) : null}
+              {projectGitState?.isGitRepo ? (
+                <div
+                  className={cn(
+                    compactCardClass,
+                    "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+                  )}
+                  title={projectGitState.branch ?? "Detached"}
+                >
+                  <span>{projectGitState.branch ?? "Detached"}</span>
+                </div>
+              ) : null}
+              <button
+                type="button"
+                className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
+                onClick={onOpenGitOps}
+                aria-label="Open desktop git ops"
+                title="Open desktop git ops"
               >
-                <span>{projectGitState.branch ?? "Detached"}</span>
-              </div>
-            ) : null}
-            <button
-              type="button"
-              className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
-              onClick={onOpenGitOps}
-              aria-label="Open desktop git ops"
-              title="Open desktop git ops"
-            >
-              <GitBranch size={14} />
-            </button>
+                <GitBranch size={14} />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -65,7 +65,8 @@ export function TerminalPanel({
           sessionPath={sessionPath}
           launchMode="pi-session"
           keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
-          className="terminal-viewport--flush min-h-0 rounded-none bg-[color:var(--terminal-bg)]"
+          backgroundCssVar="--workspace"
+          className="terminal-viewport--flush min-h-0 rounded-none bg-[color:var(--workspace)]"
         />
         <div className="overflow-hidden rounded-b-[20px] border-x border-b border-[color:var(--border)] bg-[rgba(39,42,57,0.94)] shadow-[var(--shadow)]">
           <div className="h-px bg-[rgba(169,178,215,0.07)]" />

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -15,6 +15,8 @@ import { ComposerDiffBaselineSelector } from "./composer/ComposerDiffBaselineSel
 import { getGitOpsEntryButtonClass } from "./composer/git-ops";
 import { TerminalViewport } from "./terminal/TerminalViewport";
 
+const PI_TUI_KEEP_ALIVE_MS = 30_000;
+
 type TerminalPanelProps = {
   projectId: string;
   sessionPath: string | null;
@@ -59,6 +61,7 @@ export function TerminalPanel({
             projectId={projectId}
             sessionPath={sessionPath}
             launchMode="pi-session"
+            keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
             className="min-h-0 rounded-[16px] border-[rgba(137,146,183,0.08)] bg-[rgba(23,25,35,0.98)]"
           />
         </div>

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -67,47 +67,50 @@ export function TerminalPanel({
           keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
           className="terminal-viewport--flush min-h-0 rounded-none bg-[color:var(--terminal-bg)]"
         />
-        <div className="flex items-center gap-1.5 bg-[rgba(39,42,57,0.94)] px-4 pt-2 pb-3 text-[color:var(--muted)] backdrop-blur-[18px] max-md:flex-wrap">
-          <ToolbarButton
-            label="Desktop"
-            icon={<PiLogoMark className="h-[14px] w-[14px]" />}
-            onClick={onClose}
-          />
-          <ToolbarButton
-            label="Terminal"
-            icon={<SquareTerminal size={14} />}
-            onClick={onOpenDockedTerminal}
-          />
-          <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
-            {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
-              <ComposerDiffBaselineSelector
-                composerPanelRef={panelRef}
-                projectId={projectId}
-                projectGitState={projectGitState}
-                selectedBaseline={diffBaseline}
-                onSelectBaseline={onSetDiffBaseline}
-              />
-            ) : null}
-            {projectGitState?.isGitRepo ? (
-              <div
-                className={cn(
-                  compactCardClass,
-                  "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
-                )}
-                title={projectGitState.branch ?? "Detached"}
+        <div className="overflow-hidden rounded-b-[20px] border-x border-b border-[color:var(--border)] bg-[rgba(39,42,57,0.94)] shadow-[var(--shadow)]">
+          <div className="h-px bg-[rgba(169,178,215,0.07)]" />
+          <div className="flex items-center gap-1.5 rounded-b-[20px] px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+            <ToolbarButton
+              label="Desktop"
+              icon={<PiLogoMark className="h-[14px] w-[14px]" />}
+              onClick={onClose}
+            />
+            <ToolbarButton
+              label="Terminal"
+              icon={<SquareTerminal size={14} />}
+              onClick={onOpenDockedTerminal}
+            />
+            <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+              {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
+                <ComposerDiffBaselineSelector
+                  composerPanelRef={panelRef}
+                  projectId={projectId}
+                  projectGitState={projectGitState}
+                  selectedBaseline={diffBaseline}
+                  onSelectBaseline={onSetDiffBaseline}
+                />
+              ) : null}
+              {projectGitState?.isGitRepo ? (
+                <div
+                  className={cn(
+                    compactCardClass,
+                    "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+                  )}
+                  title={projectGitState.branch ?? "Detached"}
+                >
+                  <span>{projectGitState.branch ?? "Detached"}</span>
+                </div>
+              ) : null}
+              <button
+                type="button"
+                className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
+                onClick={onOpenGitOps}
+                aria-label="Open desktop git ops"
+                title="Open desktop git ops"
               >
-                <span>{projectGitState.branch ?? "Detached"}</span>
-              </div>
-            ) : null}
-            <button
-              type="button"
-              className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
-              onClick={onOpenGitOps}
-              aria-label="Open desktop git ops"
-              title="Open desktop git ops"
-            >
-              <GitBranch size={14} />
-            </button>
+                <GitBranch size={14} />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -252,6 +252,15 @@ export function ComposerPromptSurface({
           ) : null}
         </div>
         <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+          <button
+            type="button"
+            className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
+            onClick={onOpenGitOps}
+            aria-label="Open git ops"
+            title="Open git ops"
+          >
+            <GitBranch size={14} />
+          </button>
           {projectGitState?.isGitRepo ? (
             <div
               className={cn(
@@ -273,15 +282,6 @@ export function ComposerPromptSurface({
               onSelectBaseline={onSetDiffBaseline}
             />
           ) : null}
-          <button
-            type="button"
-            className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
-            onClick={onOpenGitOps}
-            aria-label="Open git ops"
-            title="Open git ops"
-          >
-            <GitBranch size={14} />
-          </button>
         </div>
       </div>
     </div>

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -252,27 +252,6 @@ export function ComposerPromptSurface({
           ) : null}
         </div>
         <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
-          <button
-            type="button"
-            className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
-            onClick={onOpenGitOps}
-            aria-label="Open git ops"
-            title="Open git ops"
-          >
-            <GitBranch size={14} />
-          </button>
-          {projectGitState?.isGitRepo ? (
-            <div
-              className={cn(
-                compactCardClass,
-                "inline-flex items-center gap-1 px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
-              )}
-              title={projectGitState.branch ?? "Detached"}
-            >
-              <GitBranch size={12} />
-              <span>{projectGitState.branch ?? "Detached"}</span>
-            </div>
-          ) : null}
           {projectGitState?.isGitRepo ? (
             <ComposerDiffBaselineSelector
               composerPanelRef={composerPanelRef}
@@ -282,6 +261,26 @@ export function ComposerPromptSurface({
               onSelectBaseline={onSetDiffBaseline}
             />
           ) : null}
+          {projectGitState?.isGitRepo ? (
+            <div
+              className={cn(
+                compactCardClass,
+                "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+              )}
+              title={projectGitState.branch ?? "Detached"}
+            >
+              <span>{projectGitState.branch ?? "Detached"}</span>
+            </div>
+          ) : null}
+          <button
+            type="button"
+            className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
+            onClick={onOpenGitOps}
+            aria-label="Open git ops"
+            title="Open git ops"
+          >
+            <GitBranch size={14} />
+          </button>
         </div>
       </div>
     </div>

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -265,11 +265,11 @@ export function ComposerPromptSurface({
             <div
               className={cn(
                 compactCardClass,
-                "inline-flex px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+                "inline-flex max-w-[12rem] px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
               )}
               title={projectGitState.branch ?? "Detached"}
             >
-              <span>{projectGitState.branch ?? "Detached"}</span>
+              <span className="truncate">{projectGitState.branch ?? "Detached"}</span>
             </div>
           ) : null}
           <button

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -1,7 +1,7 @@
 import { Bot, GitBranch, Mic, Plus, Send, Terminal } from "lucide-react";
 import type { RefObject } from "react";
 import { getFeatureStatusButtonClass } from "../../../features/feature-status";
-import { compactIconButtonClass, iconButtonClass } from "../../../ui/classes";
+import { compactCardClass, compactIconButtonClass, iconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { FeatureStatusBadge } from "../../common/FeatureStatusBadge";
 import { PiLogoMark } from "../../common/PiLogoMark";
@@ -251,7 +251,19 @@ export function ComposerPromptSurface({
             />
           ) : null}
         </div>
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+          {projectGitState?.isGitRepo ? (
+            <div
+              className={cn(
+                compactCardClass,
+                "inline-flex items-center gap-1 px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+              )}
+              title={projectGitState.branch ?? "Detached"}
+            >
+              <GitBranch size={12} />
+              <span>{projectGitState.branch ?? "Detached"}</span>
+            </div>
+          ) : null}
           {projectGitState?.isGitRepo ? (
             <ComposerDiffBaselineSelector
               composerPanelRef={composerPanelRef}

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -50,30 +50,41 @@ function writeSystemMessage(terminal: Terminal, message: string) {
 
 function terminalThemeFromApp(): ITheme {
   const rootStyles = getComputedStyle(document.documentElement);
+  const getToken = (name: string, fallback: string) =>
+    rootStyles.getPropertyValue(name).trim() || fallback;
+
+  const background = getToken("--terminal-bg", "#171923");
+  const foreground = getToken("--text", "#d5daed");
+  const accent = getToken("--accent", "#b9bff3");
+  const muted = getToken("--muted", "#969db7");
+  const mutedStrong = getToken("--muted-2", "#727894");
+  const green = getToken("--green", "#86d9a0");
+
   return {
-    background: rootStyles.getPropertyValue("--terminal-bg").trim() || "#171923",
-    foreground: "#e2e7f8",
-    cursor: rootStyles.getPropertyValue("--accent").trim() || "#b9bff3",
-    cursorAccent: rootStyles.getPropertyValue("--terminal-bg").trim() || "#171923",
+    background,
+    foreground,
+    cursor: accent,
+    cursorAccent: background,
     selectionBackground: "rgba(185, 191, 243, 0.18)",
+    selectionInactiveBackground: "rgba(185, 191, 243, 0.12)",
     scrollbarSliderBackground: "rgba(255, 255, 255, 0.08)",
     scrollbarSliderHoverBackground: "rgba(255, 255, 255, 0.14)",
     scrollbarSliderActiveBackground: "rgba(255, 255, 255, 0.2)",
-    black: "#171923",
+    black: background,
     red: "#db7d84",
-    green: "#8ad7a5",
-    yellow: "#d9ba77",
-    blue: "#96b8ff",
-    magenta: "#c7a8ff",
-    cyan: "#88dee4",
-    white: "#e2e7f8",
-    brightBlack: "#7c839f",
+    green,
+    yellow: accent,
+    blue: accent,
+    magenta: accent,
+    cyan: muted,
+    white: foreground,
+    brightBlack: mutedStrong,
     brightRed: "#ec979d",
-    brightGreen: "#a5e7bb",
-    brightYellow: "#e6cc93",
-    brightBlue: "#afc8ff",
-    brightMagenta: "#d7bfff",
-    brightCyan: "#a2e9ef",
+    brightGreen: green,
+    brightYellow: foreground,
+    brightBlue: foreground,
+    brightMagenta: foreground,
+    brightCyan: foreground,
     brightWhite: "#f7f9ff",
   };
 }
@@ -360,7 +371,7 @@ export function TerminalViewport({
     <div
       ref={containerRef}
       className={cn(
-        "terminal-viewport h-full min-h-[220px] min-w-0 w-full flex-1 overflow-hidden rounded-[12px] border border-[rgba(169,178,215,0.04)] bg-[color:var(--terminal-bg)]",
+        "terminal-viewport h-full min-h-[220px] min-w-0 w-full flex-1 overflow-hidden rounded-[12px] bg-[color:var(--terminal-bg)] text-[color:var(--text)]",
         className,
       )}
     />

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -23,6 +23,18 @@ type TerminalViewportProps = {
 
 const pendingTerminalCloseTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+const XTERM_SCROLLBAR_VISIBILITY_VISIBLE = 3;
+
+type XtermPrivateTerminal = Terminal & {
+  _core?: {
+    _viewport?: {
+      _scrollableElement?: {
+        updateOptions?: (options: { vertical?: number; horizontal?: number }) => void;
+      };
+    };
+  };
+};
+
 function cancelScheduledTerminalClose(sessionId: string) {
   const timer = pendingTerminalCloseTimers.get(sessionId);
   if (!timer) {
@@ -46,6 +58,11 @@ function scheduleTerminalClose(sessionId: string, delayMs: number) {
 
 function writeSystemMessage(terminal: Terminal, message: string) {
   terminal.write(`\r\n[terminal] ${message}\r\n`);
+}
+
+function forcePersistentTerminalScrollbar(terminal: Terminal) {
+  const scrollableElement = (terminal as XtermPrivateTerminal)._core?._viewport?._scrollableElement;
+  scrollableElement?.updateOptions?.({ vertical: XTERM_SCROLLBAR_VISIBILITY_VISIBLE });
 }
 
 function terminalThemeFromApp(): ITheme {
@@ -140,6 +157,7 @@ export function TerminalViewport({
 
     terminal.loadAddon(fitAddon);
     terminal.open(mount);
+    forcePersistentTerminalScrollbar(terminal);
     fitAddon.fit();
     terminal.focus();
     lastSizeRef.current = {

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -18,6 +18,7 @@ type TerminalViewportProps = {
   launchMode?: "shell" | "pi-session";
   preserveSessionOnUnmount?: boolean;
   keepAliveMsOnUnmount?: number;
+  backgroundCssVar?: "--terminal-bg" | "--workspace";
   className?: string;
 };
 
@@ -65,12 +66,12 @@ function forcePersistentTerminalScrollbar(terminal: Terminal) {
   scrollableElement?.updateOptions?.({ vertical: XTERM_SCROLLBAR_VISIBILITY_VISIBLE });
 }
 
-function terminalThemeFromApp(): ITheme {
+function terminalThemeFromApp(backgroundCssVar: "--terminal-bg" | "--workspace"): ITheme {
   const rootStyles = getComputedStyle(document.documentElement);
   const getToken = (name: string, fallback: string) =>
     rootStyles.getPropertyValue(name).trim() || fallback;
 
-  const background = getToken("--terminal-bg", "#171923");
+  const background = getToken(backgroundCssVar, "#171923");
   const foreground = getToken("--text", "#d5daed");
   const accent = getToken("--accent", "#b9bff3");
   const muted = getToken("--muted", "#969db7");
@@ -121,6 +122,7 @@ export function TerminalViewport({
   launchMode = "shell",
   preserveSessionOnUnmount = false,
   keepAliveMsOnUnmount = 0,
+  backgroundCssVar = "--terminal-bg",
   className,
 }: TerminalViewportProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -152,7 +154,7 @@ export function TerminalViewport({
       fontWeight: "400",
       fontWeightBold: "600",
       letterSpacing: 0,
-      theme: terminalThemeFromApp(),
+      theme: terminalThemeFromApp(backgroundCssVar),
     });
 
     terminal.loadAddon(fitAddon);
@@ -256,7 +258,7 @@ export function TerminalViewport({
     });
 
     const themeObserver = new MutationObserver(() => {
-      terminal.options.theme = terminalThemeFromApp();
+      terminal.options.theme = terminalThemeFromApp(backgroundCssVar);
     });
 
     themeObserver.observe(document.documentElement, {
@@ -380,6 +382,7 @@ export function TerminalViewport({
   }, [
     effectiveLaunchMode,
     keepAliveMsOnUnmount,
+    backgroundCssVar,
     persistedSessionPath,
     preserveSessionOnUnmount,
     projectId,

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -17,8 +17,32 @@ type TerminalViewportProps = {
   sessionPath: string | null;
   launchMode?: "shell" | "pi-session";
   preserveSessionOnUnmount?: boolean;
+  keepAliveMsOnUnmount?: number;
   className?: string;
 };
+
+const pendingTerminalCloseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function cancelScheduledTerminalClose(sessionId: string) {
+  const timer = pendingTerminalCloseTimers.get(sessionId);
+  if (!timer) {
+    return;
+  }
+
+  clearTimeout(timer);
+  pendingTerminalCloseTimers.delete(sessionId);
+}
+
+function scheduleTerminalClose(sessionId: string, delayMs: number) {
+  cancelScheduledTerminalClose(sessionId);
+
+  const timer = setTimeout(() => {
+    pendingTerminalCloseTimers.delete(sessionId);
+    void closeDesktopTerminal({ sessionId });
+  }, delayMs);
+
+  pendingTerminalCloseTimers.set(sessionId, timer);
+}
 
 function writeSystemMessage(terminal: Terminal, message: string) {
   terminal.write(`\r\n[terminal] ${message}\r\n`);
@@ -68,6 +92,7 @@ export function TerminalViewport({
   sessionPath,
   launchMode = "shell",
   preserveSessionOnUnmount = false,
+  keepAliveMsOnUnmount = 0,
   className,
 }: TerminalViewportProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -279,6 +304,7 @@ export function TerminalViewport({
       }
 
       sessionIdRef.current = snapshot.sessionId;
+      cancelScheduledTerminalClose(snapshot.sessionId);
       terminal.clear();
       if (snapshot.history) {
         terminal.write(snapshot.history);
@@ -315,10 +341,20 @@ export function TerminalViewport({
       terminal.dispose();
 
       if (sessionId && !preserveSessionOnUnmount) {
-        void closeDesktopTerminal({ sessionId });
+        if (keepAliveMsOnUnmount > 0) {
+          scheduleTerminalClose(sessionId, keepAliveMsOnUnmount);
+        } else {
+          void closeDesktopTerminal({ sessionId });
+        }
       }
     };
-  }, [effectiveLaunchMode, persistedSessionPath, preserveSessionOnUnmount, projectId]);
+  }, [
+    effectiveLaunchMode,
+    keepAliveMsOnUnmount,
+    persistedSessionPath,
+    preserveSessionOnUnmount,
+    projectId,
+  ]);
 
   return (
     <div

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { AppShellController } from "../../app-shell/useAppShellController";
-import { Composer, type ComposerSurface } from "../../components/workspace/Composer";
+import { Composer } from "../../components/workspace/Composer";
 import { DiffPanel } from "../../components/workspace/DiffPanel";
 import { TerminalPanel } from "../../components/workspace/TerminalPanel";
 import { buildDiffCommentPrompt } from "../../components/workspace/diff/diffCommentPrompt";
@@ -18,13 +18,12 @@ type CodeWorkspaceViewProps = {
   activeComposerState: AppShellController["activeComposerState"];
   activeThreadData: AppShellController["activeThreadData"];
   composerProjectId: string;
-  composerSurface: ComposerSurface;
+  composerOpenGitOpsRequestKey: number;
   currentProjectName: string;
   diffBaseline: ProjectDiffBaseline;
   dockedTerminalVisible: boolean;
   terminalSessionPath: string | null;
   workspaceContentClass: string;
-  onSetComposerSurface: (surface: ComposerSurface) => void;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
 };
 
@@ -35,13 +34,12 @@ export function CodeWorkspaceView({
   activeComposerState,
   activeThreadData,
   composerProjectId,
-  composerSurface,
+  composerOpenGitOpsRequestKey,
   currentProjectName,
   diffBaseline,
   dockedTerminalVisible,
   terminalSessionPath,
   workspaceContentClass,
-  onSetComposerSurface,
   onSetDiffBaseline,
 }: CodeWorkspaceViewProps) {
   const [composerPromptResetKey, setComposerPromptResetKey] = useState(0);
@@ -139,7 +137,6 @@ export function CodeWorkspaceView({
     setDiffCommentsSending(true);
     setDiffCommentError(null);
     setSelectedDiffCommentId(null);
-    onSetComposerSurface("prompt");
     setComposerPromptResetKey((current) => current + 1);
 
     try {
@@ -245,7 +242,7 @@ export function CodeWorkspaceView({
                 diffCommentCount={diffCommentCount}
                 diffCommentsSending={diffCommentsSending}
                 diffCommentError={diffCommentError}
-                surface={composerSurface}
+                openGitOpsRequestKey={composerOpenGitOpsRequestKey}
                 onSetDiffBaseline={onSetDiffBaseline}
                 onSetDiffRenderMode={setDiffRenderMode}
                 onSendDiffComments={(message) => {
@@ -264,7 +261,6 @@ export function CodeWorkspaceView({
                 onPickAttachments={pickComposerAttachments}
                 onListAttachmentEntries={listComposerAttachmentEntries}
                 onAction={handleAction}
-                onSetSurface={onSetComposerSurface}
               />
             </div>
             {dockedTerminalVisible ? (

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -59,6 +59,7 @@ export function CodeWorkspaceView({
     handleAction,
     handleLoadEarlierMessages,
     handleOpenDiffSelection,
+    handleOpenGitOpsSurface,
     handleOpenWorktreeDiffFile,
     handleShowTakeoverTerminal,
     handleToggleDiff,
@@ -264,6 +265,7 @@ export function CodeWorkspaceView({
                 onPickAttachments={pickComposerAttachments}
                 onListAttachmentEntries={listComposerAttachmentEntries}
                 onAction={handleAction}
+                onOpenGitOpsSurface={handleOpenGitOpsSurface}
                 onSetSurface={onSetComposerSurface}
               />
             </div>

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { AppShellController } from "../../app-shell/useAppShellController";
-import { Composer } from "../../components/workspace/Composer";
+import { Composer, type ComposerSurface } from "../../components/workspace/Composer";
 import { DiffPanel } from "../../components/workspace/DiffPanel";
 import { TerminalPanel } from "../../components/workspace/TerminalPanel";
-import { defaultDiffBaseline } from "../../components/workspace/composer/diff-baseline";
 import { buildDiffCommentPrompt } from "../../components/workspace/diff/diffCommentPrompt";
 import {
   type SavedDiffComment,
@@ -19,28 +18,31 @@ type CodeWorkspaceViewProps = {
   activeComposerState: AppShellController["activeComposerState"];
   activeThreadData: AppShellController["activeThreadData"];
   composerProjectId: string;
+  composerSurface: ComposerSurface;
   currentProjectName: string;
+  diffBaseline: ProjectDiffBaseline;
   dockedTerminalVisible: boolean;
   terminalSessionPath: string | null;
   workspaceContentClass: string;
+  onSetComposerSurface: (surface: ComposerSurface) => void;
+  onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
 };
 
 const WORKSPACE_FOOTER_OVERLAP_PX = 20;
-
-type ProjectScopedDiffBaseline = {
-  projectId: string;
-  baseline: ProjectDiffBaseline;
-};
 
 export function CodeWorkspaceView({
   controller,
   activeComposerState,
   activeThreadData,
   composerProjectId,
+  composerSurface,
   currentProjectName,
+  diffBaseline,
   dockedTerminalVisible,
   terminalSessionPath,
   workspaceContentClass,
+  onSetComposerSurface,
+  onSetDiffBaseline,
 }: CodeWorkspaceViewProps) {
   const [composerPromptResetKey, setComposerPromptResetKey] = useState(0);
   const [composerLayoutVersion, setComposerLayoutVersion] = useState(0);
@@ -52,10 +54,6 @@ export function CodeWorkspaceView({
   const [selectedDiffCommentJumpKey, setSelectedDiffCommentJumpKey] = useState(0);
   const [diffCommentsSending, setDiffCommentsSending] = useState(false);
   const [diffCommentError, setDiffCommentError] = useState<string | null>(null);
-  const [diffBaselineState, setDiffBaselineState] = useState<ProjectScopedDiffBaseline>({
-    projectId: composerProjectId,
-    baseline: defaultDiffBaseline,
-  });
   const footerContentRef = useRef<HTMLDivElement>(null);
   const {
     handleAction,
@@ -73,10 +71,6 @@ export function CodeWorkspaceView({
   } = controller;
   const showWorkspaceFooter = state.activeView === "thread";
   const showDiffInMainView = state.diffVisible && showWorkspaceFooter;
-  const diffBaseline =
-    diffBaselineState.projectId === composerProjectId
-      ? diffBaselineState.baseline
-      : defaultDiffBaseline;
   const footerInset = showWorkspaceFooter
     ? Math.max(footerHeight - WORKSPACE_FOOTER_OVERLAP_PX, 0)
     : 0;
@@ -84,19 +78,6 @@ export function CodeWorkspaceView({
     () => getDiffCommentContextId({ projectId: composerProjectId }),
     [composerProjectId],
   );
-
-  useEffect(() => {
-    setDiffBaselineState((current) => {
-      if (current.projectId === composerProjectId && current.baseline.kind === "head") {
-        return current;
-      }
-
-      return {
-        projectId: composerProjectId,
-        baseline: defaultDiffBaseline,
-      };
-    });
-  }, [composerProjectId]);
 
   useLayoutEffect(() => {
     const footerContent = footerContentRef.current;
@@ -158,6 +139,7 @@ export function CodeWorkspaceView({
     setDiffCommentsSending(true);
     setDiffCommentError(null);
     setSelectedDiffCommentId(null);
+    onSetComposerSurface("prompt");
     setComposerPromptResetKey((current) => current + 1);
 
     try {
@@ -210,6 +192,7 @@ export function CodeWorkspaceView({
                   preferredProjectLocation: null,
                   initializeGitOnProjectCreate: false,
                   useAgentsSkillsPaths: false,
+                  piTuiTakeover: false,
                 }
               }
               availableModels={activeComposerState?.availableModels ?? []}
@@ -262,12 +245,8 @@ export function CodeWorkspaceView({
                 diffCommentCount={diffCommentCount}
                 diffCommentsSending={diffCommentsSending}
                 diffCommentError={diffCommentError}
-                onSetDiffBaseline={(baseline) => {
-                  setDiffBaselineState({
-                    projectId: composerProjectId,
-                    baseline,
-                  });
-                }}
+                surface={composerSurface}
+                onSetDiffBaseline={onSetDiffBaseline}
                 onSetDiffRenderMode={setDiffRenderMode}
                 onSendDiffComments={(message) => {
                   void handleSendDiffComments(message);
@@ -285,6 +264,7 @@ export function CodeWorkspaceView({
                 onPickAttachments={pickComposerAttachments}
                 onListAttachmentEntries={listComposerAttachmentEntries}
                 onAction={handleAction}
+                onSetSurface={onSetComposerSurface}
               />
             </div>
             {dockedTerminalVisible ? (
@@ -294,7 +274,6 @@ export function CodeWorkspaceView({
                   sessionPath={terminalSessionPath}
                   onClose={handleToggleTerminal}
                   mode="docked"
-                  onAction={handleAction}
                 />
               </div>
             ) : null}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -59,7 +59,6 @@ export function CodeWorkspaceView({
     handleAction,
     handleLoadEarlierMessages,
     handleOpenDiffSelection,
-    handleOpenGitOpsSurface,
     handleOpenWorktreeDiffFile,
     handleShowTakeoverTerminal,
     handleToggleDiff,
@@ -265,7 +264,6 @@ export function CodeWorkspaceView({
                 onPickAttachments={pickComposerAttachments}
                 onListAttachmentEntries={listComposerAttachmentEntries}
                 onAction={handleAction}
-                onOpenGitOpsSurface={handleOpenGitOpsSurface}
                 onSetSurface={onSetComposerSurface}
               />
             </div>

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { AppShellController } from "../../app-shell/useAppShellController";
 import { Composer } from "../../components/workspace/Composer";
 import { DiffPanel } from "../../components/workspace/DiffPanel";
+import { GitOpsComposerPanel } from "../../components/workspace/GitOpsComposerPanel";
 import { TerminalPanel } from "../../components/workspace/TerminalPanel";
 import { buildDiffCommentPrompt } from "../../components/workspace/diff/diffCommentPrompt";
 import {
@@ -18,7 +19,6 @@ type CodeWorkspaceViewProps = {
   activeComposerState: AppShellController["activeComposerState"];
   activeThreadData: AppShellController["activeThreadData"];
   composerProjectId: string;
-  composerOpenGitOpsRequestKey: number;
   currentProjectName: string;
   diffBaseline: ProjectDiffBaseline;
   dockedTerminalVisible: boolean;
@@ -34,7 +34,6 @@ export function CodeWorkspaceView({
   activeComposerState,
   activeThreadData,
   composerProjectId,
-  composerOpenGitOpsRequestKey,
   currentProjectName,
   diffBaseline,
   dockedTerminalVisible,
@@ -56,10 +55,11 @@ export function CodeWorkspaceView({
   const {
     handleAction,
     handleLoadEarlierMessages,
+    handleCloseGitOpsView,
     handleOpenDiffSelection,
+    handleOpenGitOpsView,
     handleOpenWorktreeDiffFile,
     handleShowTakeoverTerminal,
-    handleToggleDiff,
     handleToggleTerminal,
     listComposerAttachmentEntries,
     pickComposerAttachments,
@@ -67,8 +67,8 @@ export function CodeWorkspaceView({
     shellState,
     state,
   } = controller;
-  const showWorkspaceFooter = state.activeView === "thread";
-  const showDiffInMainView = state.diffVisible && showWorkspaceFooter;
+  const showWorkspaceFooter = state.activeView === "thread" || state.activeView === "gitops";
+  const showDiffInMainView = state.activeView === "gitops";
   const footerInset = showWorkspaceFooter
     ? Math.max(footerHeight - WORKSPACE_FOOTER_OVERLAP_PX, 0)
     : 0;
@@ -218,50 +218,68 @@ export function CodeWorkspaceView({
         <footer className="pointer-events-none absolute inset-x-0 bottom-0 z-10 px-5 pb-4">
           <div ref={footerContentRef} className="pointer-events-auto grid gap-2.5">
             <div className={workspaceContentClass}>
-              <Composer
-                activeView={state.activeView}
-                hostLabel={shellState?.availableHosts[0] ?? "Local"}
-                model={activeComposerState?.currentModel ?? null}
-                availableModels={activeComposerState?.availableModels ?? []}
-                thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
-                availableThinkingLevels={activeComposerState?.availableThinkingLevels ?? ["off"]}
-                projectId={composerProjectId}
-                projectGitState={projectGitState}
-                diffBaseline={diffBaseline}
-                sessionPath={terminalSessionPath}
-                favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
-                onSetDiffPanelVisible={(visible) => {
-                  if (visible === state.diffVisible) {
-                    return;
-                  }
-
-                  handleToggleDiff();
-                }}
-                diffRenderMode={diffRenderMode}
-                diffComments={diffComments}
-                diffCommentCount={diffCommentCount}
-                diffCommentsSending={diffCommentsSending}
-                diffCommentError={diffCommentError}
-                openGitOpsRequestKey={composerOpenGitOpsRequestKey}
-                onSetDiffBaseline={onSetDiffBaseline}
-                onSetDiffRenderMode={setDiffRenderMode}
-                onSendDiffComments={(message) => {
-                  void handleSendDiffComments(message);
-                }}
-                onSelectDiffComment={(filePath, commentId) => {
-                  setSelectedDiffCommentId(commentId);
-                  setSelectedDiffCommentJumpKey((current) => current + 1);
-                  handleOpenWorktreeDiffFile(filePath);
-                }}
-                promptResetKey={composerPromptResetKey}
-                onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
-                onOpenTakeoverTerminal={handleShowTakeoverTerminal}
-                onToggleTerminal={handleToggleTerminal}
-                terminalVisible={state.terminalVisible}
-                onPickAttachments={pickComposerAttachments}
-                onListAttachmentEntries={listComposerAttachmentEntries}
-                onAction={handleAction}
-              />
+              {state.activeView === "gitops" ? (
+                <GitOpsComposerPanel
+                  projectGitState={projectGitState}
+                  diffBaseline={diffBaseline}
+                  diffRenderMode={diffRenderMode}
+                  diffComments={diffComments}
+                  diffCommentCount={diffCommentCount}
+                  diffCommentsSending={diffCommentsSending}
+                  diffCommentError={diffCommentError}
+                  onSetDiffBaseline={onSetDiffBaseline}
+                  onSetDiffRenderMode={setDiffRenderMode}
+                  onSendDiffComments={(message) => {
+                    void handleSendDiffComments(message);
+                  }}
+                  onSelectDiffComment={(filePath, commentId) => {
+                    setSelectedDiffCommentId(commentId);
+                    setSelectedDiffCommentJumpKey((current) => current + 1);
+                    handleOpenWorktreeDiffFile(filePath);
+                  }}
+                  onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
+                  onAction={handleAction}
+                  onBack={handleCloseGitOpsView}
+                />
+              ) : (
+                <Composer
+                  activeView={state.activeView}
+                  hostLabel={shellState?.availableHosts[0] ?? "Local"}
+                  model={activeComposerState?.currentModel ?? null}
+                  availableModels={activeComposerState?.availableModels ?? []}
+                  thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
+                  availableThinkingLevels={activeComposerState?.availableThinkingLevels ?? ["off"]}
+                  projectId={composerProjectId}
+                  projectGitState={projectGitState}
+                  diffBaseline={diffBaseline}
+                  sessionPath={terminalSessionPath}
+                  favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
+                  diffRenderMode={diffRenderMode}
+                  diffComments={diffComments}
+                  diffCommentCount={diffCommentCount}
+                  diffCommentsSending={diffCommentsSending}
+                  diffCommentError={diffCommentError}
+                  onSetDiffBaseline={onSetDiffBaseline}
+                  onSetDiffRenderMode={setDiffRenderMode}
+                  onSendDiffComments={(message) => {
+                    void handleSendDiffComments(message);
+                  }}
+                  onSelectDiffComment={(filePath, commentId) => {
+                    setSelectedDiffCommentId(commentId);
+                    setSelectedDiffCommentJumpKey((current) => current + 1);
+                    handleOpenWorktreeDiffFile(filePath);
+                  }}
+                  promptResetKey={composerPromptResetKey}
+                  onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
+                  onOpenTakeoverTerminal={handleShowTakeoverTerminal}
+                  onOpenGitOpsView={handleOpenGitOpsView}
+                  onToggleTerminal={handleToggleTerminal}
+                  terminalVisible={state.terminalVisible}
+                  onPickAttachments={pickComposerAttachments}
+                  onListAttachmentEntries={listComposerAttachmentEntries}
+                  onAction={handleAction}
+                />
+              )}
             </div>
             {dockedTerminalVisible ? (
               <div className={workspaceContentClass}>

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -199,7 +199,7 @@ describe("workspace state", () => {
     expect(nextState.takeoverVisible).toBe(false);
   });
 
-  it("can explicitly control docked terminal and takeover visibility", () => {
+  it("can explicitly control docked terminal, takeover, and composer surface", () => {
     const state = createInitialWorkspaceState(mockProjects);
     const withDockedTerminal = workspaceReducer(state, {
       type: "set-terminal-visible",
@@ -212,9 +212,14 @@ describe("workspace state", () => {
       },
       { type: "set-takeover-visible", visible: false },
     );
+    const withGitOpsSurface = workspaceReducer(withoutTakeover, {
+      type: "set-composer-surface",
+      surface: "git-ops",
+    });
 
     expect(withDockedTerminal.terminalVisible).toBe(true);
     expect(withoutTakeover.takeoverVisible).toBe(false);
+    expect(withGitOpsSurface.composerSurface).toBe("git-ops");
   });
 
   it("resolves fallback project and thread titles safely", () => {

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -199,6 +199,24 @@ describe("workspace state", () => {
     expect(nextState.takeoverVisible).toBe(false);
   });
 
+  it("can explicitly control docked terminal and takeover visibility", () => {
+    const state = createInitialWorkspaceState(mockProjects);
+    const withDockedTerminal = workspaceReducer(state, {
+      type: "set-terminal-visible",
+      visible: true,
+    });
+    const withoutTakeover = workspaceReducer(
+      {
+        ...withDockedTerminal,
+        takeoverVisible: true,
+      },
+      { type: "set-takeover-visible", visible: false },
+    );
+
+    expect(withDockedTerminal.terminalVisible).toBe(true);
+    expect(withoutTakeover.takeoverVisible).toBe(false);
+  });
+
   it("resolves fallback project and thread titles safely", () => {
     const project = selectProject(mockProjects, "missing-project");
     const thread = selectThread(project, "missing-thread");

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -84,14 +84,14 @@ describe("workspace state", () => {
     expect(nextState.selectedProjectId).toBe("claw-phone");
   });
 
-  it("can open the diff panel with a selected turn and file", () => {
+  it("can open git ops with a selected turn and file", () => {
     const nextState = workspaceReducer(createInitialWorkspaceState(mockProjects), {
-      type: "open-diff",
+      type: "open-gitops",
       checkpointTurnCount: 3,
       filePath: "src/app/AppShell.tsx",
     });
 
-    expect(nextState.diffVisible).toBe(true);
+    expect(nextState.activeView).toBe("gitops");
     expect(nextState.selectedDiffTurnCount).toBe(3);
     expect(nextState.selectedDiffFilePath).toBe("src/app/AppShell.tsx");
   });
@@ -224,6 +224,7 @@ describe("workspace state", () => {
     expect(getProjectName(project)).toBe("pi-plugin-codex");
     expect(thread).toBeUndefined();
     expect(getCurrentTitle("thread", thread)).toBe("New thread");
+    expect(getCurrentTitle("gitops", thread)).toBe("Git ops");
     expect(getCurrentTitle("code", thread)).toBe("New thread");
   });
 });

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -199,7 +199,7 @@ describe("workspace state", () => {
     expect(nextState.takeoverVisible).toBe(false);
   });
 
-  it("can explicitly control docked terminal, takeover, and composer surface", () => {
+  it("can explicitly control docked terminal and takeover visibility", () => {
     const state = createInitialWorkspaceState(mockProjects);
     const withDockedTerminal = workspaceReducer(state, {
       type: "set-terminal-visible",
@@ -212,14 +212,9 @@ describe("workspace state", () => {
       },
       { type: "set-takeover-visible", visible: false },
     );
-    const withGitOpsSurface = workspaceReducer(withoutTakeover, {
-      type: "set-composer-surface",
-      surface: "git-ops",
-    });
 
     expect(withDockedTerminal.terminalVisible).toBe(true);
     expect(withoutTakeover.takeoverVisible).toBe(false);
-    expect(withGitOpsSurface.composerSurface).toBe("git-ops");
   });
 
   it("resolves fallback project and thread titles safely", () => {

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -217,6 +217,23 @@ describe("workspace state", () => {
     expect(withoutTakeover.takeoverVisible).toBe(false);
   });
 
+  it("can store and clear per-session takeover overrides", () => {
+    const state = createInitialWorkspaceState(mockProjects);
+    const withOverride = workspaceReducer(state, {
+      type: "set-session-takeover-override",
+      sessionPath: "/tmp/thread.jsonl",
+      visible: true,
+    });
+    const withoutOverride = workspaceReducer(withOverride, {
+      type: "set-session-takeover-override",
+      sessionPath: "/tmp/thread.jsonl",
+      visible: null,
+    });
+
+    expect(withOverride.takeoverOverrides["/tmp/thread.jsonl"]).toBe(true);
+    expect(withoutOverride.takeoverOverrides["/tmp/thread.jsonl"]).toBeUndefined();
+  });
+
   it("resolves fallback project and thread titles safely", () => {
     const project = selectProject(mockProjects, "missing-project");
     const thread = selectThread(project, "missing-thread");

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -25,8 +25,10 @@ export type WorkspaceAction =
   | { type: "set-selected-project"; projectId: string }
   | { type: "open-thread"; projectId: string; threadId: string; sessionPath: string }
   | { type: "toggle-terminal" }
+  | { type: "set-terminal-visible"; visible: boolean }
   | { type: "show-takeover" }
   | { type: "hide-takeover" }
+  | { type: "set-takeover-visible"; visible: boolean }
   | { type: "toggle-diff" }
   | { type: "open-diff"; checkpointTurnCount: number | null; filePath?: string | null }
   | { type: "set-diff-turn"; checkpointTurnCount: number | null }
@@ -104,6 +106,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedSessionPath: action.view === "thread" ? state.selectedSessionPath : null,
         selectedDiffTurnCount: action.view === "thread" ? state.selectedDiffTurnCount : null,
         selectedDiffFilePath: action.view === "thread" ? state.selectedDiffFilePath : null,
+        takeoverVisible: action.view === "thread" ? state.takeoverVisible : false,
       };
     case "select-inbox-thread":
       return {
@@ -119,6 +122,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedSessionPath: null,
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
+        takeoverVisible: false,
       };
     case "set-selected-project":
       return {
@@ -141,10 +145,14 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
       };
     case "toggle-terminal":
       return { ...state, terminalVisible: !state.terminalVisible };
+    case "set-terminal-visible":
+      return { ...state, terminalVisible: action.visible };
     case "show-takeover":
       return { ...state, takeoverVisible: true };
     case "hide-takeover":
       return { ...state, takeoverVisible: false };
+    case "set-takeover-visible":
+      return { ...state, takeoverVisible: action.visible };
     case "toggle-diff":
       return { ...state, diffVisible: !state.diffVisible };
     case "open-diff":

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -10,6 +10,7 @@ export type WorkspaceState = {
   selectedSessionPath: string | null;
   terminalVisible: boolean;
   takeoverVisible: boolean;
+  takeoverOverrides: Record<string, boolean>;
   gitOpsReturnView: NonGitOpsView;
   selectedDiffTurnCount: number | null;
   selectedDiffFilePath: string | null;
@@ -38,6 +39,7 @@ export type WorkspaceAction =
   | { type: "show-takeover" }
   | { type: "hide-takeover" }
   | { type: "set-takeover-visible"; visible: boolean }
+  | { type: "set-session-takeover-override"; sessionPath: string; visible: boolean | null }
   | { type: "set-diff-turn"; checkpointTurnCount: number | null }
   | { type: "toggle-settings" }
   | { type: "set-settings-panel-open"; open: boolean }
@@ -66,6 +68,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     selectedSessionPath: null,
     terminalVisible: false,
     takeoverVisible: false,
+    takeoverOverrides: {},
     gitOpsReturnView: "code",
     selectedDiffTurnCount: null,
     selectedDiffFilePath: null,
@@ -191,6 +194,24 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
       return { ...state, takeoverVisible: false };
     case "set-takeover-visible":
       return { ...state, takeoverVisible: action.visible };
+    case "set-session-takeover-override": {
+      if (action.visible === null) {
+        const { [action.sessionPath]: _removedOverride, ...remainingOverrides } =
+          state.takeoverOverrides;
+        return {
+          ...state,
+          takeoverOverrides: remainingOverrides,
+        };
+      }
+
+      return {
+        ...state,
+        takeoverOverrides: {
+          ...state.takeoverOverrides,
+          [action.sessionPath]: action.visible,
+        },
+      };
+    }
     case "set-diff-turn":
       return {
         ...state,

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -1,5 +1,7 @@
 import type { Project, Thread, View } from "../types";
 
+type NonGitOpsView = Exclude<View, "gitops">;
+
 export type WorkspaceState = {
   activeView: View;
   selectedProjectId: string;
@@ -8,7 +10,7 @@ export type WorkspaceState = {
   selectedSessionPath: string | null;
   terminalVisible: boolean;
   takeoverVisible: boolean;
-  diffVisible: boolean;
+  gitOpsReturnView: NonGitOpsView;
   selectedDiffTurnCount: number | null;
   selectedDiffFilePath: string | null;
   settingsOpen: boolean;
@@ -19,24 +21,37 @@ export type WorkspaceState = {
 
 export type WorkspaceAction =
   | { type: "sync-projects"; projects: Project[] }
-  | { type: "show-view"; view: View }
+  | { type: "show-view"; view: NonGitOpsView }
   | { type: "select-inbox-thread"; sessionPath: string | null }
   | { type: "select-project"; projectId: string }
   | { type: "set-selected-project"; projectId: string }
   | { type: "open-thread"; projectId: string; threadId: string; sessionPath: string }
+  | {
+      type: "open-gitops";
+      checkpointTurnCount: number | null;
+      filePath?: string | null;
+      returnView?: NonGitOpsView;
+    }
+  | { type: "close-gitops" }
   | { type: "toggle-terminal" }
   | { type: "set-terminal-visible"; visible: boolean }
   | { type: "show-takeover" }
   | { type: "hide-takeover" }
   | { type: "set-takeover-visible"; visible: boolean }
-  | { type: "toggle-diff" }
-  | { type: "open-diff"; checkpointTurnCount: number | null; filePath?: string | null }
   | { type: "set-diff-turn"; checkpointTurnCount: number | null }
   | { type: "toggle-settings" }
   | { type: "set-settings-panel-open"; open: boolean }
   | { type: "set-archived-threads-open"; open: boolean }
   | { type: "toggle-project-collapse"; projectId: string }
   | { type: "collapse-all-projects" };
+
+function getGitOpsReturnView(activeView: View, fallback: NonGitOpsView): NonGitOpsView {
+  if (activeView === "gitops") {
+    return fallback;
+  }
+
+  return activeView;
+}
 
 // The collapsed map is derived once from project metadata so the tree interaction
 // stays deterministic even before we add persisted desktop state.
@@ -51,7 +66,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     selectedSessionPath: null,
     terminalVisible: false,
     takeoverVisible: false,
-    diffVisible: false,
+    gitOpsReturnView: "code",
     selectedDiffTurnCount: null,
     selectedDiffFilePath: null,
     settingsOpen: false,
@@ -95,6 +110,8 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
           hasSelectedProject || !state.selectedProjectId ? state.selectedDiffTurnCount : null,
         selectedDiffFilePath:
           hasSelectedProject || !state.selectedProjectId ? state.selectedDiffFilePath : null,
+        gitOpsReturnView:
+          hasSelectedProject || !state.selectedProjectId ? state.gitOpsReturnView : "code",
         collapsedProjectIds,
       };
     }
@@ -123,6 +140,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
         takeoverVisible: false,
+        gitOpsReturnView: "code",
       };
     case "set-selected-project":
       return {
@@ -138,10 +156,30 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedSessionPath: action.sessionPath,
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
+        gitOpsReturnView: "thread",
         collapsedProjectIds: {
           ...state.collapsedProjectIds,
           [action.projectId]: false,
         },
+      };
+    case "open-gitops":
+      return {
+        ...state,
+        activeView: "gitops",
+        takeoverVisible: false,
+        gitOpsReturnView:
+          action.returnView ?? getGitOpsReturnView(state.activeView, state.gitOpsReturnView),
+        selectedDiffTurnCount: action.checkpointTurnCount,
+        selectedDiffFilePath: action.filePath ?? null,
+      };
+    case "close-gitops":
+      return {
+        ...state,
+        activeView: state.gitOpsReturnView,
+        selectedThreadId: state.gitOpsReturnView === "thread" ? state.selectedThreadId : null,
+        selectedSessionPath: state.gitOpsReturnView === "thread" ? state.selectedSessionPath : null,
+        selectedDiffTurnCount: null,
+        selectedDiffFilePath: null,
       };
     case "toggle-terminal":
       return { ...state, terminalVisible: !state.terminalVisible };
@@ -153,15 +191,6 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
       return { ...state, takeoverVisible: false };
     case "set-takeover-visible":
       return { ...state, takeoverVisible: action.visible };
-    case "toggle-diff":
-      return { ...state, diffVisible: !state.diffVisible };
-    case "open-diff":
-      return {
-        ...state,
-        diffVisible: true,
-        selectedDiffTurnCount: action.checkpointTurnCount,
-        selectedDiffFilePath: action.filePath ?? null,
-      };
     case "set-diff-turn":
       return {
         ...state,
@@ -220,6 +249,10 @@ export function selectThread(
 }
 
 export function getCurrentTitle(activeView: View, selectedThread: Thread | undefined): string {
+  if (activeView === "gitops") {
+    return "Git ops";
+  }
+
   return activeView === "thread" && selectedThread ? selectedThread.title : "New thread";
 }
 

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -8,6 +8,7 @@ export type WorkspaceState = {
   selectedSessionPath: string | null;
   terminalVisible: boolean;
   takeoverVisible: boolean;
+  composerSurface: "prompt" | "git-ops";
   diffVisible: boolean;
   selectedDiffTurnCount: number | null;
   selectedDiffFilePath: string | null;
@@ -29,6 +30,7 @@ export type WorkspaceAction =
   | { type: "show-takeover" }
   | { type: "hide-takeover" }
   | { type: "set-takeover-visible"; visible: boolean }
+  | { type: "set-composer-surface"; surface: "prompt" | "git-ops" }
   | { type: "toggle-diff" }
   | { type: "open-diff"; checkpointTurnCount: number | null; filePath?: string | null }
   | { type: "set-diff-turn"; checkpointTurnCount: number | null }
@@ -51,6 +53,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     selectedSessionPath: null,
     terminalVisible: false,
     takeoverVisible: false,
+    composerSurface: "prompt",
     diffVisible: false,
     selectedDiffTurnCount: null,
     selectedDiffFilePath: null,
@@ -107,6 +110,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedDiffTurnCount: action.view === "thread" ? state.selectedDiffTurnCount : null,
         selectedDiffFilePath: action.view === "thread" ? state.selectedDiffFilePath : null,
         takeoverVisible: action.view === "thread" ? state.takeoverVisible : false,
+        composerSurface: action.view === "thread" ? state.composerSurface : "prompt",
       };
     case "select-inbox-thread":
       return {
@@ -123,6 +127,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
         takeoverVisible: false,
+        composerSurface: "prompt",
       };
     case "set-selected-project":
       return {
@@ -138,6 +143,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedSessionPath: action.sessionPath,
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
+        composerSurface: "prompt",
         collapsedProjectIds: {
           ...state.collapsedProjectIds,
           [action.projectId]: false,
@@ -153,6 +159,8 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
       return { ...state, takeoverVisible: false };
     case "set-takeover-visible":
       return { ...state, takeoverVisible: action.visible };
+    case "set-composer-surface":
+      return { ...state, composerSurface: action.surface };
     case "toggle-diff":
       return { ...state, diffVisible: !state.diffVisible };
     case "open-diff":

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -8,7 +8,6 @@ export type WorkspaceState = {
   selectedSessionPath: string | null;
   terminalVisible: boolean;
   takeoverVisible: boolean;
-  composerSurface: "prompt" | "git-ops";
   diffVisible: boolean;
   selectedDiffTurnCount: number | null;
   selectedDiffFilePath: string | null;
@@ -30,7 +29,6 @@ export type WorkspaceAction =
   | { type: "show-takeover" }
   | { type: "hide-takeover" }
   | { type: "set-takeover-visible"; visible: boolean }
-  | { type: "set-composer-surface"; surface: "prompt" | "git-ops" }
   | { type: "toggle-diff" }
   | { type: "open-diff"; checkpointTurnCount: number | null; filePath?: string | null }
   | { type: "set-diff-turn"; checkpointTurnCount: number | null }
@@ -53,7 +51,6 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     selectedSessionPath: null,
     terminalVisible: false,
     takeoverVisible: false,
-    composerSurface: "prompt",
     diffVisible: false,
     selectedDiffTurnCount: null,
     selectedDiffFilePath: null,
@@ -110,7 +107,6 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedDiffTurnCount: action.view === "thread" ? state.selectedDiffTurnCount : null,
         selectedDiffFilePath: action.view === "thread" ? state.selectedDiffFilePath : null,
         takeoverVisible: action.view === "thread" ? state.takeoverVisible : false,
-        composerSurface: action.view === "thread" ? state.composerSurface : "prompt",
       };
     case "select-inbox-thread":
       return {
@@ -127,7 +123,6 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
         takeoverVisible: false,
-        composerSurface: "prompt",
       };
     case "set-selected-project":
       return {
@@ -143,7 +138,6 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedSessionPath: action.sessionPath,
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
-        composerSurface: "prompt",
         collapsedProjectIds: {
           ...state.collapsedProjectIds,
           [action.projectId]: false,
@@ -159,8 +153,6 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
       return { ...state, takeoverVisible: false };
     case "set-takeover-visible":
       return { ...state, takeoverVisible: action.visible };
-    case "set-composer-surface":
-      return { ...state, composerSurface: action.surface };
     case "toggle-diff":
       return { ...state, diffVisible: !state.diffVisible };
     case "open-diff":

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -12,6 +12,7 @@ export type View =
   | "inbox"
   | "code"
   | "thread"
+  | "gitops"
   | "chat"
   | "claw"
   | "work"

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -29,7 +29,7 @@ export function SettingsView({
     <ViewShell maxWidthClassName="max-w-[760px]">
       <ViewHeader
         title="App settings"
-        subtitle="Git commit model, skill creator model, project UI import, and favorite folders."
+        subtitle="Git commit model, skill creator model, Pi TUI defaults, project UI import, and favorite folders."
       />
 
       <SettingsModelSection
@@ -61,6 +61,7 @@ export function SettingsView({
         savePreferredProjectLocation={controller.savePreferredProjectLocation}
         setPreferredProjectLocationDraft={controller.setPreferredProjectLocationDraft}
         toggleInitializeGitOnProjectCreate={controller.toggleInitializeGitOnProjectCreate}
+        togglePiTuiTakeover={controller.togglePiTuiTakeover}
       />
 
       <SettingsProjectImportSection

--- a/src/app/views/settings/SettingsProjectDefaultsSection.tsx
+++ b/src/app/views/settings/SettingsProjectDefaultsSection.tsx
@@ -11,12 +11,14 @@ export function SettingsProjectDefaultsSection({
   savePreferredProjectLocation,
   setPreferredProjectLocationDraft,
   toggleInitializeGitOnProjectCreate,
+  togglePiTuiTakeover,
 }: {
   appSettings: AppSettings;
   preferredProjectLocationDraft: string;
   savePreferredProjectLocation: () => void;
   setPreferredProjectLocationDraft: Dispatch<SetStateAction<string>>;
   toggleInitializeGitOnProjectCreate: () => void;
+  togglePiTuiTakeover: () => void;
 }) {
   const preferredProjectLocationMissing = !appSettings.preferredProjectLocation;
 
@@ -31,8 +33,8 @@ export function SettingsProjectDefaultsSection({
       )}
     >
       <SectionIntro
-        title="New projects"
-        description="Set where new projects are created and whether git should be initialised for diffs."
+        title="Defaults"
+        description="Set project creation defaults and whether conversations should open in Pi TUI by default."
       />
 
       <div className="grid gap-2">
@@ -78,6 +80,29 @@ export function SettingsProjectDefaultsSection({
             onClick={toggleInitializeGitOnProjectCreate}
             aria-label="Initialise git for new projects"
             aria-pressed={appSettings.initializeGitOnProjectCreate}
+          >
+            <Check size={13} />
+          </button>
+        </div>
+
+        <div className={settingsListRowClass}>
+          <div className="grid gap-0.5">
+            <div className="text-[13px] text-[color:var(--text)]">Open conversations in Pi TUI</div>
+            <div className="text-[12px] text-[color:var(--muted)]">
+              Uses Pi takeover by default until a conversation is overridden for this app session.
+            </div>
+          </div>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex h-5 w-5 items-center justify-center rounded-md border transition-colors",
+              appSettings.piTuiTakeover
+                ? "border-[color:var(--accent)] bg-[color:var(--accent)] text-[#1a1c26]"
+                : "border-[color:var(--border)] bg-transparent text-transparent hover:border-[color:var(--border-strong)]",
+            )}
+            onClick={togglePiTuiTakeover}
+            aria-label="Open conversations in Pi TUI"
+            aria-pressed={appSettings.piTuiTakeover}
           >
             <Check size={13} />
           </button>

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -152,6 +152,11 @@ export function useSettingsController({
         key: "initializeGitOnProjectCreate",
         value: !appSettings.initializeGitOnProjectCreate,
       }),
+    togglePiTuiTakeover: () =>
+      void onAction("settings.update", {
+        key: "piTuiTakeover",
+        value: !appSettings.piTuiTakeover,
+      }),
     updateFavoriteFolders,
     handleImportProjectUi,
     showFirstLaunchReminderAgain: () =>

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -30,6 +30,25 @@
   border-radius: 10px;
 }
 
+/* Public CSS fallback in case xterm internal scrollbar visibility hooks change. */
+.terminal-viewport .xterm-viewport {
+  overflow-y: scroll !important;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+}
+
+.terminal-viewport .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.terminal-viewport .xterm-viewport::-webkit-scrollbar-thumb {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: rgba(140, 148, 181, 0.22);
+  background-clip: padding-box;
+}
+
 .terminal-viewport--flush .xterm-viewport,
 .terminal-viewport--flush .xterm-screen {
   border-radius: 0;

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -25,6 +25,20 @@
 
 .terminal-viewport .xterm-viewport {
   overflow-y: scroll !important;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+}
+
+.terminal-viewport .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.terminal-viewport .xterm-viewport::-webkit-scrollbar-thumb {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: rgba(140, 148, 181, 0.22);
+  background-clip: padding-box;
 }
 
 .terminal-viewport--flush .xterm-viewport,

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -11,6 +11,13 @@
   padding: 0;
 }
 
+.terminal-viewport--flush,
+.terminal-viewport--flush .xterm,
+.terminal-viewport--flush .xterm-viewport,
+.terminal-viewport--flush .xterm-screen {
+  border-radius: 0;
+}
+
 .terminal-viewport .xterm-viewport,
 .terminal-viewport .xterm-screen {
   border-radius: 10px;
@@ -22,7 +29,7 @@
 
 .terminal-viewport--flush .xterm-viewport,
 .terminal-viewport--flush .xterm-screen {
-  border-radius: 16px 16px 0 0;
+  border-radius: 0;
 }
 
 .xterm-viewport {

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -8,7 +8,8 @@
 }
 
 .terminal-viewport--flush .xterm {
-  padding: 0;
+  padding: 0 0 0 14px;
+  background-color: var(--terminal-bg);
 }
 
 .terminal-viewport--flush,
@@ -21,39 +22,6 @@
 .terminal-viewport .xterm-viewport,
 .terminal-viewport .xterm-screen {
   border-radius: 10px;
-}
-
-.terminal-viewport .xterm-viewport {
-  overflow-y: scroll !important;
-  scrollbar-gutter: stable;
-  scrollbar-width: auto;
-}
-
-.terminal-viewport .xterm-viewport::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-
-.terminal-viewport .xterm-viewport::-webkit-scrollbar-thumb {
-  border: 1px solid transparent;
-  border-radius: 999px;
-  background: rgba(140, 148, 181, 0.22);
-  background-clip: padding-box;
-}
-
-.terminal-viewport .xterm-scrollable-element > .visible,
-.terminal-viewport .xterm-scrollable-element > .invisible {
-  opacity: 1;
-  pointer-events: auto;
-  transition: none;
-}
-
-.terminal-viewport .xterm-scrollable-element > .scrollbar {
-  z-index: 12;
-}
-
-.terminal-viewport .xterm-scrollable-element > .scrollbar > .slider {
-  opacity: 1;
 }
 
 .terminal-viewport--flush .xterm-viewport,

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -9,13 +9,13 @@
 
 .terminal-viewport--flush .xterm {
   padding: 0 0 0 14px;
-  background-color: var(--terminal-bg);
+  background-color: var(--workspace);
 }
 
 .terminal-viewport--flush .xterm-viewport,
 .terminal-viewport--flush .xterm-screen,
 .terminal-viewport--flush .xterm-scrollable-element {
-  background-color: var(--terminal-bg) !important;
+  background-color: var(--workspace) !important;
 }
 
 .terminal-viewport--flush,

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -12,6 +12,12 @@
   background-color: var(--terminal-bg);
 }
 
+.terminal-viewport--flush .xterm-viewport,
+.terminal-viewport--flush .xterm-screen,
+.terminal-viewport--flush .xterm-scrollable-element {
+  background-color: var(--terminal-bg) !important;
+}
+
 .terminal-viewport--flush,
 .terminal-viewport--flush .xterm,
 .terminal-viewport--flush .xterm-viewport,

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -41,6 +41,21 @@
   background-clip: padding-box;
 }
 
+.terminal-viewport .xterm-scrollable-element > .visible,
+.terminal-viewport .xterm-scrollable-element > .invisible {
+  opacity: 1;
+  pointer-events: auto;
+  transition: none;
+}
+
+.terminal-viewport .xterm-scrollable-element > .scrollbar {
+  z-index: 12;
+}
+
+.terminal-viewport .xterm-scrollable-element > .scrollbar > .slider {
+  opacity: 1;
+}
+
 .terminal-viewport--flush .xterm-viewport,
 .terminal-viewport--flush .xterm-screen {
   border-radius: 0;

--- a/src/test/controller-post-action-effects.test.ts
+++ b/src/test/controller-post-action-effects.test.ts
@@ -22,6 +22,7 @@ function buildShellState(): ShellState {
       preferredProjectLocation: null,
       initializeGitOnProjectCreate: false,
       useAgentsSkillsPaths: false,
+      piTuiTakeover: false,
     },
     availableHosts: [],
     composer: {
@@ -145,6 +146,17 @@ describe("controller post action effects", () => {
     ).toMatchObject({
       appSettings: {
         useAgentsSkillsPaths: true,
+      },
+    });
+
+    expect(
+      getOptimisticallyUpdatedShellState(buildShellState(), {
+        key: "piTuiTakeover",
+        value: true,
+      }),
+    ).toMatchObject({
+      appSettings: {
+        piTuiTakeover: true,
       },
     });
   });

--- a/src/test/controller-view-model.test.ts
+++ b/src/test/controller-view-model.test.ts
@@ -29,7 +29,6 @@ describe("deriveControllerViewModel", () => {
         selectedSessionPath: "/repo/session.json",
         terminalVisible: false,
         takeoverVisible: false,
-        composerSurface: "prompt",
         diffVisible: false,
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,

--- a/src/test/controller-view-model.test.ts
+++ b/src/test/controller-view-model.test.ts
@@ -29,7 +29,7 @@ describe("deriveControllerViewModel", () => {
         selectedSessionPath: "/repo/session.json",
         terminalVisible: false,
         takeoverVisible: false,
-        diffVisible: false,
+        gitOpsReturnView: "code",
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
         settingsOpen: false,

--- a/src/test/controller-view-model.test.ts
+++ b/src/test/controller-view-model.test.ts
@@ -29,6 +29,7 @@ describe("deriveControllerViewModel", () => {
         selectedSessionPath: "/repo/session.json",
         terminalVisible: false,
         takeoverVisible: false,
+        takeoverOverrides: {},
         gitOpsReturnView: "code",
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,

--- a/src/test/controller-view-model.test.ts
+++ b/src/test/controller-view-model.test.ts
@@ -29,6 +29,7 @@ describe("deriveControllerViewModel", () => {
         selectedSessionPath: "/repo/session.json",
         terminalVisible: false,
         takeoverVisible: false,
+        composerSurface: "prompt",
         diffVisible: false,
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,


### PR DESCRIPTION
## Summary

This PR narrows the scope to the Pi takeover experience and the git ops/diff flow.

It does two main things:

1. **Refreshes the Pi takeover UI** so it matches the current desktop app more closely.
2. **Decouples git ops from the prompt composer** by making git ops a dedicated workspace view with its own composer panel.

## Problem

The current desktop branch had regressed compared to `main`:

- the **git ops button could flash open and immediately fall back** to the regular thread/chat view
- the **Pi takeover git ops handoff** was especially fragile
- the existing implementation effectively tied git ops to a **composer-local surface toggle**, which made it hard to enter git ops reliably from takeover or from other parts of the app

That coupling made the flow feel stateful in the wrong place.

## What changed

### Pi takeover

- updated the takeover footer to align with the current composer/desktop UI language
- bottom row now uses the expected action structure:
  - `Desktop`
  - `Terminal`
  - RHS git controls
- RHS order is now:
  1. diff numbers / baseline selector
  2. branch chip
  3. git ops button
- added a **5 minute keepalive** for the Pi TUI terminal session after leaving takeover
- persisted the simple Pi takeover preference in app settings (`piTuiTakeover`)

### Git ops / diff separation

- introduced a dedicated **`gitops` workspace view**
- git ops is no longer a prompt-composer mode that indirectly opens the diff panel
- added a dedicated git ops footer/composer panel:
  - `src/app/components/workspace/GitOpsComposerPanel.tsx`
- entering git ops now goes through an explicit workspace action/state transition instead of composer-local side effects
- git ops remembers the previous non-gitops view so the footer back action can return cleanly
- thread session context is preserved when entering git ops from a thread

### Navigation + state wiring

- updated workspace state to support `gitops` as a first-class view
- updated sidebar/thread selection behavior so the selected thread still reads correctly while git ops is active
- updated controller/effects logic so watched session, composer state, and git state refresh all work when `activeView === "gitops"`
- updated contextual action payloads so composer / workspace commit actions still carry the thread session path when launched from git ops

## Why this is better

This removes the old hidden dependency where:

- composer local state
- diff panel visibility
- takeover handoff

all had to stay implicitly synchronized.

Now git ops is a real workspace destination, which means we can enter it consistently from:

- the normal composer
- Pi takeover
- thread diff entry points
- future entry points elsewhere in the app

without hacking into prompt-composer internals.

## Testing

Validated via existing hooks and project checks triggered during commit/push:

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

Also manually verified during development:

- normal composer git ops entry
- Pi takeover -> git ops handoff
- git ops back navigation
- takeover terminal keepalive behavior

## Scope

This PR is specifically about **Pi takeover + git ops separation**.

It intentionally narrows the branch away from broader issue work so we can land the architectural fix cleanly.

Part of #16 and #17.
