### PR TITLE
Implement composer queueing and stop behavior

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
     "lineWidth": 100
   },
   "organizeImports": {
-    "enabled": true
+    "enabled": false
   },
   "linter": {
     "enabled": true,

--- a/desktop/app-settings.cts
+++ b/desktop/app-settings.cts
@@ -1,5 +1,6 @@
 import type {
   AppSettings,
+  ComposerStreamingBehavior,
   ModelSelection,
   ProjectDeletionMode,
 } from "../shared/desktop-contracts.ts";
@@ -7,6 +8,7 @@ import { getThreadStateDatabase } from "./thread-state-db/db.cts";
 
 const gitCommitMessageModelKey = "gitCommitMessageModel";
 const skillCreatorModelKey = "skillCreatorModel";
+const composerStreamingBehaviorKey = "composerStreamingBehavior";
 const favoriteFoldersKey = "favoriteFolders";
 const projectImportStateKey = "projectImportState";
 const preferredProjectLocationKey = "preferredProjectLocation";
@@ -97,6 +99,21 @@ function parseProjectDeletionModePreference(
   }
 }
 
+function parseComposerStreamingBehaviorPreference(
+  valueJson: string | null | undefined,
+): ComposerStreamingBehavior | null {
+  if (!valueJson) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(valueJson) as unknown;
+    return parsed === "steer" || parsed === "followUp" || parsed === "stop" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 function writeAppPreference(key: string, valueJson: string) {
   const db = getThreadStateDatabase();
   db.prepare(
@@ -149,6 +166,15 @@ export function loadAppSettings(): AppSettings {
       `,
     )
     .get(skillCreatorModelKey) as PreferenceRow | undefined;
+  const composerStreamingBehaviorRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(composerStreamingBehaviorKey) as PreferenceRow | undefined;
   const projectImportStateRow = db
     .prepare(
       `
@@ -207,6 +233,9 @@ export function loadAppSettings(): AppSettings {
   return {
     gitCommitMessageModel: parseModelSelection(modelRow?.valueJson),
     skillCreatorModel: parseModelSelection(skillCreatorModelRow?.valueJson),
+    composerStreamingBehavior:
+      parseComposerStreamingBehaviorPreference(composerStreamingBehaviorRow?.valueJson) ??
+      "followUp",
     favoriteFolders: parseFavoriteFolders(favoriteFoldersRow?.valueJson),
     projectImportState: parseBooleanPreference(projectImportStateRow?.valueJson),
     preferredProjectLocation: parseStringPreference(preferredProjectLocationRow?.valueJson),
@@ -235,6 +264,10 @@ export function setSkillCreatorModelSelection(selection: ModelSelection | null) 
   }
 
   writeAppPreference(skillCreatorModelKey, JSON.stringify(selection));
+}
+
+export function setComposerStreamingBehavior(behavior: ComposerStreamingBehavior) {
+  writeAppPreference(composerStreamingBehaviorKey, JSON.stringify(behavior));
 }
 
 export function setFavoriteFolders(favoriteFolders: string[]) {

--- a/desktop/pi-desktop-runtime.cts
+++ b/desktop/pi-desktop-runtime.cts
@@ -1,4 +1,5 @@
 export {
+  dequeueComposerPrompt,
   getComposerState,
   getLiveThread,
   openThreadRuntime,
@@ -7,5 +8,6 @@ export {
   setComposerModel,
   setComposerThinkingLevel,
   startNewThread,
+  stopComposerRun,
   subscribeDesktopEvents,
 } from "./runtime/composer-service.cts";

--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -5,6 +5,7 @@ import {
   getComposerModelSelection,
   getComposerQueueId,
   getComposerQueueMode,
+  getComposerQueueSnapshotKey,
   getComposerRequest,
   getComposerStreamingBehavior,
   getComposerText,
@@ -64,14 +65,16 @@ export async function handleComposerDesktopAction(
     case "composer.dequeue": {
       const queueId = getComposerQueueId(payload);
       const queueMode = getComposerQueueMode(payload);
+      const queueSnapshotKey = getComposerQueueSnapshotKey(payload);
 
-      if (!queueId || !queueMode) {
+      if (!queueId || !queueMode || !queueSnapshotKey) {
         return handledAction();
       }
 
       const dequeuedText = await dequeueComposerPrompt({
         ...getComposerRequest(payload),
         queueId,
+        queueSnapshotKey,
         queueMode,
       });
 

--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -47,13 +47,13 @@ export async function handleComposerDesktopAction(
         return handledAction();
       }
 
-      await sendComposerPrompt({
+      const composerSendOutcome = await sendComposerPrompt({
         ...getComposerRequest(payload),
         text,
         attachments: getComposerAttachments(payload),
         streamingBehavior: getComposerStreamingBehavior(payload),
       });
-      return handledAction();
+      return handledAction({ composerSendOutcome });
     }
 
     case "composer.stop": {

--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -3,14 +3,19 @@ import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts"
 import {
   getComposerAttachments,
   getComposerModelSelection,
+  getComposerQueueIndex,
+  getComposerQueueMode,
   getComposerRequest,
+  getComposerStreamingBehavior,
   getComposerText,
   getComposerThinkingLevel,
 } from "../../shared/pi-thread-action-payloads.ts";
 import {
+  dequeueComposerPrompt,
   sendComposerPrompt,
   setComposerModel,
   setComposerThinkingLevel,
+  stopComposerRun,
 } from "../pi-desktop-runtime.cts";
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
@@ -46,8 +51,31 @@ export async function handleComposerDesktopAction(
         ...getComposerRequest(payload),
         text,
         attachments: getComposerAttachments(payload),
+        streamingBehavior: getComposerStreamingBehavior(payload),
       });
       return handledAction();
+    }
+
+    case "composer.stop": {
+      await stopComposerRun(getComposerRequest(payload));
+      return handledAction();
+    }
+
+    case "composer.dequeue": {
+      const queueMode = getComposerQueueMode(payload);
+      const queueIndex = getComposerQueueIndex(payload);
+
+      if (!queueMode || queueIndex === null) {
+        return handledAction();
+      }
+
+      const dequeuedText = await dequeueComposerPrompt({
+        ...getComposerRequest(payload),
+        queueMode,
+        queueIndex,
+      });
+
+      return handledAction({ dequeuedText });
     }
 
     default:

--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -3,7 +3,7 @@ import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts"
 import {
   getComposerAttachments,
   getComposerModelSelection,
-  getComposerQueueIndex,
+  getComposerQueueId,
   getComposerQueueMode,
   getComposerRequest,
   getComposerStreamingBehavior,
@@ -62,17 +62,17 @@ export async function handleComposerDesktopAction(
     }
 
     case "composer.dequeue": {
+      const queueId = getComposerQueueId(payload);
       const queueMode = getComposerQueueMode(payload);
-      const queueIndex = getComposerQueueIndex(payload);
 
-      if (!queueMode || queueIndex === null) {
+      if (!queueId || !queueMode) {
         return handledAction();
       }
 
       const dequeuedText = await dequeueComposerPrompt({
         ...getComposerRequest(payload),
+        queueId,
         queueMode,
-        queueIndex,
       });
 
       return handledAction({ dequeuedText });

--- a/desktop/pi-threads/settings-actions.cts
+++ b/desktop/pi-threads/settings-actions.cts
@@ -2,6 +2,7 @@ import type { DesktopAction } from "../../shared/desktop-actions.ts";
 import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts";
 import {
   getSettingsBooleanValue,
+  getSettingsComposerStreamingBehavior,
   getSettingsFavoriteFolders,
   getSettingsKey,
   getSettingsModelSelection,
@@ -11,6 +12,7 @@ import {
   getSettingsReset,
 } from "../../shared/pi-thread-action-payloads.ts";
 import {
+  setComposerStreamingBehavior,
   setFavoriteFolders,
   setGitCommitMessageModelSelection,
   setInitializeGitOnProjectCreate,
@@ -39,6 +41,14 @@ export function handleSettingsDesktopAction(
 
   if (key === "favoriteFolders") {
     setFavoriteFolders(getSettingsFavoriteFolders(payload));
+    return handledAction();
+  }
+
+  if (key === "composerStreamingBehavior") {
+    const value = getSettingsComposerStreamingBehavior(payload);
+    if (value) {
+      setComposerStreamingBehavior(value);
+    }
     return handledAction();
   }
 

--- a/desktop/runtime/composer-queue.ts
+++ b/desktop/runtime/composer-queue.ts
@@ -1,0 +1,17 @@
+export type ComposerQueueSession = {
+  followUp: (text: string) => Promise<void>;
+  steer: (text: string) => Promise<void>;
+};
+
+export async function replayComposerQueue(
+  session: ComposerQueueSession,
+  queue: { steering: string[]; followUp: string[] },
+) {
+  for (const queuedText of queue.steering) {
+    await session.steer(queuedText);
+  }
+
+  for (const queuedText of queue.followUp) {
+    await session.followUp(queuedText);
+  }
+}

--- a/desktop/runtime/composer-queue.ts
+++ b/desktop/runtime/composer-queue.ts
@@ -1,7 +1,55 @@
+import type {
+  ComposerQueuedPrompt,
+  ComposerStreamingBehavior,
+} from "../../shared/desktop-contracts.ts";
+
 export type ComposerQueueSession = {
   followUp: (text: string) => Promise<void>;
   steer: (text: string) => Promise<void>;
 };
+
+type ComposerQueueMode = Exclude<ComposerStreamingBehavior, "stop">;
+
+function buildQueuedPromptId(mode: ComposerQueueMode, text: string, duplicateIndex: number) {
+  return `${mode}:${duplicateIndex}:${text}`;
+}
+
+function buildQueuedPromptsForMode(
+  mode: ComposerQueueMode,
+  prompts: string[],
+): ComposerQueuedPrompt[] {
+  const duplicateCounts = new Map<string, number>();
+
+  return prompts.map((text, queueIndex) => {
+    const duplicateIndex = duplicateCounts.get(text) ?? 0;
+    duplicateCounts.set(text, duplicateIndex + 1);
+
+    return {
+      id: buildQueuedPromptId(mode, text, duplicateIndex),
+      mode,
+      queueIndex,
+      text,
+    };
+  });
+}
+
+export function buildQueuedPrompts(queue: { steering: string[]; followUp: string[] }) {
+  return [
+    ...buildQueuedPromptsForMode("steer", queue.steering),
+    ...buildQueuedPromptsForMode("followUp", queue.followUp),
+  ];
+}
+
+export function findQueuedPromptIndexById(
+  mode: ComposerQueueMode,
+  prompts: string[],
+  queueId: string,
+) {
+  return (
+    buildQueuedPromptsForMode(mode, prompts).find((prompt) => prompt.id === queueId)?.queueIndex ??
+    null
+  );
+}
 
 export async function replayComposerQueue(
   session: ComposerQueueSession,

--- a/desktop/runtime/composer-queue.ts
+++ b/desktop/runtime/composer-queue.ts
@@ -9,6 +9,7 @@ export type ComposerQueueSession = {
 };
 
 type ComposerQueueMode = Exclude<ComposerStreamingBehavior, "stop">;
+export type ComposerQueueSnapshot = { steering: string[]; followUp: string[] };
 
 function buildQueuedPromptId(mode: ComposerQueueMode, text: string, duplicateIndex: number) {
   return `${mode}:${duplicateIndex}:${text}`;
@@ -33,11 +34,18 @@ function buildQueuedPromptsForMode(
   });
 }
 
-export function buildQueuedPrompts(queue: { steering: string[]; followUp: string[] }) {
+export function buildQueuedPrompts(queue: ComposerQueueSnapshot) {
   return [
     ...buildQueuedPromptsForMode("steer", queue.steering),
     ...buildQueuedPromptsForMode("followUp", queue.followUp),
   ];
+}
+
+export function cloneComposerQueue(queue: ComposerQueueSnapshot): ComposerQueueSnapshot {
+  return {
+    steering: [...queue.steering],
+    followUp: [...queue.followUp],
+  };
 }
 
 export function findQueuedPromptIndexById(
@@ -51,9 +59,29 @@ export function findQueuedPromptIndexById(
   );
 }
 
+export function removeQueuedPromptById(
+  queue: ComposerQueueSnapshot,
+  mode: ComposerQueueMode,
+  queueId: string,
+) {
+  const nextQueue = cloneComposerQueue(queue);
+  const targetQueue = mode === "steer" ? nextQueue.steering : nextQueue.followUp;
+  const queueIndex = findQueuedPromptIndexById(mode, targetQueue, queueId);
+
+  if (queueIndex === null || queueIndex < 0 || queueIndex >= targetQueue.length) {
+    return null;
+  }
+
+  const [dequeuedText] = targetQueue.splice(queueIndex, 1);
+  return {
+    dequeuedText: dequeuedText ?? null,
+    nextQueue,
+  };
+}
+
 export async function replayComposerQueue(
   session: ComposerQueueSession,
-  queue: { steering: string[]; followUp: string[] },
+  queue: ComposerQueueSnapshot,
 ) {
   for (const queuedText of queue.steering) {
     await session.steer(queuedText);

--- a/desktop/runtime/composer-queue.ts
+++ b/desktop/runtime/composer-queue.ts
@@ -11,6 +11,10 @@ export type ComposerQueueSession = {
 type ComposerQueueMode = Exclude<ComposerStreamingBehavior, "stop">;
 export type ComposerQueueSnapshot = { steering: string[]; followUp: string[] };
 
+export function buildComposerQueueSnapshotKey(queue: ComposerQueueSnapshot) {
+  return JSON.stringify([queue.steering, queue.followUp]);
+}
+
 function buildQueuedPromptId(mode: ComposerQueueMode, text: string, duplicateIndex: number) {
   return `${mode}:${duplicateIndex}:${text}`;
 }
@@ -18,7 +22,7 @@ function buildQueuedPromptId(mode: ComposerQueueMode, text: string, duplicateInd
 function buildQueuedPromptsForMode(
   mode: ComposerQueueMode,
   prompts: string[],
-): ComposerQueuedPrompt[] {
+): Array<Omit<ComposerQueuedPrompt, "queueSnapshotKey">> {
   const duplicateCounts = new Map<string, number>();
 
   return prompts.map((text, queueIndex) => {
@@ -35,9 +39,17 @@ function buildQueuedPromptsForMode(
 }
 
 export function buildQueuedPrompts(queue: ComposerQueueSnapshot) {
+  const queueSnapshotKey = buildComposerQueueSnapshotKey(queue);
+
   return [
-    ...buildQueuedPromptsForMode("steer", queue.steering),
-    ...buildQueuedPromptsForMode("followUp", queue.followUp),
+    ...buildQueuedPromptsForMode("steer", queue.steering).map((prompt) => ({
+      ...prompt,
+      queueSnapshotKey,
+    })),
+    ...buildQueuedPromptsForMode("followUp", queue.followUp).map((prompt) => ({
+      ...prompt,
+      queueSnapshotKey,
+    })),
   ];
 }
 

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -9,7 +9,7 @@ import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/se
 import { loadAppSettings } from "../app-settings.cts";
 import { getPiModule } from "../pi-module.cts";
 import { buildComposerAttachmentPrompt } from "./attachments.cts";
-import { replayComposerQueue } from "./composer-queue";
+import { findQueuedPromptIndexById, replayComposerQueue } from "./composer-queue";
 import {
   buildComposerState,
   buildComposerStateSnapshot,
@@ -195,8 +195,8 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
 
 export async function dequeueComposerPrompt(
   request: ComposerStateRequest & {
+    queueId: string;
     queueMode: Exclude<ComposerStreamingBehavior, "stop">;
-    queueIndex: number;
   },
 ): Promise<string | null> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
@@ -212,8 +212,13 @@ export async function dequeueComposerPrompt(
       request.queueMode === "steer"
         ? runtime.session.getSteeringMessages()
         : runtime.session.getFollowUpMessages();
+    const queueIndex = findQueuedPromptIndexById(
+      request.queueMode,
+      [...currentQueue],
+      request.queueId,
+    );
 
-    if (request.queueIndex < 0 || request.queueIndex >= currentQueue.length) {
+    if (queueIndex === null || queueIndex < 0 || queueIndex >= currentQueue.length) {
       return null;
     }
 
@@ -221,7 +226,7 @@ export async function dequeueComposerPrompt(
     const targetQueue =
       request.queueMode === "steer" ? clearedQueue.steering : clearedQueue.followUp;
 
-    const [dequeuedText] = targetQueue.splice(request.queueIndex, 1);
+    const [dequeuedText] = targetQueue.splice(queueIndex, 1);
 
     await replayComposerQueue(runtime.session, clearedQueue);
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -2,9 +2,11 @@ import type {
   ComposerAttachment,
   ComposerState,
   ComposerStateRequest,
+  ComposerStreamingBehavior,
   ComposerThinkingLevel,
 } from "../../shared/desktop-contracts.ts";
 import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/session-paths.ts";
+import { loadAppSettings } from "../app-settings.cts";
 import { getPiModule } from "../pi-module.cts";
 import { buildComposerAttachmentPrompt } from "./attachments.cts";
 import {
@@ -140,7 +142,11 @@ export async function setComposerThinkingLevel(
 }
 
 export async function sendComposerPrompt(
-  request: ComposerStateRequest & { text: string; attachments?: ComposerAttachment[] },
+  request: ComposerStateRequest & {
+    text: string;
+    attachments?: ComposerAttachment[];
+    streamingBehavior?: ComposerStreamingBehavior | null;
+  },
 ): Promise<void> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   const runtime = persistedSessionPath
@@ -148,13 +154,83 @@ export async function sendComposerPrompt(
     : await createRuntimeForNewSession(request.projectId ?? process.cwd());
   const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
   const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;
+  const streamingBehavior =
+    request.streamingBehavior ?? loadAppSettings().composerStreamingBehavior;
 
   try {
-    await runtime.session.prompt(message);
+    if (runtime.session.isStreaming) {
+      if (streamingBehavior === "stop") {
+        await runtime.session.abort();
+        await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+        return;
+      }
+
+      await runtime.session.prompt(message, { streamingBehavior });
+    } else {
+      await runtime.session.prompt(message);
+    }
   } catch (error) {
     scheduleRuntimeDisposalForRuntime(runtime);
     throw error;
   }
+}
+
+export async function stopComposerRun(request: ComposerStateRequest): Promise<void> {
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  if (!persistedSessionPath) {
+    return;
+  }
+
+  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+    suspendDisposal: true,
+  });
+
+  await runtime.session.abort();
+  scheduleRuntimeDisposalForRuntime(runtime);
+  await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+}
+
+export async function dequeueComposerPrompt(
+  request: ComposerStateRequest & {
+    queueMode: Exclude<ComposerStreamingBehavior, "stop">;
+    queueIndex: number;
+  },
+): Promise<string | null> {
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  if (!persistedSessionPath) {
+    return null;
+  }
+
+  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+    suspendDisposal: true,
+  });
+  const currentQueue =
+    request.queueMode === "steer"
+      ? runtime.session.getSteeringMessages()
+      : runtime.session.getFollowUpMessages();
+
+  if (request.queueIndex < 0 || request.queueIndex >= currentQueue.length) {
+    return null;
+  }
+
+  const clearedQueue = runtime.session.clearQueue();
+  const targetQueue = request.queueMode === "steer" ? clearedQueue.steering : clearedQueue.followUp;
+
+  const [dequeuedText] = targetQueue.splice(request.queueIndex, 1);
+
+  if (runtime.session.isStreaming) {
+    for (const queuedText of clearedQueue.steering) {
+      await runtime.session.steer(queuedText);
+    }
+
+    for (const queuedText of clearedQueue.followUp) {
+      await runtime.session.followUp(queuedText);
+    }
+  }
+
+  scheduleRuntimeDisposalForRuntime(runtime);
+  await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+  return dequeuedText ?? null;
 }
 
 export async function startNewThread(request: ComposerStateRequest = {}) {

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -9,6 +9,7 @@ import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/se
 import { loadAppSettings } from "../app-settings.cts";
 import { getPiModule } from "../pi-module.cts";
 import { buildComposerAttachmentPrompt } from "./attachments.cts";
+import { replayComposerQueue } from "./composer-queue";
 import {
   buildComposerState,
   buildComposerStateSnapshot,
@@ -204,33 +205,28 @@ export async function dequeueComposerPrompt(
   const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
     suspendDisposal: true,
   });
-  const currentQueue =
-    request.queueMode === "steer"
-      ? runtime.session.getSteeringMessages()
-      : runtime.session.getFollowUpMessages();
+  try {
+    const currentQueue =
+      request.queueMode === "steer"
+        ? runtime.session.getSteeringMessages()
+        : runtime.session.getFollowUpMessages();
 
-  if (request.queueIndex < 0 || request.queueIndex >= currentQueue.length) {
-    return null;
-  }
-
-  const clearedQueue = runtime.session.clearQueue();
-  const targetQueue = request.queueMode === "steer" ? clearedQueue.steering : clearedQueue.followUp;
-
-  const [dequeuedText] = targetQueue.splice(request.queueIndex, 1);
-
-  if (runtime.session.isStreaming) {
-    for (const queuedText of clearedQueue.steering) {
-      await runtime.session.steer(queuedText);
+    if (request.queueIndex < 0 || request.queueIndex >= currentQueue.length) {
+      return null;
     }
 
-    for (const queuedText of clearedQueue.followUp) {
-      await runtime.session.followUp(queuedText);
-    }
-  }
+    const clearedQueue = runtime.session.clearQueue();
+    const targetQueue =
+      request.queueMode === "steer" ? clearedQueue.steering : clearedQueue.followUp;
 
-  scheduleRuntimeDisposalForRuntime(runtime);
-  await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-  return dequeuedText ?? null;
+    const [dequeuedText] = targetQueue.splice(request.queueIndex, 1);
+
+    await replayComposerQueue(runtime.session, clearedQueue);
+    await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+    return dequeuedText ?? null;
+  } finally {
+    scheduleRuntimeDisposalForRuntime(runtime);
+  }
 }
 
 export async function startNewThread(request: ComposerStateRequest = {}) {

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -148,7 +148,7 @@ export async function sendComposerPrompt(
     attachments?: ComposerAttachment[];
     streamingBehavior?: ComposerStreamingBehavior | null;
   },
-): Promise<void> {
+): Promise<"sent" | "stopped"> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   const runtime = persistedSessionPath
     ? await getOrCreateRuntimeForSessionPath(persistedSessionPath, { suspendDisposal: true })
@@ -163,13 +163,15 @@ export async function sendComposerPrompt(
       if (streamingBehavior === "stop") {
         await runtime.session.abort();
         await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-        return;
+        return "stopped";
       }
 
       await runtime.session.prompt(message, { streamingBehavior });
     } else {
       await runtime.session.prompt(message);
     }
+
+    return "sent";
   } catch (error) {
     scheduleRuntimeDisposalForRuntime(runtime);
     throw error;

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -10,6 +10,7 @@ import { loadAppSettings } from "../app-settings.cts";
 import { getPiModule } from "../pi-module.cts";
 import { buildComposerAttachmentPrompt } from "./attachments.cts";
 import {
+  buildComposerQueueSnapshotKey,
   findQueuedPromptIndexById,
   removeQueuedPromptById,
   replayComposerQueue,
@@ -25,6 +26,7 @@ import {
   getCachedRuntimeForSessionPath,
   getOrCreateRuntimeForSessionPath,
   scheduleRuntimeDisposalForRuntime,
+  withRuntimeMutationLock,
 } from "./runtime-registry.cts";
 import {
   getLiveThread,
@@ -154,32 +156,44 @@ export async function sendComposerPrompt(
   },
 ): Promise<"sent" | "stopped"> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
-  const runtime = persistedSessionPath
-    ? await getOrCreateRuntimeForSessionPath(persistedSessionPath, { suspendDisposal: true })
-    : await createRuntimeForNewSession(request.projectId ?? process.cwd());
-  const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
-  const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;
-  const streamingBehavior =
-    request.streamingBehavior ?? loadAppSettings().composerStreamingBehavior;
 
-  try {
-    if (runtime.session.isStreaming) {
-      if (streamingBehavior === "stop") {
-        await runtime.session.abort();
-        await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-        return "stopped";
+  const runSend = async (runtime: Awaited<ReturnType<typeof getOrCreateRuntimeForSessionPath>>) => {
+    const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
+    const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;
+    const streamingBehavior =
+      request.streamingBehavior ?? loadAppSettings().composerStreamingBehavior;
+
+    try {
+      if (runtime.session.isStreaming) {
+        if (streamingBehavior === "stop") {
+          await runtime.session.abort();
+          await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+          return "stopped";
+        }
+
+        await runtime.session.prompt(message, { streamingBehavior });
+      } else {
+        await runtime.session.prompt(message);
       }
 
-      await runtime.session.prompt(message, { streamingBehavior });
-    } else {
-      await runtime.session.prompt(message);
+      return "sent";
+    } catch (error) {
+      scheduleRuntimeDisposalForRuntime(runtime);
+      throw error;
     }
+  };
 
-    return "sent";
-  } catch (error) {
-    scheduleRuntimeDisposalForRuntime(runtime);
-    throw error;
+  if (!persistedSessionPath) {
+    return await runSend(await createRuntimeForNewSession(request.projectId ?? process.cwd()));
   }
+
+  return await withRuntimeMutationLock(
+    persistedSessionPath,
+    async () =>
+      await runSend(
+        await getOrCreateRuntimeForSessionPath(persistedSessionPath, { suspendDisposal: true }),
+      ),
+  );
 }
 
 export async function stopComposerRun(request: ComposerStateRequest): Promise<void> {
@@ -188,18 +202,21 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
     return;
   }
 
-  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
-    suspendDisposal: true,
-  });
+  await withRuntimeMutationLock(persistedSessionPath, async () => {
+    const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+      suspendDisposal: true,
+    });
 
-  await runtime.session.abort();
-  scheduleRuntimeDisposalForRuntime(runtime);
-  await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+    await runtime.session.abort();
+    scheduleRuntimeDisposalForRuntime(runtime);
+    await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+  });
 }
 
 export async function dequeueComposerPrompt(
   request: ComposerStateRequest & {
     queueId: string;
+    queueSnapshotKey: string;
     queueMode: Exclude<ComposerStreamingBehavior, "stop">;
   },
 ): Promise<string | null> {
@@ -208,51 +225,68 @@ export async function dequeueComposerPrompt(
     return null;
   }
 
-  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
-    suspendDisposal: true,
-  });
-  try {
-    const currentQueue =
-      request.queueMode === "steer"
-        ? runtime.session.getSteeringMessages()
-        : runtime.session.getFollowUpMessages();
-    if (findQueuedPromptIndexById(request.queueMode, [...currentQueue], request.queueId) === null) {
-      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-      return null;
-    }
-
-    const clearedQueue = runtime.session.clearQueue();
-    const dequeueResult = removeQueuedPromptById(clearedQueue, request.queueMode, request.queueId);
-
-    if (!dequeueResult) {
-      await replayComposerQueue(runtime.session, clearedQueue);
-      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-      return null;
-    }
+  return await withRuntimeMutationLock(persistedSessionPath, async () => {
+    const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+      suspendDisposal: true,
+    });
 
     try {
-      await replayComposerQueue(runtime.session, dequeueResult.nextQueue);
-      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-      return dequeueResult.dequeuedText;
-    } catch (error) {
-      runtime.session.clearQueue();
+      const currentQueueSnapshot = {
+        steering: [...runtime.session.getSteeringMessages()],
+        followUp: [...runtime.session.getFollowUpMessages()],
+      };
 
-      try {
-        await replayComposerQueue(runtime.session, clearedQueue);
+      if (buildComposerQueueSnapshotKey(currentQueueSnapshot) !== request.queueSnapshotKey) {
         await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-      } catch (rollbackError) {
-        throw new Error(
-          rollbackError instanceof Error
-            ? `Could not restore queued prompts after dequeue replay failure: ${rollbackError.message}`
-            : "Could not restore queued prompts after dequeue replay failure.",
-        );
+        return null;
       }
 
-      throw error;
+      const currentQueue =
+        request.queueMode === "steer"
+          ? currentQueueSnapshot.steering
+          : currentQueueSnapshot.followUp;
+      if (findQueuedPromptIndexById(request.queueMode, currentQueue, request.queueId) === null) {
+        await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+        return null;
+      }
+
+      const clearedQueue = runtime.session.clearQueue();
+      const dequeueResult = removeQueuedPromptById(
+        clearedQueue,
+        request.queueMode,
+        request.queueId,
+      );
+
+      if (!dequeueResult) {
+        await replayComposerQueue(runtime.session, clearedQueue);
+        await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+        return null;
+      }
+
+      try {
+        await replayComposerQueue(runtime.session, dequeueResult.nextQueue);
+        await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+        return dequeueResult.dequeuedText;
+      } catch (error) {
+        runtime.session.clearQueue();
+
+        try {
+          await replayComposerQueue(runtime.session, clearedQueue);
+          await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+        } catch (rollbackError) {
+          throw new Error(
+            rollbackError instanceof Error
+              ? `Could not restore queued prompts after dequeue replay failure: ${rollbackError.message}`
+              : "Could not restore queued prompts after dequeue replay failure.",
+          );
+        }
+
+        throw error;
+      }
+    } finally {
+      scheduleRuntimeDisposalForRuntime(runtime);
     }
-  } finally {
-    scheduleRuntimeDisposalForRuntime(runtime);
-  }
+  });
 }
 
 export async function startNewThread(request: ComposerStateRequest = {}) {

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -9,7 +9,11 @@ import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/se
 import { loadAppSettings } from "../app-settings.cts";
 import { getPiModule } from "../pi-module.cts";
 import { buildComposerAttachmentPrompt } from "./attachments.cts";
-import { findQueuedPromptIndexById, replayComposerQueue } from "./composer-queue";
+import {
+  findQueuedPromptIndexById,
+  removeQueuedPromptById,
+  replayComposerQueue,
+} from "./composer-queue";
 import {
   buildComposerState,
   buildComposerStateSnapshot,
@@ -212,25 +216,40 @@ export async function dequeueComposerPrompt(
       request.queueMode === "steer"
         ? runtime.session.getSteeringMessages()
         : runtime.session.getFollowUpMessages();
-    const queueIndex = findQueuedPromptIndexById(
-      request.queueMode,
-      [...currentQueue],
-      request.queueId,
-    );
-
-    if (queueIndex === null || queueIndex < 0 || queueIndex >= currentQueue.length) {
+    if (findQueuedPromptIndexById(request.queueMode, [...currentQueue], request.queueId) === null) {
+      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
       return null;
     }
 
     const clearedQueue = runtime.session.clearQueue();
-    const targetQueue =
-      request.queueMode === "steer" ? clearedQueue.steering : clearedQueue.followUp;
+    const dequeueResult = removeQueuedPromptById(clearedQueue, request.queueMode, request.queueId);
 
-    const [dequeuedText] = targetQueue.splice(queueIndex, 1);
+    if (!dequeueResult) {
+      await replayComposerQueue(runtime.session, clearedQueue);
+      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+      return null;
+    }
 
-    await replayComposerQueue(runtime.session, clearedQueue);
-    await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-    return dequeuedText ?? null;
+    try {
+      await replayComposerQueue(runtime.session, dequeueResult.nextQueue);
+      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+      return dequeueResult.dequeuedText;
+    } catch (error) {
+      runtime.session.clearQueue();
+
+      try {
+        await replayComposerQueue(runtime.session, clearedQueue);
+        await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+      } catch (rollbackError) {
+        throw new Error(
+          rollbackError instanceof Error
+            ? `Could not restore queued prompts after dequeue replay failure: ${rollbackError.message}`
+            : "Could not restore queued prompts after dequeue replay failure.",
+        );
+      }
+
+      throw error;
+    }
   } finally {
     scheduleRuntimeDisposalForRuntime(runtime);
   }

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -10,6 +10,7 @@ import type {
 } from "../../shared/desktop-contracts.ts";
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
+import { buildQueuedPrompts } from "./composer-queue";
 import type { PiRuntime } from "./types.cts";
 
 export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
@@ -36,21 +37,11 @@ function mapThinkingLevels(levels: ThinkingLevel[]) {
   return levels as ComposerThinkingLevel[];
 }
 
-function buildQueuedPrompts(session: AgentSession): ComposerQueuedPrompt[] {
-  return [
-    ...session.getSteeringMessages().map((text, queueIndex) => ({
-      id: `steer:${queueIndex}:${text}`,
-      mode: "steer" as const,
-      queueIndex,
-      text,
-    })),
-    ...session.getFollowUpMessages().map((text, queueIndex) => ({
-      id: `followUp:${queueIndex}:${text}`,
-      mode: "followUp" as const,
-      queueIndex,
-      text,
-    })),
-  ];
+function buildSessionQueuedPrompts(session: AgentSession): ComposerQueuedPrompt[] {
+  return buildQueuedPrompts({
+    steering: [...session.getSteeringMessages()],
+    followUp: [...session.getFollowUpMessages()],
+  });
 }
 
 export function getAvailableThinkingLevelsForModel(
@@ -220,6 +211,6 @@ export async function buildComposerState(runtime: PiRuntime): Promise<ComposerSt
     availableModels,
     currentThinkingLevel: runtime.session.thinkingLevel as ComposerThinkingLevel,
     availableThinkingLevels: mapThinkingLevels(runtime.session.getAvailableThinkingLevels()),
-    queuedPrompts: buildQueuedPrompts(runtime.session),
+    queuedPrompts: buildSessionQueuedPrompts(runtime.session),
   };
 }

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -3,6 +3,7 @@ import { type Model, supportsXhigh } from "@mariozechner/pi-ai";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type {
   ComposerModel,
+  ComposerQueuedPrompt,
   ComposerState,
   ComposerStateRequest,
   ComposerThinkingLevel,
@@ -33,6 +34,23 @@ function mapComposerModel(
 
 function mapThinkingLevels(levels: ThinkingLevel[]) {
   return levels as ComposerThinkingLevel[];
+}
+
+function buildQueuedPrompts(session: AgentSession): ComposerQueuedPrompt[] {
+  return [
+    ...session.getSteeringMessages().map((text, queueIndex) => ({
+      id: `steer:${queueIndex}:${text}`,
+      mode: "steer" as const,
+      queueIndex,
+      text,
+    })),
+    ...session.getFollowUpMessages().map((text, queueIndex) => ({
+      id: `followUp:${queueIndex}:${text}`,
+      mode: "followUp" as const,
+      queueIndex,
+      text,
+    })),
+  ];
 }
 
 export function getAvailableThinkingLevelsForModel(
@@ -184,6 +202,7 @@ export async function buildComposerStateSnapshot(
     })),
     currentThinkingLevel: snapshot.currentThinkingLevel,
     availableThinkingLevels: snapshot.availableThinkingLevels,
+    queuedPrompts: [],
   };
 }
 
@@ -201,5 +220,6 @@ export async function buildComposerState(runtime: PiRuntime): Promise<ComposerSt
     availableModels,
     currentThinkingLevel: runtime.session.thinkingLevel as ComposerThinkingLevel,
     availableThinkingLevels: mapThinkingLevels(runtime.session.getAvailableThinkingLevels()),
+    queuedPrompts: buildQueuedPrompts(runtime.session),
   };
 }

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -13,6 +13,7 @@ type RuntimeRecord = {
 };
 
 const runtimeRecords = new Map<string, RuntimeRecord>();
+const runtimeMutationTails = new Map<string, Promise<void>>();
 
 function clearRuntimeDisposeTimeout(runtimeKey: string) {
   const record = runtimeRecords.get(runtimeKey);
@@ -225,5 +226,29 @@ export function scheduleRuntimeDisposalForRuntime(runtime: PiRuntime) {
   const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
   if (runtimeKey) {
     scheduleRuntimeDisposal(runtimeKey);
+  }
+}
+
+export async function withRuntimeMutationLock<T>(runtimeKey: string, task: () => Promise<T>) {
+  const previousTail = runtimeMutationTails.get(runtimeKey) ?? Promise.resolve();
+  let releaseCurrentTail: (() => void) | undefined;
+  const currentTail = new Promise<void>((resolve) => {
+    releaseCurrentTail = resolve;
+  });
+
+  const nextTail = previousTail.then(() => currentTail);
+  runtimeMutationTails.set(runtimeKey, nextTail);
+
+  await previousTail;
+
+  try {
+    return await task();
+  } finally {
+    if (releaseCurrentTail) {
+      releaseCurrentTail();
+    }
+    if (runtimeMutationTails.get(runtimeKey) === nextTail) {
+      runtimeMutationTails.delete(runtimeKey);
+    }
   }
 }

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -1,7 +1,8 @@
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
+import { buildComposerState } from "./composer-state.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
-import { publishThreadUpdate } from "./thread-publisher.cts";
+import { publishComposerUpdate, publishThreadUpdate } from "./thread-publisher.cts";
 import type { PiRuntime } from "./types.cts";
 
 const RUNTIME_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
@@ -117,6 +118,16 @@ async function createRuntime(options: {
 
     if (event.type === "message_update" && event.message.role === "assistant") {
       void publishThreadUpdate(runtime, "update");
+      return;
+    }
+
+    if (event.type === "queue_update") {
+      void buildComposerState(runtime).then((composer) => {
+        publishComposerUpdate(composer, {
+          projectId: runtime.cwd,
+          sessionPath: runtime.session.sessionFile,
+        });
+      });
     }
   });
 

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -122,12 +122,21 @@ async function createRuntime(options: {
     }
 
     if (event.type === "queue_update") {
-      void buildComposerState(runtime).then((composer) => {
-        publishComposerUpdate(composer, {
-          projectId: runtime.cwd,
-          sessionPath: runtime.session.sessionFile,
+      void buildComposerState(runtime)
+        .then((composer) => {
+          publishComposerUpdate(composer, {
+            projectId: runtime.cwd,
+            sessionPath: runtime.session.sessionFile,
+          });
+        })
+        .catch(() => {
+          // Ignore transient composer snapshot errors; a later runtime event will republish state.
+        })
+        .finally(() => {
+          if (runtimeKey && !runtime.session.isStreaming) {
+            scheduleRuntimeDisposal(runtimeKey);
+          }
         });
-      });
     }
   });
 

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -3,6 +3,7 @@ import type {
   AppSettings,
   ComposerAttachment,
   ComposerState,
+  ComposerStreamingBehavior,
   ComposerThinkingLevel,
   ProjectDeletionMode,
   ProjectImportCandidate,
@@ -25,9 +26,12 @@ export type DesktopActionPayloadFields = {
   projectName?: string;
   provider?: string;
   push?: boolean;
+  queueIndex?: number;
+  queueMode?: Exclude<ComposerStreamingBehavior, "stop">;
   repoUrl?: string | null;
   reset?: boolean;
   sessionPath?: string | null;
+  streamingBehavior?: ComposerStreamingBehavior;
   text?: string;
   threadId?: string;
   threadIds?: string[];
@@ -44,6 +48,7 @@ export type DesktopSettingsUpdatePayload =
   | { key: "gitCommitMessageModel"; reset: true }
   | { key: "skillCreatorModel"; provider: string; modelId: string; reset?: false }
   | { key: "skillCreatorModel"; reset: true }
+  | { key: "composerStreamingBehavior"; value: ComposerStreamingBehavior }
   | { key: "favoriteFolders"; folders: string[] }
   | { key: "projectImportState"; imported: boolean | null }
   | { key: "preferredProjectLocation"; value: string | null }
@@ -115,6 +120,14 @@ export type DesktopActionPayloadMap = {
     sessionPath?: string | null;
     text: string;
     attachments?: ComposerAttachment[];
+    streamingBehavior?: ComposerStreamingBehavior;
+  };
+  "composer.stop": { projectId?: string | null; sessionPath?: string | null };
+  "composer.dequeue": {
+    projectId?: string | null;
+    sessionPath?: string | null;
+    queueMode: Exclude<ComposerStreamingBehavior, "stop">;
+    queueIndex: number;
   };
   "inbox.mark-read": { sessionPath: string; projectId?: string | null };
   "inbox.dismiss": { sessionPath: string; projectId?: string | null };
@@ -139,6 +152,7 @@ export type DesktopActionResultData = {
   checkedProjectCount?: number;
   committed?: boolean;
   composer?: ComposerState;
+  dequeuedText?: string | null;
   deletedThreadIds?: string[];
   didMutate?: boolean;
   error?: string;

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -26,6 +26,7 @@ export type DesktopActionPayloadFields = {
   projectName?: string;
   provider?: string;
   queueId?: string;
+  queueSnapshotKey?: string;
   push?: boolean;
   queueIndex?: number;
   queueMode?: Exclude<ComposerStreamingBehavior, "stop">;
@@ -128,6 +129,7 @@ export type DesktopActionPayloadMap = {
     projectId?: string | null;
     sessionPath?: string | null;
     queueId: string;
+    queueSnapshotKey: string;
     queueMode: Exclude<ComposerStreamingBehavior, "stop">;
   };
   "inbox.mark-read": { sessionPath: string; projectId?: string | null };

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -25,6 +25,7 @@ export type DesktopActionPayloadFields = {
   projectIds?: string[];
   projectName?: string;
   provider?: string;
+  queueId?: string;
   push?: boolean;
   queueIndex?: number;
   queueMode?: Exclude<ComposerStreamingBehavior, "stop">;
@@ -126,8 +127,8 @@ export type DesktopActionPayloadMap = {
   "composer.dequeue": {
     projectId?: string | null;
     sessionPath?: string | null;
+    queueId: string;
     queueMode: Exclude<ComposerStreamingBehavior, "stop">;
-    queueIndex: number;
   };
   "inbox.mark-read": { sessionPath: string; projectId?: string | null };
   "inbox.dismiss": { sessionPath: string; projectId?: string | null };

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -152,6 +152,7 @@ export type DesktopActionResultData = {
   checkedProjectCount?: number;
   committed?: boolean;
   composer?: ComposerState;
+  composerSendOutcome?: "sent" | "stopped";
   dequeuedText?: string | null;
   deletedThreadIds?: string[];
   didMutate?: boolean;

--- a/shared/desktop-actions.ts
+++ b/shared/desktop-actions.ts
@@ -37,6 +37,8 @@ export const desktopActions = [
   "composer.thinking",
   "composer.dictate",
   "composer.send",
+  "composer.stop",
+  "composer.dequeue",
   "composer.host",
   "inbox.mark-read",
   "inbox.dismiss",

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -107,6 +107,15 @@ export type Message =
 
 export type ComposerThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
+export type ComposerStreamingBehavior = "steer" | "followUp" | "stop";
+
+export type ComposerQueuedPrompt = {
+  id: string;
+  mode: Exclude<ComposerStreamingBehavior, "stop">;
+  queueIndex: number;
+  text: string;
+};
+
 export type ComposerModel = {
   provider: string;
   id: string;
@@ -120,6 +129,7 @@ export type ComposerState = {
   availableModels: ComposerModel[];
   currentThinkingLevel: ComposerThinkingLevel;
   availableThinkingLevels: ComposerThinkingLevel[];
+  queuedPrompts: ComposerQueuedPrompt[];
 };
 
 export type ComposerAttachment = {
@@ -247,6 +257,7 @@ export type ProjectDeletionMode = "pi-only" | "full-clean";
 export type AppSettings = {
   gitCommitMessageModel: ModelSelection | null;
   skillCreatorModel: ModelSelection | null;
+  composerStreamingBehavior: ComposerStreamingBehavior;
   favoriteFolders: string[];
   projectImportState: boolean | null;
   preferredProjectLocation: string | null;

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -113,6 +113,7 @@ export type ComposerQueuedPrompt = {
   id: string;
   mode: Exclude<ComposerStreamingBehavior, "stop">;
   queueIndex: number;
+  queueSnapshotKey: string;
   text: string;
 };
 

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -98,6 +98,10 @@ export function getComposerQueueMode(payload: DesktopActionPayloadInput) {
     : null;
 }
 
+export function getComposerQueueId(payload: DesktopActionPayloadInput) {
+  return typeof payload.queueId === "string" && payload.queueId.length > 0 ? payload.queueId : null;
+}
+
 export function getComposerQueueIndex(payload: DesktopActionPayloadInput) {
   return typeof payload.queueIndex === "number" && Number.isInteger(payload.queueIndex)
     ? payload.queueIndex

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -102,6 +102,12 @@ export function getComposerQueueId(payload: DesktopActionPayloadInput) {
   return typeof payload.queueId === "string" && payload.queueId.length > 0 ? payload.queueId : null;
 }
 
+export function getComposerQueueSnapshotKey(payload: DesktopActionPayloadInput) {
+  return typeof payload.queueSnapshotKey === "string" && payload.queueSnapshotKey.length > 0
+    ? payload.queueSnapshotKey
+    : null;
+}
+
 export function getComposerQueueIndex(payload: DesktopActionPayloadInput) {
   return typeof payload.queueIndex === "number" && Number.isInteger(payload.queueIndex)
     ? payload.queueIndex

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -2,6 +2,7 @@ import type {
   AppSettings,
   ComposerAttachment,
   ComposerStateRequest,
+  ComposerStreamingBehavior,
   ComposerThinkingLevel,
   DesktopActionPayloadInput,
   ModelSelection,
@@ -81,6 +82,28 @@ export function getComposerAttachments(payload: DesktopActionPayloadInput): Comp
     : [];
 }
 
+export function getComposerStreamingBehavior(
+  payload: DesktopActionPayloadInput,
+): ComposerStreamingBehavior | null {
+  return payload.streamingBehavior === "steer" ||
+    payload.streamingBehavior === "followUp" ||
+    payload.streamingBehavior === "stop"
+    ? payload.streamingBehavior
+    : null;
+}
+
+export function getComposerQueueMode(payload: DesktopActionPayloadInput) {
+  return payload.queueMode === "steer" || payload.queueMode === "followUp"
+    ? payload.queueMode
+    : null;
+}
+
+export function getComposerQueueIndex(payload: DesktopActionPayloadInput) {
+  return typeof payload.queueIndex === "number" && Number.isInteger(payload.queueIndex)
+    ? payload.queueIndex
+    : null;
+}
+
 export function getComposerModelSelection(payload: DesktopActionPayloadInput) {
   const provider = typeof payload.provider === "string" ? payload.provider : null;
   const modelId = typeof payload.modelId === "string" ? payload.modelId : null;
@@ -120,6 +143,7 @@ export function getGitRepoUrl(payload: DesktopActionPayloadInput) {
 export function getSettingsKey(payload: DesktopActionPayloadInput) {
   return payload.key === "gitCommitMessageModel" ||
     payload.key === "skillCreatorModel" ||
+    payload.key === "composerStreamingBehavior" ||
     payload.key === "favoriteFolders" ||
     payload.key === "projectImportState" ||
     payload.key === "preferredProjectLocation" ||
@@ -169,6 +193,14 @@ export function getSettingsPreferredProjectLocation(payload: DesktopActionPayloa
 
 export function getSettingsBooleanValue(payload: DesktopActionPayloadInput) {
   return typeof payload.value === "boolean" ? payload.value : null;
+}
+
+export function getSettingsComposerStreamingBehavior(
+  payload: DesktopActionPayloadInput,
+): ComposerStreamingBehavior | null {
+  return payload.value === "steer" || payload.value === "followUp" || payload.value === "stop"
+    ? payload.value
+    : null;
 }
 
 export function getSettingsProjectDeletionMode(

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -87,6 +87,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               controller.shellState?.appSettings ?? {
                 gitCommitMessageModel: null,
                 skillCreatorModel: null,
+                composerStreamingBehavior: "followUp",
                 favoriteFolders: [],
                 projectImportState: null,
                 preferredProjectLocation: null,

--- a/src/app/app-shell/controller-action-helpers.ts
+++ b/src/app/app-shell/controller-action-helpers.ts
@@ -16,7 +16,9 @@ export function buildContextualActionPayload({
   selectedSessionPath: string | null;
 }) {
   return action === "composer.model" ||
+    action === "composer.dequeue" ||
     action === "composer.send" ||
+    action === "composer.stop" ||
     action === "composer.thinking" ||
     action === "workspace.commit" ||
     action === "workspace.commit-options"

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -103,6 +103,7 @@ export function getOptimisticallyUpdatedShellState(
   if (
     payload.key !== "gitCommitMessageModel" &&
     payload.key !== "skillCreatorModel" &&
+    payload.key !== "composerStreamingBehavior" &&
     payload.key !== "favoriteFolders" &&
     payload.key !== "projectImportState" &&
     payload.key !== "preferredProjectLocation" &&
@@ -131,6 +132,12 @@ export function getOptimisticallyUpdatedShellState(
           ? { provider: payload.provider, id: payload.modelId }
           : currentState.appSettings.skillCreatorModel
       : currentState.appSettings.skillCreatorModel;
+
+  const nextComposerStreamingBehavior =
+    payload.key === "composerStreamingBehavior" &&
+    (payload.value === "steer" || payload.value === "followUp" || payload.value === "stop")
+      ? payload.value
+      : currentState.appSettings.composerStreamingBehavior;
 
   const nextFavoriteFolders =
     payload.key === "favoriteFolders" && Array.isArray(payload.folders)
@@ -184,6 +191,7 @@ export function getOptimisticallyUpdatedShellState(
       ...currentState.appSettings,
       gitCommitMessageModel: nextSelection,
       skillCreatorModel: nextSkillCreatorSelection,
+      composerStreamingBehavior: nextComposerStreamingBehavior,
       favoriteFolders: nextFavoriteFolders,
       projectImportState: nextProjectImportState,
       preferredProjectLocation: nextPreferredProjectLocation,

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -504,9 +504,9 @@ export async function runPostDesktopActionEffects({
     await invalidateInboxThreads();
   }
 
-  if (action === "settings.update") {
-    await refreshShellState();
-  }
+  // Settings writes are local and already applied optimistically in the renderer.
+  // Refreshing shell state here can race against that optimistic update and briefly
+  // snap controls back to stale values before the next state load lands.
 
   if (action === "thread.new" || action === "project.add") {
     const projectId = getPayloadProjectId(contextualPayload) ?? composerProjectId;

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -55,7 +55,7 @@ export function Composer(props: ComposerProps) {
   return (
     <SurfacePanel
       ref={composerPanelRef}
-      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
+      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
       aria-label="Composer panel"
     >
       <ComposerPromptSurface

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -9,7 +9,6 @@ import type {
   ProjectGitState,
 } from "../../desktop/types";
 import type { View } from "../../types";
-import { SurfacePanel } from "../common/SurfacePanel";
 import { ComposerPromptSurface } from "./composer/ComposerPromptSurface";
 import type { SavedDiffComment } from "./diff/diffCommentStore";
 
@@ -53,9 +52,9 @@ export function Composer(props: ComposerProps) {
   const composerPanelRef = useRef<HTMLDivElement>(null);
 
   return (
-    <SurfacePanel
+    <div
       ref={composerPanelRef}
-      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
+      className="grid gap-0 overflow-visible rounded-[20px] border border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
       aria-label="Composer panel"
     >
       <ComposerPromptSurface
@@ -63,6 +62,6 @@ export function Composer(props: ComposerProps) {
         composerPanelRef={composerPanelRef}
         onOpenGitOps={props.onOpenGitOpsView}
       />
-    </SurfacePanel>
+    </div>
   );
 }

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -3,6 +3,7 @@ import type {
   ComposerAttachment,
   ComposerFilePickerState,
   ComposerModel,
+  ComposerStreamingBehavior,
   ComposerThinkingLevel,
   DesktopActionInvoker,
   ProjectDiffBaseline,
@@ -17,7 +18,10 @@ export type ComposerProps = {
   hostLabel: string;
   model: ComposerModel | null;
   availableModels: ComposerModel[];
+  isStreaming: boolean;
   thinkingLevel: ComposerThinkingLevel;
+  restoredQueuedPrompt: string | null;
+  streamingBehaviorPreference: ComposerStreamingBehavior;
   availableThinkingLevels: ComposerThinkingLevel[];
   projectId: string;
   projectGitState: ProjectGitState | null;
@@ -36,6 +40,7 @@ export type ComposerProps = {
   promptResetKey: number;
   onOpenTakeoverTerminal: () => void;
   onOpenGitOpsView: () => void;
+  onRestoredQueuedPromptApplied: () => void;
   onToggleTerminal: () => void;
   terminalVisible: boolean;
   onLayoutChange: () => void;

--- a/src/app/components/workspace/GitOpsComposerPanel.tsx
+++ b/src/app/components/workspace/GitOpsComposerPanel.tsx
@@ -4,7 +4,6 @@ import type {
   ProjectDiffBaseline,
   ProjectGitState,
 } from "../../desktop/types";
-import { SurfacePanel } from "../common/SurfacePanel";
 import { ComposerGitOpsSurface } from "./composer/ComposerGitOpsSurface";
 import type { SavedDiffComment } from "./diff/diffCommentStore";
 
@@ -44,9 +43,9 @@ export function GitOpsComposerPanel({
   const composerPanelRef = useRef<HTMLDivElement>(null);
 
   return (
-    <SurfacePanel
+    <div
       ref={composerPanelRef}
-      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
+      className="grid gap-0 overflow-visible rounded-[20px] border border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
       aria-label="Git ops composer panel"
     >
       <ComposerGitOpsSurface
@@ -66,6 +65,6 @@ export function GitOpsComposerPanel({
         onLayoutChange={onLayoutChange}
         onBack={onBack}
       />
-    </SurfacePanel>
+    </div>
   );
 }

--- a/src/app/components/workspace/GitOpsComposerPanel.tsx
+++ b/src/app/components/workspace/GitOpsComposerPanel.tsx
@@ -46,7 +46,7 @@ export function GitOpsComposerPanel({
   return (
     <SurfacePanel
       ref={composerPanelRef}
-      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
+      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
       aria-label="Git ops composer panel"
     >
       <ComposerGitOpsSurface

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -25,7 +25,10 @@ export function ComposerPromptSurface({
   composerPanelRef,
   model,
   availableModels,
+  isStreaming,
   thinkingLevel,
+  restoredQueuedPrompt,
+  streamingBehaviorPreference,
   availableThinkingLevels,
   projectId,
   projectGitState,
@@ -34,6 +37,7 @@ export function ComposerPromptSurface({
   favoriteFolders,
   onOpenTakeoverTerminal,
   onToggleTerminal,
+  onRestoredQueuedPromptApplied,
   onPickAttachments,
   onListAttachmentEntries,
   onAction,
@@ -53,6 +57,7 @@ export function ComposerPromptSurface({
     clearError,
     draft,
     errorMessage,
+    isStreaming: composerIsStreaming,
     pickerButtonRef,
     pickerLoading,
     pickerOpen,
@@ -71,6 +76,7 @@ export function ComposerPromptSurface({
     send,
     setDraft,
     setOpenMenu,
+    stop,
     attachPendingPickerAttachments,
     togglePendingPickerAttachment,
     thinkingLevelLabels,
@@ -78,7 +84,11 @@ export function ComposerPromptSurface({
     model,
     projectId,
     sessionPath,
+    isStreaming,
+    restoredQueuedPrompt,
+    streamingBehaviorPreference,
     onAction,
+    onRestoredQueuedPromptApplied,
     onPickAttachments,
     onListAttachmentEntries,
   });
@@ -169,9 +179,10 @@ export function ComposerPromptSurface({
                 type="button"
                 className={cn(
                   compactIconButtonClass,
-                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1]",
+                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
-                onClick={() => undefined}
+                onClick={() => void stop()}
+                disabled={!composerIsStreaming}
                 aria-label="Stop Pi"
                 title="Stop Pi"
               >

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -57,6 +57,7 @@ export function ComposerPromptSurface({
     clearError,
     draft,
     errorMessage,
+    isSending,
     isStreaming: composerIsStreaming,
     pickerButtonRef,
     pickerLoading,
@@ -182,7 +183,7 @@ export function ComposerPromptSurface({
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
                 onClick={() => void stop()}
-                disabled={!composerIsStreaming}
+                disabled={!composerIsStreaming || isSending}
                 aria-label="Stop Pi"
                 title="Stop Pi"
               >

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -1,4 +1,4 @@
-import { Bot, GitBranch, Mic, Plus, Send, Terminal } from "lucide-react";
+import { Bot, GitBranch, Mic, Plus, Send, Square, Terminal } from "lucide-react";
 import type { RefObject } from "react";
 import { getFeatureStatusButtonClass } from "../../../features/feature-status";
 import { compactCardClass, compactIconButtonClass, iconButtonClass } from "../../../ui/classes";
@@ -169,11 +169,24 @@ export function ComposerPromptSurface({
                 type="button"
                 className={cn(
                   compactIconButtonClass,
+                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1]",
+                )}
+                onClick={() => undefined}
+                aria-label="Stop Pi"
+                title="Stop Pi"
+              >
+                <Square size={11} fill="currentColor" />
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  compactIconButtonClass,
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
                 onClick={() => void send()}
                 disabled={!canSend}
                 aria-label="Send"
+                title="Send"
               >
                 <Send size={14} />
               </button>

--- a/src/app/components/workspace/composer/MockQueuedPromptsCard.tsx
+++ b/src/app/components/workspace/composer/MockQueuedPromptsCard.tsx
@@ -23,8 +23,12 @@ export function MockQueuedPromptsCard({
   }
 
   return (
-    <div className="mx-auto grid w-full max-w-[664px] gap-1.5">
-      <div className="px-1 text-[12px] text-[color:var(--muted)]">
+    <div
+      className={cn(
+        "relative -left-1 mx-auto grid w-full max-w-[664px] gap-1.5 rounded-t-xl rounded-b-none border border-[color:var(--border)] bg-[#272a39] px-2.5 py-2",
+      )}
+    >
+      <div className="pl-3.5 text-[12px] text-[color:var(--muted)]">
         Queued messages. Click to edit.
       </div>
 
@@ -34,7 +38,7 @@ export function MockQueuedPromptsCard({
             key={prompt.id}
             className={cn(
               compactCardClass,
-              "group grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-xl border-transparent bg-transparent px-1 py-0 text-[12px] shadow-none hover:border-[color:var(--border)] hover:bg-[rgba(255,255,255,0.03)]",
+              "group grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-xl border-transparent px-1 py-0 text-[12px] shadow-none hover:border-[color:var(--border)]",
             )}
           >
             <button

--- a/src/app/components/workspace/composer/MockQueuedPromptsCard.tsx
+++ b/src/app/components/workspace/composer/MockQueuedPromptsCard.tsx
@@ -1,0 +1,63 @@
+import { X } from "lucide-react";
+import { compactCardClass, compactIconButtonClass } from "../../../ui/classes";
+import { cn } from "../../../utils/cn";
+
+export type MockQueuedPrompt = {
+  id: string;
+  text: string;
+};
+
+type MockQueuedPromptsCardProps = {
+  prompts: MockQueuedPrompt[];
+  onEditPrompt: (promptId: string) => void;
+  onRemovePrompt: (promptId: string) => void;
+};
+
+export function MockQueuedPromptsCard({
+  prompts,
+  onEditPrompt,
+  onRemovePrompt,
+}: MockQueuedPromptsCardProps) {
+  if (prompts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto grid w-full max-w-[664px] gap-1.5">
+      <div className="px-1 text-[12px] text-[color:var(--muted)]">
+        Queued messages. Click to edit.
+      </div>
+
+      <div className="grid gap-1">
+        {prompts.map((prompt) => (
+          <div
+            key={prompt.id}
+            className={cn(
+              compactCardClass,
+              "group grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-xl border-transparent bg-transparent px-1 py-0 text-[12px] shadow-none hover:border-[color:var(--border)] hover:bg-[rgba(255,255,255,0.03)]",
+            )}
+          >
+            <button
+              type="button"
+              className="min-w-0 px-2.5 py-1 text-left text-[12px] leading-5 text-[color:var(--text)]/88"
+              onClick={() => onEditPrompt(prompt.id)}
+              title={prompt.text}
+            >
+              <span className="block truncate">{prompt.text}</span>
+            </button>
+
+            <button
+              type="button"
+              className={cn(compactIconButtonClass, "mr-1 shrink-0")}
+              onClick={() => onRemovePrompt(prompt.id)}
+              aria-label="Remove queued message"
+              title="Remove queued message"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/workspace/composer/QueuedPromptsCard.tsx
+++ b/src/app/components/workspace/composer/QueuedPromptsCard.tsx
@@ -5,12 +5,14 @@ import { cn } from "../../../utils/cn";
 
 type QueuedPromptsCardProps = {
   prompts: ComposerQueuedPrompt[];
+  pendingPromptIds?: string[];
   onEditPrompt: (prompt: ComposerQueuedPrompt) => void;
   onRemovePrompt: (prompt: ComposerQueuedPrompt) => void;
 };
 
 export function QueuedPromptsCard({
   prompts,
+  pendingPromptIds = [],
   onEditPrompt,
   onRemovePrompt,
 }: QueuedPromptsCardProps) {
@@ -29,32 +31,39 @@ export function QueuedPromptsCard({
       </div>
 
       <div className="grid gap-1">
-        {prompts.map((prompt) => (
-          <div
-            key={prompt.id}
-            className={cn(
-              compactCardClass,
-              "group grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-xl border-transparent px-1 py-0 text-[12px] shadow-none hover:border-[color:var(--border)]",
-            )}
-          >
-            <button
-              type="button"
-              className="min-w-0 px-2.5 py-1 text-left text-[12px] leading-5 text-[color:var(--text)]/88"
-              onClick={() => onEditPrompt(prompt)}
-            >
-              <span className="block truncate">{prompt.text}</span>
-            </button>
+        {prompts.map((prompt) => {
+          const isPending = pendingPromptIds.includes(prompt.id);
 
-            <button
-              type="button"
-              className={cn(compactIconButtonClass, "mr-1 shrink-0")}
-              onClick={() => onRemovePrompt(prompt)}
-              aria-label="Remove queued message"
+          return (
+            <div
+              key={prompt.id}
+              className={cn(
+                compactCardClass,
+                "group grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-xl border-transparent px-1 py-0 text-[12px] shadow-none hover:border-[color:var(--border)]",
+                isPending && "opacity-60",
+              )}
             >
-              <X size={12} />
-            </button>
-          </div>
-        ))}
+              <button
+                type="button"
+                className="min-w-0 px-2.5 py-1 text-left text-[12px] leading-5 text-[color:var(--text)]/88 disabled:cursor-default"
+                onClick={() => onEditPrompt(prompt)}
+                disabled={isPending}
+              >
+                <span className="block truncate">{prompt.text}</span>
+              </button>
+
+              <button
+                type="button"
+                className={cn(compactIconButtonClass, "mr-1 shrink-0")}
+                onClick={() => onRemovePrompt(prompt)}
+                aria-label="Remove queued message"
+                disabled={isPending}
+              >
+                <X size={12} />
+              </button>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/components/workspace/composer/QueuedPromptsCard.tsx
+++ b/src/app/components/workspace/composer/QueuedPromptsCard.tsx
@@ -1,23 +1,19 @@
 import { X } from "lucide-react";
+import type { ComposerQueuedPrompt } from "../../../desktop/types";
 import { compactCardClass, compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 
-export type MockQueuedPrompt = {
-  id: string;
-  text: string;
+type QueuedPromptsCardProps = {
+  prompts: ComposerQueuedPrompt[];
+  onEditPrompt: (prompt: ComposerQueuedPrompt) => void;
+  onRemovePrompt: (prompt: ComposerQueuedPrompt) => void;
 };
 
-type MockQueuedPromptsCardProps = {
-  prompts: MockQueuedPrompt[];
-  onEditPrompt: (promptId: string) => void;
-  onRemovePrompt: (promptId: string) => void;
-};
-
-export function MockQueuedPromptsCard({
+export function QueuedPromptsCard({
   prompts,
   onEditPrompt,
   onRemovePrompt,
-}: MockQueuedPromptsCardProps) {
+}: QueuedPromptsCardProps) {
   if (prompts.length === 0) {
     return null;
   }
@@ -44,8 +40,7 @@ export function MockQueuedPromptsCard({
             <button
               type="button"
               className="min-w-0 px-2.5 py-1 text-left text-[12px] leading-5 text-[color:var(--text)]/88"
-              onClick={() => onEditPrompt(prompt.id)}
-              title={prompt.text}
+              onClick={() => onEditPrompt(prompt)}
             >
               <span className="block truncate">{prompt.text}</span>
             </button>
@@ -53,9 +48,8 @@ export function MockQueuedPromptsCard({
             <button
               type="button"
               className={cn(compactIconButtonClass, "mr-1 shrink-0")}
-              onClick={() => onRemovePrompt(prompt.id)}
+              onClick={() => onRemovePrompt(prompt)}
               aria-label="Remove queued message"
-              title="Remove queued message"
             >
               <X size={12} />
             </button>

--- a/src/app/components/workspace/composer/composer-queue.helpers.ts
+++ b/src/app/components/workspace/composer/composer-queue.helpers.ts
@@ -1,0 +1,21 @@
+export function mergeDraftWithRestoredQueuedPrompt(
+  currentDraft: string,
+  restoredQueuedPrompt: string,
+) {
+  const currentText = currentDraft.trim();
+  const restoredText = restoredQueuedPrompt.trim();
+
+  if (!restoredText) {
+    return currentDraft;
+  }
+
+  if (!currentText) {
+    return restoredQueuedPrompt;
+  }
+
+  if (currentText === restoredText) {
+    return currentDraft;
+  }
+
+  return `${currentDraft.replace(/\s+$/u, "")}\n\n${restoredQueuedPrompt}`;
+}

--- a/src/app/components/workspace/composer/submitComposerDraft.ts
+++ b/src/app/components/workspace/composer/submitComposerDraft.ts
@@ -2,6 +2,7 @@ import type {
   ComposerAttachment,
   ComposerStreamingBehavior,
   DesktopActionInvoker,
+  DesktopActionResult,
 } from "../../../desktop/types";
 
 type SubmitComposerDraftResult =
@@ -23,6 +24,18 @@ type SubmitComposerDraftOptions = {
   clearStoredDraft: (threadId: string) => void;
 };
 
+function getDesktopActionErrorMessage(actionResult: DesktopActionResult | null) {
+  if (actionResult?.ok === false && typeof actionResult.result?.error === "string") {
+    return actionResult.result.error;
+  }
+
+  if (typeof actionResult?.result?.error === "string") {
+    return actionResult.result.error;
+  }
+
+  return actionResult?.ok === false ? "Could not send prompt." : null;
+}
+
 export async function submitComposerDraft({
   draft,
   attachments,
@@ -42,21 +55,39 @@ export async function submitComposerDraft({
 
   try {
     if (isStreaming && streamingBehaviorPreference === "stop") {
-      await onAction("composer.stop", {
+      const actionResult = await onAction("composer.stop", {
         projectId,
         sessionPath,
       });
 
+      const actionErrorMessage = getDesktopActionErrorMessage(actionResult);
+      if (actionErrorMessage) {
+        return {
+          status: "error",
+          errorMessage: actionErrorMessage,
+          text,
+        };
+      }
+
       return { status: "stopped", text };
     }
 
-    await onAction("composer.send", {
+    const actionResult = await onAction("composer.send", {
       text,
       attachments,
       projectId,
       sessionPath,
       streamingBehavior: streamingBehaviorPreference,
     });
+
+    const actionErrorMessage = getDesktopActionErrorMessage(actionResult);
+    if (actionErrorMessage) {
+      return {
+        status: "error",
+        errorMessage: actionErrorMessage,
+        text,
+      };
+    }
 
     if (draftThreadId) {
       clearStoredDraft(draftThreadId);

--- a/src/app/components/workspace/composer/submitComposerDraft.ts
+++ b/src/app/components/workspace/composer/submitComposerDraft.ts
@@ -1,9 +1,13 @@
-import type { DesktopAction } from "../../../desktop/actions";
-import type { ComposerAttachment, DesktopActionInvoker } from "../../../desktop/types";
+import type {
+  ComposerAttachment,
+  ComposerStreamingBehavior,
+  DesktopActionInvoker,
+} from "../../../desktop/types";
 
 type SubmitComposerDraftResult =
   | { status: "skipped" }
   | { status: "sent"; text: string }
+  | { status: "stopped"; text: string }
   | { status: "error"; errorMessage: string; text: string };
 
 type SubmitComposerDraftOptions = {
@@ -11,8 +15,10 @@ type SubmitComposerDraftOptions = {
   attachments: ComposerAttachment[];
   draftThreadId: string | null;
   isSending: boolean;
+  isStreaming: boolean;
   projectId: string;
   sessionPath: string | null;
+  streamingBehaviorPreference: ComposerStreamingBehavior;
   onAction: DesktopActionInvoker;
   clearStoredDraft: (threadId: string) => void;
 };
@@ -22,8 +28,10 @@ export async function submitComposerDraft({
   attachments,
   draftThreadId,
   isSending,
+  isStreaming,
   projectId,
   sessionPath,
+  streamingBehaviorPreference,
   onAction,
   clearStoredDraft,
 }: SubmitComposerDraftOptions): Promise<SubmitComposerDraftResult> {
@@ -33,11 +41,21 @@ export async function submitComposerDraft({
   }
 
   try {
+    if (isStreaming && streamingBehaviorPreference === "stop") {
+      await onAction("composer.stop", {
+        projectId,
+        sessionPath,
+      });
+
+      return { status: "stopped", text };
+    }
+
     await onAction("composer.send", {
       text,
       attachments,
       projectId,
       sessionPath,
+      streamingBehavior: streamingBehaviorPreference,
     });
 
     if (draftThreadId) {

--- a/src/app/components/workspace/composer/submitComposerDraft.ts
+++ b/src/app/components/workspace/composer/submitComposerDraft.ts
@@ -2,8 +2,8 @@ import type {
   ComposerAttachment,
   ComposerStreamingBehavior,
   DesktopActionInvoker,
-  DesktopActionResult,
 } from "../../../desktop/types";
+import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
 
 type SubmitComposerDraftResult =
   | { status: "skipped" }
@@ -16,7 +16,6 @@ type SubmitComposerDraftOptions = {
   attachments: ComposerAttachment[];
   draftThreadId: string | null;
   isSending: boolean;
-  isStreaming: boolean;
   projectId: string;
   sessionPath: string | null;
   streamingBehaviorPreference: ComposerStreamingBehavior;
@@ -24,24 +23,11 @@ type SubmitComposerDraftOptions = {
   clearStoredDraft: (threadId: string) => void;
 };
 
-function getDesktopActionErrorMessage(actionResult: DesktopActionResult | null) {
-  if (actionResult?.ok === false && typeof actionResult.result?.error === "string") {
-    return actionResult.result.error;
-  }
-
-  if (typeof actionResult?.result?.error === "string") {
-    return actionResult.result.error;
-  }
-
-  return actionResult?.ok === false ? "Could not send prompt." : null;
-}
-
 export async function submitComposerDraft({
   draft,
   attachments,
   draftThreadId,
   isSending,
-  isStreaming,
   projectId,
   sessionPath,
   streamingBehaviorPreference,
@@ -54,24 +40,6 @@ export async function submitComposerDraft({
   }
 
   try {
-    if (isStreaming && streamingBehaviorPreference === "stop") {
-      const actionResult = await onAction("composer.stop", {
-        projectId,
-        sessionPath,
-      });
-
-      const actionErrorMessage = getDesktopActionErrorMessage(actionResult);
-      if (actionErrorMessage) {
-        return {
-          status: "error",
-          errorMessage: actionErrorMessage,
-          text,
-        };
-      }
-
-      return { status: "stopped", text };
-    }
-
     const actionResult = await onAction("composer.send", {
       text,
       attachments,
@@ -80,13 +48,17 @@ export async function submitComposerDraft({
       streamingBehavior: streamingBehaviorPreference,
     });
 
-    const actionErrorMessage = getDesktopActionErrorMessage(actionResult);
+    const actionErrorMessage = getDesktopActionErrorMessage(actionResult, "Could not send prompt.");
     if (actionErrorMessage) {
       return {
         status: "error",
         errorMessage: actionErrorMessage,
         text,
       };
+    }
+
+    if (actionResult?.result?.composerSendOutcome === "stopped") {
+      return { status: "stopped", text };
     }
 
     if (draftThreadId) {

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -8,6 +8,7 @@ import type {
   ComposerThinkingLevel,
   DesktopActionInvoker,
 } from "../../../desktop/types";
+import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
 import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
 import { mergeDraftWithRestoredQueuedPrompt } from "./composer-queue.helpers";
 import { composerDraftStore, getComposerDraftThreadId } from "./composerDraftStore";
@@ -191,7 +192,6 @@ export function useComposerController({
       attachments: submittedAttachments,
       draftThreadId: submittedDraftThreadId,
       isSending,
-      isStreaming,
       projectId,
       sessionPath,
       streamingBehaviorPreference,
@@ -218,10 +218,15 @@ export function useComposerController({
     setErrorMessage(null);
 
     try {
-      await onAction("composer.stop", {
+      const result = await onAction("composer.stop", {
         projectId,
         sessionPath,
       });
+
+      const actionErrorMessage = getDesktopActionErrorMessage(result, "Could not stop Pi.");
+      if (actionErrorMessage) {
+        setErrorMessage(actionErrorMessage);
+      }
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Could not stop Pi.");
     }

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -220,6 +220,7 @@ export function useComposerController({
       return;
     }
 
+    setIsSending(true);
     setErrorMessage(null);
 
     try {
@@ -234,6 +235,8 @@ export function useComposerController({
       }
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Could not stop Pi.");
+    } finally {
+      setIsSending(false);
     }
   };
 

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -9,6 +9,7 @@ import type {
   DesktopActionInvoker,
 } from "../../../desktop/types";
 import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
+import { mergeDraftWithRestoredQueuedPrompt } from "./composer-queue.helpers";
 import { composerDraftStore, getComposerDraftThreadId } from "./composerDraftStore";
 import { submitComposerDraft } from "./submitComposerDraft";
 
@@ -108,7 +109,10 @@ export function useComposerController({
       return;
     }
 
-    setDraft(restoredQueuedPrompt);
+    setDraft((currentDraft) =>
+      mergeDraftWithRestoredQueuedPrompt(currentDraft, restoredQueuedPrompt),
+    );
+    setAttachments([]);
     setOpenMenu(null);
     setErrorMessage(null);
     onRestoredQueuedPromptApplied();

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -112,7 +112,6 @@ export function useComposerController({
     setDraft((currentDraft) =>
       mergeDraftWithRestoredQueuedPrompt(currentDraft, restoredQueuedPrompt),
     );
-    setAttachments([]);
     setOpenMenu(null);
     setErrorMessage(null);
     onRestoredQueuedPromptApplied();
@@ -206,11 +205,6 @@ export function useComposerController({
         currentAttachments.length === 0 ? submittedAttachments : currentAttachments,
       );
       setErrorMessage(result.errorMessage);
-    }
-
-    if (result.status === "sent" && activeDraftThreadIdRef.current === submittedDraftThreadId) {
-      setDraft("");
-      setAttachments([]);
     }
 
     setIsSending(false);

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -176,19 +176,17 @@ export function useComposerController({
     }
 
     const submittedAttachments = attachments;
+    const submittedDraft = draft;
     const submittedDraftThreadId = draftThreadId;
-    const shouldClearComposer = !isStreaming || streamingBehaviorPreference !== "stop";
 
     setIsSending(true);
     setErrorMessage(null);
-    if (shouldClearComposer) {
-      skipNextDraftPersistenceRef.current = submittedDraftThreadId;
-      setDraft("");
-      setAttachments([]);
-    }
+    skipNextDraftPersistenceRef.current = submittedDraftThreadId;
+    setDraft("");
+    setAttachments([]);
 
     const result = await submitComposerDraft({
-      draft,
+      draft: submittedDraft,
       attachments: submittedAttachments,
       draftThreadId: submittedDraftThreadId,
       isSending,
@@ -205,6 +203,13 @@ export function useComposerController({
         currentAttachments.length === 0 ? submittedAttachments : currentAttachments,
       );
       setErrorMessage(result.errorMessage);
+    }
+
+    if (result.status === "stopped" && activeDraftThreadIdRef.current === submittedDraftThreadId) {
+      setDraft((currentDraft) => (currentDraft.length === 0 ? result.text : currentDraft));
+      setAttachments((currentAttachments) =>
+        currentAttachments.length === 0 ? submittedAttachments : currentAttachments,
+      );
     }
 
     setIsSending(false);

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -4,6 +4,7 @@ import type {
   ComposerAttachment,
   ComposerFilePickerState,
   ComposerModel,
+  ComposerStreamingBehavior,
   ComposerThinkingLevel,
   DesktopActionInvoker,
 } from "../../../desktop/types";
@@ -32,7 +33,11 @@ type UseComposerControllerProps = {
   model: ComposerModel | null;
   projectId: string;
   sessionPath: string | null;
+  isStreaming: boolean;
+  restoredQueuedPrompt: string | null;
+  streamingBehaviorPreference: ComposerStreamingBehavior;
   onAction: DesktopActionInvoker;
+  onRestoredQueuedPromptApplied: () => void;
   onPickAttachments: (projectId?: string | null) => Promise<ComposerAttachment[]>;
   onListAttachmentEntries: (request: {
     projectId?: string | null;
@@ -45,7 +50,11 @@ export function useComposerController({
   model,
   projectId,
   sessionPath,
+  isStreaming,
+  restoredQueuedPrompt,
+  streamingBehaviorPreference,
   onAction,
+  onRestoredQueuedPromptApplied,
   onPickAttachments,
   onListAttachmentEntries,
 }: UseComposerControllerProps) {
@@ -93,6 +102,17 @@ export function useComposerController({
 
     composerDraftStore.setDraft(draftThreadId, { prompt: draft, attachments });
   }, [attachments, draft, draftThreadId]);
+
+  useEffect(() => {
+    if (!restoredQueuedPrompt) {
+      return;
+    }
+
+    setDraft(restoredQueuedPrompt);
+    setOpenMenu(null);
+    setErrorMessage(null);
+    onRestoredQueuedPromptApplied();
+  }, [onRestoredQueuedPromptApplied, restoredQueuedPrompt]);
 
   useDismissibleLayer({
     open: openMenu !== null,
@@ -153,20 +173,25 @@ export function useComposerController({
 
     const submittedAttachments = attachments;
     const submittedDraftThreadId = draftThreadId;
+    const shouldClearComposer = !isStreaming || streamingBehaviorPreference !== "stop";
 
     setIsSending(true);
     setErrorMessage(null);
-    skipNextDraftPersistenceRef.current = submittedDraftThreadId;
-    setDraft("");
-    setAttachments([]);
+    if (shouldClearComposer) {
+      skipNextDraftPersistenceRef.current = submittedDraftThreadId;
+      setDraft("");
+      setAttachments([]);
+    }
 
     const result = await submitComposerDraft({
       draft,
       attachments: submittedAttachments,
       draftThreadId: submittedDraftThreadId,
       isSending,
+      isStreaming,
       projectId,
       sessionPath,
+      streamingBehaviorPreference,
       onAction,
       clearStoredDraft: (threadId) => composerDraftStore.clearThreadDraft(threadId),
     });
@@ -179,7 +204,29 @@ export function useComposerController({
       setErrorMessage(result.errorMessage);
     }
 
+    if (result.status === "sent" && activeDraftThreadIdRef.current === submittedDraftThreadId) {
+      setDraft("");
+      setAttachments([]);
+    }
+
     setIsSending(false);
+  };
+
+  const stop = async () => {
+    if (!isStreaming || isSending) {
+      return;
+    }
+
+    setErrorMessage(null);
+
+    try {
+      await onAction("composer.stop", {
+        projectId,
+        sessionPath,
+      });
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Could not stop Pi.");
+    }
   };
 
   const pickAttachments = async () => {
@@ -256,6 +303,7 @@ export function useComposerController({
     modelLabel,
     modelMenuOpen: openMenu === "model",
     modelMenuRef,
+    isStreaming,
     pendingPickerAttachments,
     pickAttachments,
     openPickerDirectory,
@@ -266,6 +314,7 @@ export function useComposerController({
     send,
     setDraft,
     setOpenMenu,
+    stop,
     attachPendingPickerAttachments,
     togglePendingPickerAttachment,
     thinkingLevelLabels,

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -9,21 +9,25 @@ import { ComposerTextField } from "../composer/ComposerTextField";
 type InboxComposerProps = {
   draft: string;
   errorMessage: string | null;
+  isStreaming: boolean;
   isSending: boolean;
   onChangeDraft: (value: string) => void;
   onDismiss: () => void;
   onOpenThread: () => void;
   onSend: () => void;
+  onStop: () => void;
 };
 
 export function InboxComposer({
   draft,
   errorMessage,
+  isStreaming,
   isSending,
   onChangeDraft,
   onDismiss,
   onOpenThread,
   onSend,
+  onStop,
 }: InboxComposerProps) {
   const canSend = draft.trim().length > 0 && !isSending;
 
@@ -55,9 +59,10 @@ export function InboxComposer({
                 type="button"
                 className={cn(
                   compactIconButtonClass,
-                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1]",
+                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
-                onClick={() => undefined}
+                onClick={onStop}
+                disabled={!isStreaming || isSending}
                 aria-label="Stop Pi"
                 title="Stop Pi"
               >

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Send, X } from "lucide-react";
+import { ArrowUpRight, Send, Square, X } from "lucide-react";
 import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { IconButton } from "../../common/IconButton";
@@ -55,11 +55,24 @@ export function InboxComposer({
                 type="button"
                 className={cn(
                   compactIconButtonClass,
+                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1]",
+                )}
+                onClick={() => undefined}
+                aria-label="Stop Pi"
+                title="Stop Pi"
+              >
+                <Square size={11} fill="currentColor" />
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  compactIconButtonClass,
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
                 onClick={onSend}
                 disabled={!canSend}
                 aria-label="Send"
+                title="Send"
               >
                 <Send size={14} />
               </button>

--- a/src/app/components/workspace/thread/ThreadTimeline.tsx
+++ b/src/app/components/workspace/thread/ThreadTimeline.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Message } from "../../../types";
+import { CHAT_TEXT_MAX_WIDTH_CLASS } from "../../../ui/layout";
 import { ThreadTimelineRow } from "./ThreadTimelineRow";
 import { buildTimelineRows } from "./buildTimelineRows";
 import { CHAT_AUTO_SCROLL_BOTTOM_THRESHOLD_PX, isScrollContainerNearBottom } from "./chat-scroll";
@@ -220,7 +221,9 @@ export function ThreadTimeline({
   return (
     <div className={chatViewportClass}>
       <div ref={containerRef} className={chatScrollableAreaClass} onScroll={handleScroll}>
-        <div className="mx-auto w-full min-w-0 max-w-[744px] overflow-x-hidden px-4 pt-4 pb-4">
+        <div
+          className={`mx-auto w-full min-w-0 ${CHAT_TEXT_MAX_WIDTH_CLASS} overflow-x-hidden px-4 pt-4 pb-4`}
+        >
           <div className="grid min-w-0 gap-4">{rows.map(renderRow)}</div>
           <div ref={bottomSentinelRef} aria-hidden="true" className="h-px w-full" />
         </div>

--- a/src/app/desktop/action-results.ts
+++ b/src/app/desktop/action-results.ts
@@ -1,0 +1,16 @@
+import type { DesktopActionResult } from "./types";
+
+export function getDesktopActionErrorMessage(
+  actionResult: DesktopActionResult | null,
+  fallbackMessage: string,
+) {
+  if (actionResult?.ok === false && typeof actionResult.result?.error === "string") {
+    return actionResult.result.error;
+  }
+
+  if (typeof actionResult?.result?.error === "string") {
+    return actionResult.result.error;
+  }
+
+  return actionResult?.ok === false ? fallbackMessage : null;
+}

--- a/src/app/desktop/action-results.ts
+++ b/src/app/desktop/action-results.ts
@@ -4,6 +4,10 @@ export function getDesktopActionErrorMessage(
   actionResult: DesktopActionResult | null,
   fallbackMessage: string,
 ) {
+  if (actionResult === null) {
+    return fallbackMessage;
+  }
+
   if (actionResult?.ok === false && typeof actionResult.result?.error === "string") {
     return actionResult.result.error;
   }
@@ -12,5 +16,5 @@ export function getDesktopActionErrorMessage(
     return actionResult.result.error;
   }
 
-  return actionResult?.ok === false ? fallbackMessage : null;
+  return actionResult.ok === false ? fallbackMessage : null;
 }

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -6,6 +6,8 @@ export type {
   ComposerFilePickerEntry,
   ComposerFilePickerState,
   ComposerModel,
+  ComposerQueuedPrompt,
+  ComposerStreamingBehavior,
   ComposerState,
   ComposerStateRequest,
   ComposerThinkingLevel,

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -84,6 +84,7 @@ export function CodeWorkspaceMainView({
     return (
       <InboxView
         key={selectedInboxThread?.sessionPath ?? "inbox-empty"}
+        appSettings={appSettings}
         thread={selectedInboxThread}
         onAction={onAction}
         onDismissThread={onDismissInboxThread}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -198,8 +198,8 @@ export function CodeWorkspaceView({
       const result = await handleAction("composer.dequeue", {
         projectId: composerProjectId,
         sessionPath: terminalSessionPath,
+        queueId: prompt.id,
         queueMode: prompt.mode,
-        queueIndex: prompt.queueIndex,
       });
 
       if (typeof result?.result?.dequeuedText === "string") {
@@ -227,8 +227,8 @@ export function CodeWorkspaceView({
       await handleAction("composer.dequeue", {
         projectId: composerProjectId,
         sessionPath: terminalSessionPath,
+        queueId: prompt.id,
         queueMode: prompt.mode,
-        queueIndex: prompt.queueIndex,
       });
     } finally {
       pendingQueuedPromptIdsRef.current.delete(prompt.id);

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -212,6 +212,7 @@ export function CodeWorkspaceView({
         projectId: composerProjectId,
         sessionPath: terminalSessionPath,
         queueId: prompt.id,
+        queueSnapshotKey: prompt.queueSnapshotKey,
         queueMode: prompt.mode,
       });
 
@@ -243,6 +244,7 @@ export function CodeWorkspaceView({
         projectId: composerProjectId,
         sessionPath: terminalSessionPath,
         queueId: prompt.id,
+        queueSnapshotKey: prompt.queueSnapshotKey,
         queueMode: prompt.mode,
       });
     } finally {

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { AppShellController } from "../../app-shell/useAppShellController";
+import { getDesktopActionErrorMessage } from "../../desktop/action-results";
 import { Composer } from "../../components/workspace/Composer";
 import { DiffPanel } from "../../components/workspace/DiffPanel";
 import { GitOpsComposerPanel } from "../../components/workspace/GitOpsComposerPanel";
@@ -10,7 +11,7 @@ import {
   diffCommentStore,
   getDiffCommentContextId,
 } from "../../components/workspace/diff/diffCommentStore";
-import type { ProjectDiffBaseline } from "../../desktop/types";
+import type { ComposerQueuedPrompt, ProjectDiffBaseline } from "../../desktop/types";
 import { mainPanelClass } from "../../ui/classes";
 import { CodeWorkspaceMainView } from "./CodeWorkspaceMainView";
 
@@ -29,6 +30,12 @@ type CodeWorkspaceViewProps = {
 
 const TERMINAL_DRAWER_OFFSET = "min(28rem, calc(100% - 2.5rem))";
 const TERMINAL_DRAWER_FOOTER_OFFSET = `calc(${TERMINAL_DRAWER_OFFSET} + 1.25rem)`;
+
+type RestoredQueuedPromptState = {
+  projectId: string;
+  sessionPath: string | null;
+  text: string;
+};
 
 export function CodeWorkspaceView({
   controller,
@@ -52,8 +59,11 @@ export function CodeWorkspaceView({
   const [selectedDiffCommentJumpKey, setSelectedDiffCommentJumpKey] = useState(0);
   const [diffCommentsSending, setDiffCommentsSending] = useState(false);
   const [diffCommentError, setDiffCommentError] = useState<string | null>(null);
-  const [restoredQueuedPrompt, setRestoredQueuedPrompt] = useState<string | null>(null);
-  const footerRef = useRef<HTMLDivElement>(null);
+  const [restoredQueuedPrompt, setRestoredQueuedPrompt] =
+    useState<RestoredQueuedPromptState | null>(null);
+  const [pendingQueuedPromptIds, setPendingQueuedPromptIds] = useState<string[]>([]);
+  const pendingQueuedPromptIdsRef = useRef(new Set<string>());
+  const footerRef = useRef<HTMLElement>(null);
   const {
     handleAction,
     handleLoadEarlierMessages,
@@ -76,6 +86,12 @@ export function CodeWorkspaceView({
     () => getDiffCommentContextId({ projectId: composerProjectId }),
     [composerProjectId],
   );
+
+  const scopedRestoredQueuedPrompt =
+    restoredQueuedPrompt?.projectId === composerProjectId &&
+    restoredQueuedPrompt.sessionPath === terminalSessionPath
+      ? restoredQueuedPrompt.text
+      : null;
 
   useLayoutEffect(() => {
     const footer = footerRef.current;
@@ -142,16 +158,24 @@ export function CodeWorkspaceView({
     try {
       const streamingBehaviorPreference =
         shellState?.appSettings.composerStreamingBehavior ?? "followUp";
-
-      if (activeThreadData?.isStreaming && streamingBehaviorPreference === "stop") {
-        await handleAction("composer.stop");
-        return;
-      }
-
-      await handleAction("composer.send", {
+      const result = await handleAction("composer.send", {
         text: buildDiffCommentPrompt({ comments: context.comments, instruction: message }),
         streamingBehavior: streamingBehaviorPreference,
       });
+
+      const actionErrorMessage = getDesktopActionErrorMessage(
+        result,
+        "Could not send comments to the agent.",
+      );
+      if (actionErrorMessage) {
+        setDiffCommentError(actionErrorMessage);
+        return;
+      }
+
+      if (result?.result?.composerSendOutcome === "stopped") {
+        return;
+      }
+
       diffCommentStore.clearContext(diffCommentContextId);
     } catch (error) {
       setDiffCommentError(
@@ -159,6 +183,56 @@ export function CodeWorkspaceView({
       );
     } finally {
       setDiffCommentsSending(false);
+    }
+  };
+
+  const handleEditQueuedPrompt = async (prompt: ComposerQueuedPrompt) => {
+    if (pendingQueuedPromptIdsRef.current.has(prompt.id)) {
+      return;
+    }
+
+    pendingQueuedPromptIdsRef.current.add(prompt.id);
+    setPendingQueuedPromptIds((current) => [...current, prompt.id]);
+
+    try {
+      const result = await handleAction("composer.dequeue", {
+        projectId: composerProjectId,
+        sessionPath: terminalSessionPath,
+        queueMode: prompt.mode,
+        queueIndex: prompt.queueIndex,
+      });
+
+      if (typeof result?.result?.dequeuedText === "string") {
+        setRestoredQueuedPrompt({
+          projectId: composerProjectId,
+          sessionPath: terminalSessionPath,
+          text: result.result.dequeuedText,
+        });
+      }
+    } finally {
+      pendingQueuedPromptIdsRef.current.delete(prompt.id);
+      setPendingQueuedPromptIds((current) => current.filter((id) => id !== prompt.id));
+    }
+  };
+
+  const handleRemoveQueuedPrompt = async (prompt: ComposerQueuedPrompt) => {
+    if (pendingQueuedPromptIdsRef.current.has(prompt.id)) {
+      return;
+    }
+
+    pendingQueuedPromptIdsRef.current.add(prompt.id);
+    setPendingQueuedPromptIds((current) => [...current, prompt.id]);
+
+    try {
+      await handleAction("composer.dequeue", {
+        projectId: composerProjectId,
+        sessionPath: terminalSessionPath,
+        queueMode: prompt.mode,
+        queueIndex: prompt.queueIndex,
+      });
+    } finally {
+      pendingQueuedPromptIdsRef.current.delete(prompt.id);
+      setPendingQueuedPromptIds((current) => current.filter((id) => id !== prompt.id));
     }
   };
 
@@ -239,13 +313,14 @@ export function CodeWorkspaceView({
 
       {showWorkspaceFooter ? (
         <footer
+          ref={footerRef}
           className="motion-terminal-drawer-offset pointer-events-none absolute inset-x-0 bottom-0 z-10 px-5 pb-4"
           style={terminalDrawerFooterPaddingStyle}
         >
           <div className="pointer-events-auto grid gap-2.5">
             <div className={workspaceContentClass}>
               {state.activeView === "gitops" ? (
-                <div ref={footerRef}>
+                <div>
                   <GitOpsComposerPanel
                     projectGitState={projectGitState}
                     diffBaseline={diffBaseline}
@@ -273,27 +348,15 @@ export function CodeWorkspaceView({
                 <div className="grid gap-0">
                   <QueuedPromptsCard
                     prompts={activeComposerState?.queuedPrompts ?? []}
-                    onEditPrompt={async (prompt) => {
-                      const result = await handleAction("composer.dequeue", {
-                        projectId: composerProjectId,
-                        sessionPath: terminalSessionPath,
-                        queueMode: prompt.mode,
-                        queueIndex: prompt.queueIndex,
-                      });
-                      if (typeof result?.result?.dequeuedText === "string") {
-                        setRestoredQueuedPrompt(result.result.dequeuedText);
-                      }
+                    pendingPromptIds={pendingQueuedPromptIds}
+                    onEditPrompt={(prompt) => {
+                      void handleEditQueuedPrompt(prompt);
                     }}
                     onRemovePrompt={(prompt) => {
-                      void handleAction("composer.dequeue", {
-                        projectId: composerProjectId,
-                        sessionPath: terminalSessionPath,
-                        queueMode: prompt.mode,
-                        queueIndex: prompt.queueIndex,
-                      });
+                      void handleRemoveQueuedPrompt(prompt);
                     }}
                   />
-                  <div ref={footerRef}>
+                  <div>
                     <Composer
                       activeView={state.activeView}
                       hostLabel={shellState?.availableHosts[0] ?? "Local"}
@@ -301,7 +364,7 @@ export function CodeWorkspaceView({
                       availableModels={activeComposerState?.availableModels ?? []}
                       isStreaming={activeThreadData?.isStreaming ?? false}
                       thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
-                      restoredQueuedPrompt={restoredQueuedPrompt}
+                      restoredQueuedPrompt={scopedRestoredQueuedPrompt}
                       streamingBehaviorPreference={
                         shellState?.appSettings.composerStreamingBehavior ?? "followUp"
                       }
@@ -332,7 +395,14 @@ export function CodeWorkspaceView({
                       onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
                       onOpenTakeoverTerminal={handleShowTakeoverTerminal}
                       onOpenGitOpsView={handleOpenGitOpsView}
-                      onRestoredQueuedPromptApplied={() => setRestoredQueuedPrompt(null)}
+                      onRestoredQueuedPromptApplied={() => {
+                        setRestoredQueuedPrompt((current) =>
+                          current?.projectId === composerProjectId &&
+                          current.sessionPath === terminalSessionPath
+                            ? null
+                            : current,
+                        );
+                      }}
                       onToggleTerminal={handleToggleTerminal}
                       terminalVisible={state.terminalVisible}
                       onPickAttachments={pickComposerAttachments}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -3,6 +3,10 @@ import type { AppShellController } from "../../app-shell/useAppShellController";
 import { Composer } from "../../components/workspace/Composer";
 import { DiffPanel } from "../../components/workspace/DiffPanel";
 import { GitOpsComposerPanel } from "../../components/workspace/GitOpsComposerPanel";
+import {
+  type MockQueuedPrompt,
+  MockQueuedPromptsCard,
+} from "../../components/workspace/composer/MockQueuedPromptsCard";
 import { buildDiffCommentPrompt } from "../../components/workspace/diff/diffCommentPrompt";
 import {
   type SavedDiffComment,
@@ -28,6 +32,20 @@ type CodeWorkspaceViewProps = {
 
 const TERMINAL_DRAWER_OFFSET = "min(28rem, calc(100% - 2.5rem))";
 const TERMINAL_DRAWER_FOOTER_OFFSET = `calc(${TERMINAL_DRAWER_OFFSET} + 1.25rem)`;
+const mockQueuedPromptsSeed: MockQueuedPrompt[] = [
+  {
+    id: "queued-1",
+    text: "After this finishes, tighten the composer spacing and make the stop action feel more intentional.",
+  },
+  {
+    id: "queued-2",
+    text: "Then add a quick empty state for queued prompts so the transition feels natural when the list clears.",
+  },
+  {
+    id: "queued-3",
+    text: "Finally, revisit whether queued follow-ups should stack newest-first or stay in the order they were added.",
+  },
+];
 
 export function CodeWorkspaceView({
   controller,
@@ -51,6 +69,8 @@ export function CodeWorkspaceView({
   const [selectedDiffCommentJumpKey, setSelectedDiffCommentJumpKey] = useState(0);
   const [diffCommentsSending, setDiffCommentsSending] = useState(false);
   const [diffCommentError, setDiffCommentError] = useState<string | null>(null);
+  const [mockQueuedPrompts, setMockQueuedPrompts] =
+    useState<MockQueuedPrompt[]>(mockQueuedPromptsSeed);
   const footerRef = useRef<HTMLElement>(null);
   const {
     handleAction,
@@ -257,43 +277,57 @@ export function CodeWorkspaceView({
                   onBack={handleCloseGitOpsView}
                 />
               ) : (
-                <Composer
-                  activeView={state.activeView}
-                  hostLabel={shellState?.availableHosts[0] ?? "Local"}
-                  model={activeComposerState?.currentModel ?? null}
-                  availableModels={activeComposerState?.availableModels ?? []}
-                  thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
-                  availableThinkingLevels={activeComposerState?.availableThinkingLevels ?? ["off"]}
-                  projectId={composerProjectId}
-                  projectGitState={projectGitState}
-                  diffBaseline={diffBaseline}
-                  sessionPath={terminalSessionPath}
-                  favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
-                  diffRenderMode={diffRenderMode}
-                  diffComments={diffComments}
-                  diffCommentCount={diffCommentCount}
-                  diffCommentsSending={diffCommentsSending}
-                  diffCommentError={diffCommentError}
-                  onSetDiffBaseline={onSetDiffBaseline}
-                  onSetDiffRenderMode={setDiffRenderMode}
-                  onSendDiffComments={(message) => {
-                    void handleSendDiffComments(message);
-                  }}
-                  onSelectDiffComment={(filePath, commentId) => {
-                    setSelectedDiffCommentId(commentId);
-                    setSelectedDiffCommentJumpKey((current) => current + 1);
-                    handleOpenWorktreeDiffFile(filePath);
-                  }}
-                  promptResetKey={composerPromptResetKey}
-                  onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
-                  onOpenTakeoverTerminal={handleShowTakeoverTerminal}
-                  onOpenGitOpsView={handleOpenGitOpsView}
-                  onToggleTerminal={handleToggleTerminal}
-                  terminalVisible={state.terminalVisible}
-                  onPickAttachments={pickComposerAttachments}
-                  onListAttachmentEntries={listComposerAttachmentEntries}
-                  onAction={handleAction}
-                />
+                <div className="grid gap-0">
+                  <MockQueuedPromptsCard
+                    prompts={mockQueuedPrompts}
+                    onEditPrompt={() => undefined}
+                    onRemovePrompt={(promptId) => {
+                      setMockQueuedPrompts((current) =>
+                        current.filter((prompt) => prompt.id !== promptId),
+                      );
+                      setComposerLayoutVersion((current) => current + 1);
+                    }}
+                  />
+                  <Composer
+                    activeView={state.activeView}
+                    hostLabel={shellState?.availableHosts[0] ?? "Local"}
+                    model={activeComposerState?.currentModel ?? null}
+                    availableModels={activeComposerState?.availableModels ?? []}
+                    thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
+                    availableThinkingLevels={
+                      activeComposerState?.availableThinkingLevels ?? ["off"]
+                    }
+                    projectId={composerProjectId}
+                    projectGitState={projectGitState}
+                    diffBaseline={diffBaseline}
+                    sessionPath={terminalSessionPath}
+                    favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
+                    diffRenderMode={diffRenderMode}
+                    diffComments={diffComments}
+                    diffCommentCount={diffCommentCount}
+                    diffCommentsSending={diffCommentsSending}
+                    diffCommentError={diffCommentError}
+                    onSetDiffBaseline={onSetDiffBaseline}
+                    onSetDiffRenderMode={setDiffRenderMode}
+                    onSendDiffComments={(message) => {
+                      void handleSendDiffComments(message);
+                    }}
+                    onSelectDiffComment={(filePath, commentId) => {
+                      setSelectedDiffCommentId(commentId);
+                      setSelectedDiffCommentJumpKey((current) => current + 1);
+                      handleOpenWorktreeDiffFile(filePath);
+                    }}
+                    promptResetKey={composerPromptResetKey}
+                    onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
+                    onOpenTakeoverTerminal={handleShowTakeoverTerminal}
+                    onOpenGitOpsView={handleOpenGitOpsView}
+                    onToggleTerminal={handleToggleTerminal}
+                    terminalVisible={state.terminalVisible}
+                    onPickAttachments={pickComposerAttachments}
+                    onListAttachmentEntries={listComposerAttachmentEntries}
+                    onAction={handleAction}
+                  />
+                </div>
               )}
             </div>
           </div>

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -71,7 +71,7 @@ export function CodeWorkspaceView({
   const [diffCommentError, setDiffCommentError] = useState<string | null>(null);
   const [mockQueuedPrompts, setMockQueuedPrompts] =
     useState<MockQueuedPrompt[]>(mockQueuedPromptsSeed);
-  const footerRef = useRef<HTMLElement>(null);
+  const footerRef = useRef<HTMLDivElement>(null);
   const {
     handleAction,
     handleLoadEarlierMessages,
@@ -247,61 +247,16 @@ export function CodeWorkspaceView({
 
       {showWorkspaceFooter ? (
         <footer
-          ref={footerRef}
           className="motion-terminal-drawer-offset pointer-events-none absolute inset-x-0 bottom-0 z-10 px-5 pb-4"
           style={terminalDrawerFooterPaddingStyle}
         >
           <div className="pointer-events-auto grid gap-2.5">
             <div className={workspaceContentClass}>
               {state.activeView === "gitops" ? (
-                <GitOpsComposerPanel
-                  projectGitState={projectGitState}
-                  diffBaseline={diffBaseline}
-                  diffRenderMode={diffRenderMode}
-                  diffComments={diffComments}
-                  diffCommentCount={diffCommentCount}
-                  diffCommentsSending={diffCommentsSending}
-                  diffCommentError={diffCommentError}
-                  onSetDiffBaseline={onSetDiffBaseline}
-                  onSetDiffRenderMode={setDiffRenderMode}
-                  onSendDiffComments={(message) => {
-                    void handleSendDiffComments(message);
-                  }}
-                  onSelectDiffComment={(filePath, commentId) => {
-                    setSelectedDiffCommentId(commentId);
-                    setSelectedDiffCommentJumpKey((current) => current + 1);
-                    handleOpenWorktreeDiffFile(filePath);
-                  }}
-                  onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
-                  onAction={handleAction}
-                  onBack={handleCloseGitOpsView}
-                />
-              ) : (
-                <div className="grid gap-0">
-                  <MockQueuedPromptsCard
-                    prompts={mockQueuedPrompts}
-                    onEditPrompt={() => undefined}
-                    onRemovePrompt={(promptId) => {
-                      setMockQueuedPrompts((current) =>
-                        current.filter((prompt) => prompt.id !== promptId),
-                      );
-                      setComposerLayoutVersion((current) => current + 1);
-                    }}
-                  />
-                  <Composer
-                    activeView={state.activeView}
-                    hostLabel={shellState?.availableHosts[0] ?? "Local"}
-                    model={activeComposerState?.currentModel ?? null}
-                    availableModels={activeComposerState?.availableModels ?? []}
-                    thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
-                    availableThinkingLevels={
-                      activeComposerState?.availableThinkingLevels ?? ["off"]
-                    }
-                    projectId={composerProjectId}
+                <div ref={footerRef}>
+                  <GitOpsComposerPanel
                     projectGitState={projectGitState}
                     diffBaseline={diffBaseline}
-                    sessionPath={terminalSessionPath}
-                    favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
                     diffRenderMode={diffRenderMode}
                     diffComments={diffComments}
                     diffCommentCount={diffCommentCount}
@@ -317,16 +272,64 @@ export function CodeWorkspaceView({
                       setSelectedDiffCommentJumpKey((current) => current + 1);
                       handleOpenWorktreeDiffFile(filePath);
                     }}
-                    promptResetKey={composerPromptResetKey}
                     onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
-                    onOpenTakeoverTerminal={handleShowTakeoverTerminal}
-                    onOpenGitOpsView={handleOpenGitOpsView}
-                    onToggleTerminal={handleToggleTerminal}
-                    terminalVisible={state.terminalVisible}
-                    onPickAttachments={pickComposerAttachments}
-                    onListAttachmentEntries={listComposerAttachmentEntries}
                     onAction={handleAction}
+                    onBack={handleCloseGitOpsView}
                   />
+                </div>
+              ) : (
+                <div className="grid gap-0">
+                  <MockQueuedPromptsCard
+                    prompts={mockQueuedPrompts}
+                    onEditPrompt={() => undefined}
+                    onRemovePrompt={(promptId) => {
+                      setMockQueuedPrompts((current) =>
+                        current.filter((prompt) => prompt.id !== promptId),
+                      );
+                      setComposerLayoutVersion((current) => current + 1);
+                    }}
+                  />
+                  <div ref={footerRef}>
+                    <Composer
+                      activeView={state.activeView}
+                      hostLabel={shellState?.availableHosts[0] ?? "Local"}
+                      model={activeComposerState?.currentModel ?? null}
+                      availableModels={activeComposerState?.availableModels ?? []}
+                      thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
+                      availableThinkingLevels={
+                        activeComposerState?.availableThinkingLevels ?? ["off"]
+                      }
+                      projectId={composerProjectId}
+                      projectGitState={projectGitState}
+                      diffBaseline={diffBaseline}
+                      sessionPath={terminalSessionPath}
+                      favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
+                      diffRenderMode={diffRenderMode}
+                      diffComments={diffComments}
+                      diffCommentCount={diffCommentCount}
+                      diffCommentsSending={diffCommentsSending}
+                      diffCommentError={diffCommentError}
+                      onSetDiffBaseline={onSetDiffBaseline}
+                      onSetDiffRenderMode={setDiffRenderMode}
+                      onSendDiffComments={(message) => {
+                        void handleSendDiffComments(message);
+                      }}
+                      onSelectDiffComment={(filePath, commentId) => {
+                        setSelectedDiffCommentId(commentId);
+                        setSelectedDiffCommentJumpKey((current) => current + 1);
+                        handleOpenWorktreeDiffFile(filePath);
+                      }}
+                      promptResetKey={composerPromptResetKey}
+                      onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
+                      onOpenTakeoverTerminal={handleShowTakeoverTerminal}
+                      onOpenGitOpsView={handleOpenGitOpsView}
+                      onToggleTerminal={handleToggleTerminal}
+                      terminalVisible={state.terminalVisible}
+                      onPickAttachments={pickComposerAttachments}
+                      onListAttachmentEntries={listComposerAttachmentEntries}
+                      onAction={handleAction}
+                    />
+                  </div>
                 </div>
               )}
             </div>

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -3,10 +3,7 @@ import type { AppShellController } from "../../app-shell/useAppShellController";
 import { Composer } from "../../components/workspace/Composer";
 import { DiffPanel } from "../../components/workspace/DiffPanel";
 import { GitOpsComposerPanel } from "../../components/workspace/GitOpsComposerPanel";
-import {
-  type MockQueuedPrompt,
-  MockQueuedPromptsCard,
-} from "../../components/workspace/composer/MockQueuedPromptsCard";
+import { QueuedPromptsCard } from "../../components/workspace/composer/QueuedPromptsCard";
 import { buildDiffCommentPrompt } from "../../components/workspace/diff/diffCommentPrompt";
 import {
   type SavedDiffComment,
@@ -32,20 +29,6 @@ type CodeWorkspaceViewProps = {
 
 const TERMINAL_DRAWER_OFFSET = "min(28rem, calc(100% - 2.5rem))";
 const TERMINAL_DRAWER_FOOTER_OFFSET = `calc(${TERMINAL_DRAWER_OFFSET} + 1.25rem)`;
-const mockQueuedPromptsSeed: MockQueuedPrompt[] = [
-  {
-    id: "queued-1",
-    text: "After this finishes, tighten the composer spacing and make the stop action feel more intentional.",
-  },
-  {
-    id: "queued-2",
-    text: "Then add a quick empty state for queued prompts so the transition feels natural when the list clears.",
-  },
-  {
-    id: "queued-3",
-    text: "Finally, revisit whether queued follow-ups should stack newest-first or stay in the order they were added.",
-  },
-];
 
 export function CodeWorkspaceView({
   controller,
@@ -69,8 +52,7 @@ export function CodeWorkspaceView({
   const [selectedDiffCommentJumpKey, setSelectedDiffCommentJumpKey] = useState(0);
   const [diffCommentsSending, setDiffCommentsSending] = useState(false);
   const [diffCommentError, setDiffCommentError] = useState<string | null>(null);
-  const [mockQueuedPrompts, setMockQueuedPrompts] =
-    useState<MockQueuedPrompt[]>(mockQueuedPromptsSeed);
+  const [restoredQueuedPrompt, setRestoredQueuedPrompt] = useState<string | null>(null);
   const footerRef = useRef<HTMLDivElement>(null);
   const {
     handleAction,
@@ -158,8 +140,17 @@ export function CodeWorkspaceView({
     setComposerPromptResetKey((current) => current + 1);
 
     try {
+      const streamingBehaviorPreference =
+        shellState?.appSettings.composerStreamingBehavior ?? "followUp";
+
+      if (activeThreadData?.isStreaming && streamingBehaviorPreference === "stop") {
+        await handleAction("composer.stop");
+        return;
+      }
+
       await handleAction("composer.send", {
         text: buildDiffCommentPrompt({ comments: context.comments, instruction: message }),
+        streamingBehavior: streamingBehaviorPreference,
       });
       diffCommentStore.clearContext(diffCommentContextId);
     } catch (error) {
@@ -213,6 +204,7 @@ export function CodeWorkspaceView({
                   shellState?.appSettings ?? {
                     gitCommitMessageModel: null,
                     skillCreatorModel: null,
+                    composerStreamingBehavior: "followUp",
                     favoriteFolders: [],
                     projectImportState: null,
                     preferredProjectLocation: null,
@@ -279,14 +271,26 @@ export function CodeWorkspaceView({
                 </div>
               ) : (
                 <div className="grid gap-0">
-                  <MockQueuedPromptsCard
-                    prompts={mockQueuedPrompts}
-                    onEditPrompt={() => undefined}
-                    onRemovePrompt={(promptId) => {
-                      setMockQueuedPrompts((current) =>
-                        current.filter((prompt) => prompt.id !== promptId),
-                      );
-                      setComposerLayoutVersion((current) => current + 1);
+                  <QueuedPromptsCard
+                    prompts={activeComposerState?.queuedPrompts ?? []}
+                    onEditPrompt={async (prompt) => {
+                      const result = await handleAction("composer.dequeue", {
+                        projectId: composerProjectId,
+                        sessionPath: terminalSessionPath,
+                        queueMode: prompt.mode,
+                        queueIndex: prompt.queueIndex,
+                      });
+                      if (typeof result?.result?.dequeuedText === "string") {
+                        setRestoredQueuedPrompt(result.result.dequeuedText);
+                      }
+                    }}
+                    onRemovePrompt={(prompt) => {
+                      void handleAction("composer.dequeue", {
+                        projectId: composerProjectId,
+                        sessionPath: terminalSessionPath,
+                        queueMode: prompt.mode,
+                        queueIndex: prompt.queueIndex,
+                      });
                     }}
                   />
                   <div ref={footerRef}>
@@ -295,7 +299,12 @@ export function CodeWorkspaceView({
                       hostLabel={shellState?.availableHosts[0] ?? "Local"}
                       model={activeComposerState?.currentModel ?? null}
                       availableModels={activeComposerState?.availableModels ?? []}
+                      isStreaming={activeThreadData?.isStreaming ?? false}
                       thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
+                      restoredQueuedPrompt={restoredQueuedPrompt}
+                      streamingBehaviorPreference={
+                        shellState?.appSettings.composerStreamingBehavior ?? "followUp"
+                      }
                       availableThinkingLevels={
                         activeComposerState?.availableThinkingLevels ?? ["off"]
                       }
@@ -323,6 +332,7 @@ export function CodeWorkspaceView({
                       onLayoutChange={() => setComposerLayoutVersion((current) => current + 1)}
                       onOpenTakeoverTerminal={handleShowTakeoverTerminal}
                       onOpenGitOpsView={handleOpenGitOpsView}
+                      onRestoredQueuedPromptApplied={() => setRestoredQueuedPrompt(null)}
                       onToggleTerminal={handleToggleTerminal}
                       terminalVisible={state.terminalVisible}
                       onPickAttachments={pickComposerAttachments}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -82,9 +82,20 @@ export function CodeWorkspaceView({
   const showDiffInMainView = state.activeView === "gitops";
   const showDesktopTerminalDrawer = state.activeView === "thread" && terminalDrawerVisible;
   const footerInset = showWorkspaceFooter ? footerHeight : 0;
+  const pendingQueueScopeKey = `${composerProjectId}:${terminalSessionPath ?? ""}`;
+  const pendingQueueScopePrefix = `${pendingQueueScopeKey}:`;
   const diffCommentContextId = useMemo(
     () => getDiffCommentContextId({ projectId: composerProjectId }),
     [composerProjectId],
+  );
+  const pendingQueuedPromptIdsForSession = useMemo(
+    () =>
+      pendingQueuedPromptIds.flatMap((pendingKey) =>
+        pendingKey.startsWith(pendingQueueScopePrefix)
+          ? [pendingKey.slice(pendingQueueScopePrefix.length)]
+          : [],
+      ),
+    [pendingQueueScopePrefix, pendingQueuedPromptIds],
   );
 
   const scopedRestoredQueuedPrompt =
@@ -187,12 +198,14 @@ export function CodeWorkspaceView({
   };
 
   const handleEditQueuedPrompt = async (prompt: ComposerQueuedPrompt) => {
-    if (pendingQueuedPromptIdsRef.current.has(prompt.id)) {
+    const pendingKey = `${pendingQueueScopeKey}:${prompt.id}`;
+
+    if (pendingQueuedPromptIdsRef.current.has(pendingKey)) {
       return;
     }
 
-    pendingQueuedPromptIdsRef.current.add(prompt.id);
-    setPendingQueuedPromptIds((current) => [...current, prompt.id]);
+    pendingQueuedPromptIdsRef.current.add(pendingKey);
+    setPendingQueuedPromptIds((current) => [...current, pendingKey]);
 
     try {
       const result = await handleAction("composer.dequeue", {
@@ -210,18 +223,20 @@ export function CodeWorkspaceView({
         });
       }
     } finally {
-      pendingQueuedPromptIdsRef.current.delete(prompt.id);
-      setPendingQueuedPromptIds((current) => current.filter((id) => id !== prompt.id));
+      pendingQueuedPromptIdsRef.current.delete(pendingKey);
+      setPendingQueuedPromptIds((current) => current.filter((id) => id !== pendingKey));
     }
   };
 
   const handleRemoveQueuedPrompt = async (prompt: ComposerQueuedPrompt) => {
-    if (pendingQueuedPromptIdsRef.current.has(prompt.id)) {
+    const pendingKey = `${pendingQueueScopeKey}:${prompt.id}`;
+
+    if (pendingQueuedPromptIdsRef.current.has(pendingKey)) {
       return;
     }
 
-    pendingQueuedPromptIdsRef.current.add(prompt.id);
-    setPendingQueuedPromptIds((current) => [...current, prompt.id]);
+    pendingQueuedPromptIdsRef.current.add(pendingKey);
+    setPendingQueuedPromptIds((current) => [...current, pendingKey]);
 
     try {
       await handleAction("composer.dequeue", {
@@ -231,8 +246,8 @@ export function CodeWorkspaceView({
         queueMode: prompt.mode,
       });
     } finally {
-      pendingQueuedPromptIdsRef.current.delete(prompt.id);
-      setPendingQueuedPromptIds((current) => current.filter((id) => id !== prompt.id));
+      pendingQueuedPromptIdsRef.current.delete(pendingKey);
+      setPendingQueuedPromptIds((current) => current.filter((id) => id !== pendingKey));
     }
   };
 
@@ -348,7 +363,7 @@ export function CodeWorkspaceView({
                 <div className="grid gap-0">
                   <QueuedPromptsCard
                     prompts={activeComposerState?.queuedPrompts ?? []}
-                    pendingPromptIds={pendingQueuedPromptIds}
+                    pendingPromptIds={pendingQueuedPromptIdsForSession}
                     onEditPrompt={(prompt) => {
                       void handleEditQueuedPrompt(prompt);
                     }}

--- a/src/app/ui/layout.ts
+++ b/src/app/ui/layout.ts
@@ -1,1 +1,2 @@
 export const WORKSPACE_CONTENT_MAX_WIDTH_CLASS = "max-w-[800px]";
+export const CHAT_TEXT_MAX_WIDTH_CLASS = "max-w-[744px]";

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -2,16 +2,23 @@ import { useState } from "react";
 import { EmptyStateCard } from "../components/common/EmptyStateCard";
 import { MarkdownContent } from "../components/common/MarkdownContent";
 import { InboxComposer } from "../components/workspace/inbox/InboxComposer";
-import type { DesktopActionInvoker, InboxThread } from "../desktop/types";
+import type { AppSettings, DesktopActionInvoker, InboxThread } from "../desktop/types";
 
 type InboxViewProps = {
+  appSettings: AppSettings;
   thread: InboxThread | null;
   onAction: DesktopActionInvoker;
   onDismissThread: (thread: InboxThread) => void;
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
 };
 
-export function InboxView({ thread, onAction, onDismissThread, onOpenThread }: InboxViewProps) {
+export function InboxView({
+  appSettings,
+  thread,
+  onAction,
+  onDismissThread,
+  onOpenThread,
+}: InboxViewProps) {
   const [draft, setDraft] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -28,11 +35,19 @@ export function InboxView({ thread, onAction, onDismissThread, onOpenThread }: I
     let result: Awaited<ReturnType<DesktopActionInvoker>> | null = null;
 
     try {
-      result = await onAction("composer.send", {
-        projectId: thread.projectId,
-        sessionPath: thread.sessionPath,
-        text: nextDraft,
-      });
+      if (thread.running && appSettings.composerStreamingBehavior === "stop") {
+        result = await onAction("composer.stop", {
+          projectId: thread.projectId,
+          sessionPath: thread.sessionPath,
+        });
+      } else {
+        result = await onAction("composer.send", {
+          projectId: thread.projectId,
+          sessionPath: thread.sessionPath,
+          text: nextDraft,
+          streamingBehavior: appSettings.composerStreamingBehavior,
+        });
+      }
     } catch {
       setErrorMessage("Could not send follow-up.");
       return;
@@ -45,8 +60,30 @@ export function InboxView({ thread, onAction, onDismissThread, onOpenThread }: I
       return;
     }
 
-    setDraft("");
-    onDismissThread(thread);
+    if (!thread.running || appSettings.composerStreamingBehavior !== "stop") {
+      setDraft("");
+      onDismissThread(thread);
+    }
+  };
+
+  const handleStop = async () => {
+    if (!thread?.running || isSending) {
+      return;
+    }
+
+    setIsSending(true);
+    setErrorMessage(null);
+
+    try {
+      await onAction("composer.stop", {
+        projectId: thread.projectId,
+        sessionPath: thread.sessionPath,
+      });
+    } catch {
+      setErrorMessage("Could not stop Pi.");
+    } finally {
+      setIsSending(false);
+    }
   };
 
   if (!thread) {
@@ -93,11 +130,13 @@ export function InboxView({ thread, onAction, onDismissThread, onOpenThread }: I
           <InboxComposer
             draft={draft}
             errorMessage={errorMessage}
+            isStreaming={thread.running}
             isSending={isSending}
             onChangeDraft={setDraft}
             onDismiss={() => onDismissThread(thread)}
             onOpenThread={() => onOpenThread(thread.projectId, thread.threadId, thread.sessionPath)}
             onSend={handleSend}
+            onStop={handleStop}
           />
         </div>
       </div>

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { getDesktopActionErrorMessage } from "../desktop/action-results";
 import { EmptyStateCard } from "../components/common/EmptyStateCard";
 import { MarkdownContent } from "../components/common/MarkdownContent";
 import { InboxComposer } from "../components/workspace/inbox/InboxComposer";
@@ -35,19 +36,12 @@ export function InboxView({
     let result: Awaited<ReturnType<DesktopActionInvoker>> | null = null;
 
     try {
-      if (thread.running && appSettings.composerStreamingBehavior === "stop") {
-        result = await onAction("composer.stop", {
-          projectId: thread.projectId,
-          sessionPath: thread.sessionPath,
-        });
-      } else {
-        result = await onAction("composer.send", {
-          projectId: thread.projectId,
-          sessionPath: thread.sessionPath,
-          text: nextDraft,
-          streamingBehavior: appSettings.composerStreamingBehavior,
-        });
-      }
+      result = await onAction("composer.send", {
+        projectId: thread.projectId,
+        sessionPath: thread.sessionPath,
+        text: nextDraft,
+        streamingBehavior: appSettings.composerStreamingBehavior,
+      });
     } catch {
       setErrorMessage("Could not send follow-up.");
       return;
@@ -55,12 +49,13 @@ export function InboxView({
       setIsSending(false);
     }
 
-    if (!result?.ok || result.result?.error) {
-      setErrorMessage(result?.result?.error ?? "Could not send follow-up.");
+    const actionErrorMessage = getDesktopActionErrorMessage(result, "Could not send follow-up.");
+    if (actionErrorMessage) {
+      setErrorMessage(actionErrorMessage);
       return;
     }
 
-    if (!thread.running || appSettings.composerStreamingBehavior !== "stop") {
+    if (result?.result?.composerSendOutcome !== "stopped") {
       setDraft("");
       onDismissThread(thread);
     }
@@ -75,10 +70,15 @@ export function InboxView({
     setErrorMessage(null);
 
     try {
-      await onAction("composer.stop", {
+      const result = await onAction("composer.stop", {
         projectId: thread.projectId,
         sessionPath: thread.sessionPath,
       });
+
+      const actionErrorMessage = getDesktopActionErrorMessage(result, "Could not stop Pi.");
+      if (actionErrorMessage) {
+        setErrorMessage(actionErrorMessage);
+      }
     } catch {
       setErrorMessage("Could not stop Pi.");
     } finally {

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -29,7 +29,7 @@ export function SettingsView({
     <ViewShell maxWidthClassName="max-w-[760px]">
       <ViewHeader
         title="App settings"
-        subtitle="Git commit model, skill creator model, project cleanup defaults, Pi TUI defaults, project UI import, and favorite folders."
+        subtitle="Git commit model, skill creator model, streaming send behavior, project cleanup defaults, Pi TUI defaults, project UI import, and favorite folders."
       />
 
       <SettingsModelSection
@@ -59,6 +59,7 @@ export function SettingsView({
         appSettings={appSettings}
         preferredProjectLocationDraft={controller.preferredProjectLocationDraft}
         savePreferredProjectLocation={controller.savePreferredProjectLocation}
+        setComposerStreamingBehavior={controller.setComposerStreamingBehavior}
         setPreferredProjectLocationDraft={controller.setPreferredProjectLocationDraft}
         setProjectDeletionMode={controller.setProjectDeletionMode}
         toggleInitializeGitOnProjectCreate={controller.toggleInitializeGitOnProjectCreate}

--- a/src/app/views/settings/SettingsProjectDefaultsSection.tsx
+++ b/src/app/views/settings/SettingsProjectDefaultsSection.tsx
@@ -10,6 +10,7 @@ export function SettingsProjectDefaultsSection({
   appSettings,
   preferredProjectLocationDraft,
   savePreferredProjectLocation,
+  setComposerStreamingBehavior,
   setPreferredProjectLocationDraft,
   setProjectDeletionMode,
   toggleInitializeGitOnProjectCreate,
@@ -18,6 +19,7 @@ export function SettingsProjectDefaultsSection({
   appSettings: AppSettings;
   preferredProjectLocationDraft: string;
   savePreferredProjectLocation: () => void;
+  setComposerStreamingBehavior: (value: AppSettings["composerStreamingBehavior"]) => void;
   setPreferredProjectLocationDraft: Dispatch<SetStateAction<string>>;
   setProjectDeletionMode: (value: AppSettings["projectDeletionMode"]) => void;
   toggleInitializeGitOnProjectCreate: () => void;
@@ -37,7 +39,7 @@ export function SettingsProjectDefaultsSection({
     >
       <SectionIntro
         title="Defaults"
-        description="Set project creation defaults and whether conversations should open in Pi TUI by default."
+        description="Set project creation defaults, streaming send behavior, and whether conversations should open in Pi TUI by default."
       />
 
       <div className="grid gap-2">
@@ -60,6 +62,27 @@ export function SettingsProjectDefaultsSection({
             className={settingsInputClass}
             placeholder="Paste an absolute folder path"
             aria-label="Default project location"
+          />
+        </div>
+
+        <div className={settingsListRowClass}>
+          <div className="grid gap-0.5">
+            <div className="text-[13px] text-[color:var(--text)]">Send while Pi is responding</div>
+            <div className="text-[12px] text-[color:var(--muted)]">
+              Steer interrupts immediately, Queue waits for the current turn, Stop aborts without
+              sending the draft.
+            </div>
+          </div>
+          <SegmentedToggle
+            value={appSettings.composerStreamingBehavior}
+            options={
+              [
+                { value: "steer", label: "Steer" },
+                { value: "followUp", label: "Queue" },
+                { value: "stop", label: "Stop" },
+              ] as const
+            }
+            onChange={setComposerStreamingBehavior}
           />
         </div>
 

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -128,6 +128,11 @@ export function useSettingsController({
     importStatusMessage,
     preferredProjectLocationDraft,
     savePreferredProjectLocation,
+    setComposerStreamingBehavior: (value: AppSettings["composerStreamingBehavior"]) =>
+      void onAction("settings.update", {
+        key: "composerStreamingBehavior",
+        value,
+      }),
     selectGitCommitModel: (id: string) =>
       selectModel("gitCommitMessageModel", id, closeGitCommitMenu),
     selectSkillCreatorModel: (id: string) =>

--- a/src/test/composer-queue.helpers.test.ts
+++ b/src/test/composer-queue.helpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { mergeDraftWithRestoredQueuedPrompt } from "../app/components/workspace/composer/composer-queue.helpers";
+
+describe("mergeDraftWithRestoredQueuedPrompt", () => {
+  it("uses the restored queued prompt when the composer draft is empty", () => {
+    expect(mergeDraftWithRestoredQueuedPrompt("", "queued prompt")).toBe("queued prompt");
+  });
+
+  it("preserves the current draft when restoring a queued prompt", () => {
+    expect(mergeDraftWithRestoredQueuedPrompt("keep this draft", "queued prompt")).toBe(
+      "keep this draft\n\nqueued prompt",
+    );
+  });
+
+  it("avoids duplicating identical draft text", () => {
+    expect(mergeDraftWithRestoredQueuedPrompt("queued prompt", "queued prompt")).toBe(
+      "queued prompt",
+    );
+  });
+});

--- a/src/test/composer-runtime-queue.test.ts
+++ b/src/test/composer-runtime-queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildComposerQueueSnapshotKey,
   buildQueuedPrompts,
   cloneComposerQueue,
   findQueuedPromptIndexById,
@@ -26,6 +27,20 @@ describe("replayComposerQueue", () => {
 });
 
 describe("composer queue helpers", () => {
+  it("adds the same snapshot key to every prompt in a queue snapshot", () => {
+    const queue = {
+      steering: ["first", "dup", "dup"],
+      followUp: ["later"],
+    };
+
+    expect(buildQueuedPrompts(queue).map((prompt) => prompt.queueSnapshotKey)).toEqual([
+      buildComposerQueueSnapshotKey(queue),
+      buildComposerQueueSnapshotKey(queue),
+      buildComposerQueueSnapshotKey(queue),
+      buildComposerQueueSnapshotKey(queue),
+    ]);
+  });
+
   it("builds stable ids that do not depend on unrelated queue positions", () => {
     expect(
       buildQueuedPrompts({
@@ -45,6 +60,20 @@ describe("composer queue helpers", () => {
   it("finds the current queue index from a stable queue id", () => {
     expect(findQueuedPromptIndexById("steer", ["dup", "dup", "other"], "steer:1:dup")).toBe(1);
     expect(findQueuedPromptIndexById("followUp", ["other"], "followUp:0:missing")).toBeNull();
+  });
+
+  it("changes the snapshot key when identical duplicates shift, so stale actions can be rejected", () => {
+    expect(
+      buildComposerQueueSnapshotKey({
+        steering: [],
+        followUp: ["dup", "dup"],
+      }),
+    ).not.toBe(
+      buildComposerQueueSnapshotKey({
+        steering: [],
+        followUp: ["dup"],
+      }),
+    );
   });
 
   it("removes a queued prompt by stable id without mutating the original queue", () => {

--- a/src/test/composer-runtime-queue.test.ts
+++ b/src/test/composer-runtime-queue.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { replayComposerQueue } from "../../desktop/runtime/composer-queue";
+
+describe("replayComposerQueue", () => {
+  it("requeues steering and follow-up messages in order", async () => {
+    const steer = vi.fn(async () => undefined);
+    const followUp = vi.fn(async () => undefined);
+
+    await replayComposerQueue(
+      { steer, followUp },
+      {
+        steering: ["steer-1", "steer-2"],
+        followUp: ["follow-1", "follow-2"],
+      },
+    );
+
+    expect(steer.mock.calls).toEqual([["steer-1"], ["steer-2"]]);
+    expect(followUp.mock.calls).toEqual([["follow-1"], ["follow-2"]]);
+  });
+});

--- a/src/test/composer-runtime-queue.test.ts
+++ b/src/test/composer-runtime-queue.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildQueuedPrompts,
+  cloneComposerQueue,
   findQueuedPromptIndexById,
+  removeQueuedPromptById,
   replayComposerQueue,
 } from "../../desktop/runtime/composer-queue";
 
@@ -43,5 +45,39 @@ describe("composer queue helpers", () => {
   it("finds the current queue index from a stable queue id", () => {
     expect(findQueuedPromptIndexById("steer", ["dup", "dup", "other"], "steer:1:dup")).toBe(1);
     expect(findQueuedPromptIndexById("followUp", ["other"], "followUp:0:missing")).toBeNull();
+  });
+
+  it("removes a queued prompt by stable id without mutating the original queue", () => {
+    const queue = {
+      steering: ["dup", "dup", "other"],
+      followUp: ["later"],
+    };
+
+    expect(removeQueuedPromptById(queue, "steer", "steer:1:dup")).toEqual({
+      dequeuedText: "dup",
+      nextQueue: {
+        steering: ["dup", "other"],
+        followUp: ["later"],
+      },
+    });
+    expect(queue).toEqual({
+      steering: ["dup", "dup", "other"],
+      followUp: ["later"],
+    });
+  });
+
+  it("clones queue snapshots for safe replay rollback", () => {
+    const queue = {
+      steering: ["one"],
+      followUp: ["two"],
+    };
+
+    const clone = cloneComposerQueue(queue);
+    clone.steering.push("three");
+
+    expect(queue).toEqual({
+      steering: ["one"],
+      followUp: ["two"],
+    });
   });
 });

--- a/src/test/composer-runtime-queue.test.ts
+++ b/src/test/composer-runtime-queue.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { replayComposerQueue } from "../../desktop/runtime/composer-queue";
+import {
+  buildQueuedPrompts,
+  findQueuedPromptIndexById,
+  replayComposerQueue,
+} from "../../desktop/runtime/composer-queue";
 
 describe("replayComposerQueue", () => {
   it("requeues steering and follow-up messages in order", async () => {
@@ -16,5 +20,28 @@ describe("replayComposerQueue", () => {
 
     expect(steer.mock.calls).toEqual([["steer-1"], ["steer-2"]]);
     expect(followUp.mock.calls).toEqual([["follow-1"], ["follow-2"]]);
+  });
+});
+
+describe("composer queue helpers", () => {
+  it("builds stable ids that do not depend on unrelated queue positions", () => {
+    expect(
+      buildQueuedPrompts({
+        steering: ["first", "dup", "dup"],
+        followUp: ["later"],
+      }).map((prompt) => prompt.id),
+    ).toEqual(["steer:0:first", "steer:0:dup", "steer:1:dup", "followUp:0:later"]);
+
+    expect(
+      buildQueuedPrompts({
+        steering: ["dup", "dup"],
+        followUp: ["later"],
+      }).map((prompt) => prompt.id),
+    ).toEqual(["steer:0:dup", "steer:1:dup", "followUp:0:later"]);
+  });
+
+  it("finds the current queue index from a stable queue id", () => {
+    expect(findQueuedPromptIndexById("steer", ["dup", "dup", "other"], "steer:1:dup")).toBe(1);
+    expect(findQueuedPromptIndexById("followUp", ["other"], "followUp:0:missing")).toBeNull();
   });
 });

--- a/src/test/controller-post-action-effects.test.ts
+++ b/src/test/controller-post-action-effects.test.ts
@@ -17,6 +17,7 @@ function buildShellState(): ShellState {
     appSettings: {
       gitCommitMessageModel: null,
       skillCreatorModel: null,
+      composerStreamingBehavior: "followUp",
       favoriteFolders: ["/existing"],
       projectImportState: null,
       preferredProjectLocation: null,
@@ -31,6 +32,7 @@ function buildShellState(): ShellState {
       availableModels: [],
       currentThinkingLevel: "medium",
       availableThinkingLevels: ["off", "minimal", "low", "medium", "high", "xhigh"],
+      queuedPrompts: [],
     },
     projects: [
       {
@@ -117,6 +119,17 @@ describe("controller post action effects", () => {
   });
 
   it("updates project creation settings optimistically", () => {
+    expect(
+      getOptimisticallyUpdatedShellState(buildShellState(), {
+        key: "composerStreamingBehavior",
+        value: "steer",
+      }),
+    ).toMatchObject({
+      appSettings: {
+        composerStreamingBehavior: "steer",
+      },
+    });
+
     expect(
       getOptimisticallyUpdatedShellState(buildShellState(), {
         key: "preferredProjectLocation",

--- a/src/test/submit-composer-draft.test.ts
+++ b/src/test/submit-composer-draft.test.ts
@@ -11,8 +11,10 @@ describe("submitComposerDraft", () => {
       attachments: [{ path: "/repo/file.ts", name: "file.ts", kind: "text" }],
       draftThreadId: "session:/repo/thread.json",
       isSending: false,
+      isStreaming: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
+      streamingBehaviorPreference: "followUp",
       onAction,
       clearStoredDraft,
     });
@@ -23,6 +25,7 @@ describe("submitComposerDraft", () => {
       attachments: [{ path: "/repo/file.ts", name: "file.ts", kind: "text" }],
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
+      streamingBehavior: "followUp",
     });
     expect(clearStoredDraft).toHaveBeenCalledWith("session:/repo/thread.json");
   });
@@ -35,8 +38,10 @@ describe("submitComposerDraft", () => {
       attachments: [],
       draftThreadId: "session:/repo/thread.json",
       isSending: false,
+      isStreaming: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
+      streamingBehaviorPreference: "followUp",
       onAction: vi.fn(async () => {
         throw new Error("network down");
       }),
@@ -61,8 +66,10 @@ describe("submitComposerDraft", () => {
         attachments: [],
         draftThreadId: "session:/repo/thread.json",
         isSending: false,
+        isStreaming: false,
         projectId: "/repo",
         sessionPath: "/repo/thread.json",
+        streamingBehaviorPreference: "followUp",
         onAction,
         clearStoredDraft,
       }),
@@ -81,8 +88,10 @@ describe("submitComposerDraft", () => {
         attachments: [],
         draftThreadId: "session:/repo/thread.json",
         isSending: true,
+        isStreaming: false,
         projectId: "/repo",
         sessionPath: "/repo/thread.json",
+        streamingBehaviorPreference: "followUp",
         onAction,
         clearStoredDraft: vi.fn(),
       }),

--- a/src/test/submit-composer-draft.test.ts
+++ b/src/test/submit-composer-draft.test.ts
@@ -106,6 +106,29 @@ describe("submitComposerDraft", () => {
     expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
+  it("treats null action results as errors", async () => {
+    const clearStoredDraft = vi.fn();
+
+    const result = await submitComposerDraft({
+      draft: "retry me",
+      attachments: [],
+      draftThreadId: "session:/repo/thread.json",
+      isSending: false,
+      projectId: "/repo",
+      sessionPath: "/repo/thread.json",
+      streamingBehaviorPreference: "followUp",
+      onAction: vi.fn(async () => null),
+      clearStoredDraft,
+    });
+
+    expect(result).toEqual({
+      status: "error",
+      errorMessage: "Could not send prompt.",
+      text: "retry me",
+    });
+    expect(clearStoredDraft).not.toHaveBeenCalled();
+  });
+
   it("treats non-throwing stop-mode send failures as errors", async () => {
     const clearStoredDraft = vi.fn();
 

--- a/src/test/submit-composer-draft.test.ts
+++ b/src/test/submit-composer-draft.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 import { submitComposerDraft } from "../app/components/workspace/composer/submitComposerDraft";
+import type { DesktopActionResult } from "../app/desktop/types";
+
+function buildActionFailureResult(action: "composer.send" | "composer.stop", error: string) {
+  return {
+    ok: false,
+    at: new Date().toISOString(),
+    payload: {
+      action,
+      payload: {},
+    },
+    result: {
+      error,
+    },
+  } satisfies DesktopActionResult;
+}
 
 describe("submitComposerDraft", () => {
   it("clears the stored draft after a successful send", async () => {
@@ -52,6 +67,54 @@ describe("submitComposerDraft", () => {
       status: "error",
       errorMessage: "network down",
       text: "retry me",
+    });
+    expect(clearStoredDraft).not.toHaveBeenCalled();
+  });
+
+  it("treats non-throwing send failures as errors", async () => {
+    const clearStoredDraft = vi.fn();
+
+    const result = await submitComposerDraft({
+      draft: "retry me",
+      attachments: [],
+      draftThreadId: "session:/repo/thread.json",
+      isSending: false,
+      isStreaming: false,
+      projectId: "/repo",
+      sessionPath: "/repo/thread.json",
+      streamingBehaviorPreference: "followUp",
+      onAction: vi.fn(async () => buildActionFailureResult("composer.send", "bridge failed")),
+      clearStoredDraft,
+    });
+
+    expect(result).toEqual({
+      status: "error",
+      errorMessage: "bridge failed",
+      text: "retry me",
+    });
+    expect(clearStoredDraft).not.toHaveBeenCalled();
+  });
+
+  it("treats non-throwing stop failures as errors", async () => {
+    const clearStoredDraft = vi.fn();
+
+    const result = await submitComposerDraft({
+      draft: "stop me",
+      attachments: [],
+      draftThreadId: "session:/repo/thread.json",
+      isSending: false,
+      isStreaming: true,
+      projectId: "/repo",
+      sessionPath: "/repo/thread.json",
+      streamingBehaviorPreference: "stop",
+      onAction: vi.fn(async () => buildActionFailureResult("composer.stop", "stop failed")),
+      clearStoredDraft,
+    });
+
+    expect(result).toEqual({
+      status: "error",
+      errorMessage: "stop failed",
+      text: "stop me",
     });
     expect(clearStoredDraft).not.toHaveBeenCalled();
   });

--- a/src/test/submit-composer-draft.test.ts
+++ b/src/test/submit-composer-draft.test.ts
@@ -16,9 +16,23 @@ function buildActionFailureResult(action: "composer.send" | "composer.stop", err
   } satisfies DesktopActionResult;
 }
 
+function buildActionSuccessResult(outcome: "sent" | "stopped" = "sent") {
+  return {
+    ok: true,
+    at: new Date().toISOString(),
+    payload: {
+      action: "composer.send",
+      payload: {},
+    },
+    result: {
+      composerSendOutcome: outcome,
+    },
+  } satisfies DesktopActionResult;
+}
+
 describe("submitComposerDraft", () => {
   it("clears the stored draft after a successful send", async () => {
-    const onAction = vi.fn(async () => null);
+    const onAction = vi.fn(async () => buildActionSuccessResult());
     const clearStoredDraft = vi.fn();
 
     const result = await submitComposerDraft({
@@ -26,7 +40,6 @@ describe("submitComposerDraft", () => {
       attachments: [{ path: "/repo/file.ts", name: "file.ts", kind: "text" }],
       draftThreadId: "session:/repo/thread.json",
       isSending: false,
-      isStreaming: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
@@ -53,7 +66,6 @@ describe("submitComposerDraft", () => {
       attachments: [],
       draftThreadId: "session:/repo/thread.json",
       isSending: false,
-      isStreaming: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
@@ -79,7 +91,6 @@ describe("submitComposerDraft", () => {
       attachments: [],
       draftThreadId: "session:/repo/thread.json",
       isSending: false,
-      isStreaming: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
@@ -95,7 +106,7 @@ describe("submitComposerDraft", () => {
     expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
-  it("treats non-throwing stop failures as errors", async () => {
+  it("treats non-throwing stop-mode send failures as errors", async () => {
     const clearStoredDraft = vi.fn();
 
     const result = await submitComposerDraft({
@@ -103,17 +114,38 @@ describe("submitComposerDraft", () => {
       attachments: [],
       draftThreadId: "session:/repo/thread.json",
       isSending: false,
-      isStreaming: true,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "stop",
-      onAction: vi.fn(async () => buildActionFailureResult("composer.stop", "stop failed")),
+      onAction: vi.fn(async () => buildActionFailureResult("composer.send", "stop failed")),
       clearStoredDraft,
     });
 
     expect(result).toEqual({
       status: "error",
       errorMessage: "stop failed",
+      text: "stop me",
+    });
+    expect(clearStoredDraft).not.toHaveBeenCalled();
+  });
+
+  it("returns stopped when runtime converts stop-mode send into a stop", async () => {
+    const clearStoredDraft = vi.fn();
+
+    const result = await submitComposerDraft({
+      draft: "stop me",
+      attachments: [],
+      draftThreadId: "session:/repo/thread.json",
+      isSending: false,
+      projectId: "/repo",
+      sessionPath: "/repo/thread.json",
+      streamingBehaviorPreference: "stop",
+      onAction: vi.fn(async () => buildActionSuccessResult("stopped")),
+      clearStoredDraft,
+    });
+
+    expect(result).toEqual({
+      status: "stopped",
       text: "stop me",
     });
     expect(clearStoredDraft).not.toHaveBeenCalled();
@@ -129,7 +161,6 @@ describe("submitComposerDraft", () => {
         attachments: [],
         draftThreadId: "session:/repo/thread.json",
         isSending: false,
-        isStreaming: false,
         projectId: "/repo",
         sessionPath: "/repo/thread.json",
         streamingBehaviorPreference: "followUp",
@@ -151,7 +182,6 @@ describe("submitComposerDraft", () => {
         attachments: [],
         draftThreadId: "session:/repo/thread.json",
         isSending: true,
-        isStreaming: false,
         projectId: "/repo",
         sessionPath: "/repo/thread.json",
         streamingBehaviorPreference: "followUp",


### PR DESCRIPTION
## Summary
- implement real send-while-streaming behavior with steer, queue, and stop modes
- replace the mock queued prompt UI with live queue state and dequeue/edit interactions
- wire the composer and inbox send button to stop active runs while Pi is streaming
- add follow-up fixes from review for queue replay, draft preservation, attachment handling, and action error handling

## Details
- added `composerStreamingBehavior` app settings plumbing and UI
- added `composer.stop` and `composer.dequeue` desktop/runtime actions
- publish live queued prompt state from the runtime session into composer state
- restore dequeued prompts back into the composer while preserving in-progress draft content
- handle non-throwing desktop action failures correctly in composer submit flow
- replay queued messages safely after dequeue even during idle compaction/retry handoff windows

## Validation
- pre-commit hooks passed
- pre-push checks passed: lint, typecheck, test, build
- addressed `/review` findings across multiple follow-up commits

Closes #26
Closes #27
