### PR TITLE
Fix Pi takeover launch for new conversations

### DIFF
--- a/desktop/terminal/terminal-command.helpers.ts
+++ b/desktop/terminal/terminal-command.helpers.ts
@@ -1,5 +1,6 @@
 import { constants, accessSync } from "node:fs";
 import path from "node:path";
+import { getPersistedSessionPath } from "../../shared/session-paths";
 import type { TerminalOpenRequest } from "../../shared/terminal-contracts.ts";
 
 export function findExecutable(name: string, pathValue = process.env.PATH ?? "") {
@@ -31,6 +32,7 @@ export function resolveTerminalCommand(
   const env = options?.env ?? process.env;
 
   if (request.launchMode === "pi-session") {
+    const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
     const executable =
       platform === "win32"
         ? findExecutable("pi.cmd", env.PATH ?? "")
@@ -38,7 +40,7 @@ export function resolveTerminalCommand(
 
     return {
       shell: executable,
-      args: request.sessionPath ? ["--session", request.sessionPath] : ["--continue"],
+      args: persistedSessionPath ? ["--session", persistedSessionPath] : [],
     };
   }
 

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -1,7 +1,6 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
-import { getPersistedSessionPath } from "../../../../../shared/session-paths";
 import type { TerminalEvent } from "../../../desktop/types";
 import {
   closeDesktopTerminal,
@@ -133,9 +132,6 @@ export function TerminalViewport({
   const lastSizeRef = useRef<{ width: number; height: number; cols: number; rows: number } | null>(
     null,
   );
-  const persistedSessionPath = getPersistedSessionPath(sessionPath);
-  const effectiveLaunchMode =
-    launchMode === "pi-session" && !persistedSessionPath ? "shell" : launchMode;
 
   useEffect(() => {
     const mount = containerRef.current;
@@ -324,8 +320,8 @@ export function TerminalViewport({
       fitAddon.fit();
       const snapshot = await openDesktopTerminal({
         projectId,
-        sessionPath: persistedSessionPath,
-        launchMode: effectiveLaunchMode,
+        sessionPath,
+        launchMode,
         cols: Math.max(terminal.cols, 20),
         rows: Math.max(terminal.rows, 5),
       });
@@ -380,12 +376,12 @@ export function TerminalViewport({
       }
     };
   }, [
-    effectiveLaunchMode,
+    launchMode,
     keepAliveMsOnUnmount,
     backgroundCssVar,
-    persistedSessionPath,
     preserveSessionOnUnmount,
     projectId,
+    sessionPath,
   ]);
 
   return (

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -234,6 +234,30 @@ describe("workspace state", () => {
     expect(withoutOverride.takeoverOverrides["/tmp/thread.jsonl"]).toBeUndefined();
   });
 
+  it("migrates a takeover override from a local draft to the persisted thread session", () => {
+    const nextState = workspaceReducer(
+      {
+        ...createInitialWorkspaceState(mockProjects),
+        activeView: "thread",
+        selectedProjectId: "pi-plugin-codex",
+        selectedThreadId: "thread-1",
+        selectedSessionPath: "local://%2Frepo/draft",
+        takeoverOverrides: {
+          "local://%2Frepo/draft": false,
+        },
+      },
+      {
+        type: "open-thread",
+        projectId: "pi-plugin-codex",
+        threadId: "thread-1",
+        sessionPath: "/repo/.pi/thread-1.json",
+      },
+    );
+
+    expect(nextState.takeoverOverrides["local://%2Frepo/draft"]).toBeUndefined();
+    expect(nextState.takeoverOverrides["/repo/.pi/thread-1.json"]).toBe(false);
+  });
+
   it("resolves fallback project and thread titles safely", () => {
     const project = selectProject(mockProjects, "missing-project");
     const thread = selectThread(project, "missing-thread");

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -1,3 +1,4 @@
+import { isLocalSessionPath } from "../../../shared/session-paths";
 import type { Project, Thread, View } from "../types";
 
 type NonGitOpsView = Exclude<View, "gitops">;
@@ -46,6 +47,30 @@ export type WorkspaceAction =
   | { type: "set-archived-threads-open"; open: boolean }
   | { type: "toggle-project-collapse"; projectId: string }
   | { type: "collapse-all-projects" };
+
+function migrateTakeoverOverride(
+  takeoverOverrides: Record<string, boolean>,
+  fromSessionPath: string | null,
+  toSessionPath: string,
+) {
+  if (!fromSessionPath || fromSessionPath === toSessionPath) {
+    return takeoverOverrides;
+  }
+
+  if (!isLocalSessionPath(fromSessionPath) || isLocalSessionPath(toSessionPath)) {
+    return takeoverOverrides;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(takeoverOverrides, fromSessionPath)) {
+    return takeoverOverrides;
+  }
+
+  const { [fromSessionPath]: override, ...remainingOverrides } = takeoverOverrides;
+  return {
+    ...remainingOverrides,
+    [toSessionPath]: override,
+  };
+}
 
 function getGitOpsReturnView(activeView: View, fallback: NonGitOpsView): NonGitOpsView {
   if (activeView === "gitops") {
@@ -157,6 +182,14 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedProjectId: action.projectId,
         selectedThreadId: action.threadId,
         selectedSessionPath: action.sessionPath,
+        takeoverOverrides:
+          state.selectedThreadId === action.threadId
+            ? migrateTakeoverOverride(
+                state.takeoverOverrides,
+                state.selectedSessionPath,
+                action.sessionPath,
+              )
+            : state.takeoverOverrides,
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
         gitOpsReturnView: "thread",

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -182,14 +182,11 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedProjectId: action.projectId,
         selectedThreadId: action.threadId,
         selectedSessionPath: action.sessionPath,
-        takeoverOverrides:
-          state.selectedThreadId === action.threadId
-            ? migrateTakeoverOverride(
-                state.takeoverOverrides,
-                state.selectedSessionPath,
-                action.sessionPath,
-              )
-            : state.takeoverOverrides,
+        takeoverOverrides: migrateTakeoverOverride(
+          state.takeoverOverrides,
+          state.selectedSessionPath,
+          action.sessionPath,
+        ),
         selectedDiffTurnCount: null,
         selectedDiffFilePath: null,
         gitOpsReturnView: "thread",

--- a/src/test/terminal-command.helpers.test.ts
+++ b/src/test/terminal-command.helpers.test.ts
@@ -35,6 +35,19 @@ describe("terminal command helpers", () => {
     expect(
       resolveTerminalCommand(
         {
+          projectId: "/repo",
+          sessionPath: "local://%2Frepo/first",
+          launchMode: "pi-session",
+          cols: 80,
+          rows: 24,
+        },
+        { platform: "linux", env: { PATH: "" } as NodeJS.ProcessEnv },
+      ),
+    ).toEqual({ shell: "pi", args: [] });
+
+    expect(
+      resolveTerminalCommand(
+        {
           projectId: "C:/repo",
           launchMode: "shell",
           cols: 80,


### PR DESCRIPTION
## Summary
- launch Pi takeover directly into `pi` for brand-new conversations instead of falling back to a shell
- keep new-conversation takeover terminal sessions distinct while the thread is still a local draft
- migrate per-conversation takeover overrides from the local draft session path to the persisted session path

## Testing
- bun test src/test/terminal-command.helpers.test.ts src/app/state/workspace.test.ts
- pre-commit checks
- bun run lint && bun run typecheck && bun run test && bun run build