### PR TITLE
Fix inbox publishing to only show final assistant replies

### DIFF
--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -106,9 +106,16 @@ async function createRuntime(options: {
       if (event.message.role === "user") {
         void publishThreadUpdate(runtime, "start");
       }
-      if (event.message.role === "assistant") {
-        void publishThreadUpdate(runtime, "end");
+
+      if (runtimeKey) {
+        scheduleRuntimeDisposal(runtimeKey);
       }
+
+      return;
+    }
+
+    if (event.type === "agent_end") {
+      void publishThreadUpdate(runtime, "end");
 
       if (runtimeKey) {
         scheduleRuntimeDisposal(runtimeKey);

--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -2,6 +2,7 @@ import { stat } from "node:fs/promises";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ComposerState, ThreadData } from "../../shared/desktop-contracts.ts";
 import { getPreviousMessageCount } from "../../shared/pi-message-mapper.ts";
+import { getLatestInboxAssistantMessage } from "../../shared/thread-inbox.ts";
 import { buildThreadData } from "../../shared/thread-data.ts";
 import {
   beginInboxThreadTurn,
@@ -43,37 +44,9 @@ function buildLiveThreadData(runtime: PiRuntime) {
   });
 }
 
-function getLatestAssistantMessage(thread: ThreadData) {
-  const latestAssistantMessage = [...thread.messages]
-    .reverse()
-    .find((message) => message.role === "assistant");
-
-  if (!latestAssistantMessage || latestAssistantMessage.role !== "assistant") {
-    return null;
-  }
-
-  const content =
-    latestAssistantMessage.content.length > 0
-      ? latestAssistantMessage.content
-      : (latestAssistantMessage.thinkingContent ?? []);
-
-  if (content.length === 0) {
-    return null;
-  }
-
-  return {
-    content,
-    preview:
-      latestAssistantMessage.content[0] ??
-      latestAssistantMessage.thinkingHeaders?.[0] ??
-      latestAssistantMessage.thinkingContent?.[0] ??
-      null,
-  };
-}
-
 function hasAssistantMessageChanged(
   sessionPath: string,
-  latestAssistantMessage: ReturnType<typeof getLatestAssistantMessage>,
+  latestAssistantMessage: ReturnType<typeof getLatestInboxAssistantMessage>,
 ) {
   if (!latestAssistantMessage) {
     return false;
@@ -154,7 +127,7 @@ export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThr
 
     if (reason === "end") {
       const latestUserPrompt = getLatestUserPrompt(thread);
-      const latestAssistantMessage = getLatestAssistantMessage(thread);
+      const latestAssistantMessage = getLatestInboxAssistantMessage(thread.messages);
       if (latestAssistantMessage) {
         upsertInboxThreadMessage({
           sessionPath,
@@ -202,9 +175,14 @@ export async function publishExternalThreadUpdate({
   });
   setThreadRunningState(sessionPath, false);
 
-  const latestAssistantMessage = getLatestAssistantMessage(thread);
+  const latestUserPrompt = getLatestUserPrompt(thread);
+  const latestAssistantMessage = getLatestInboxAssistantMessage(thread.messages);
+
+  if (!latestAssistantMessage && (latestUserPrompt || hasInboxItem(sessionPath))) {
+    beginInboxThreadTurn(sessionPath, latestUserPrompt);
+  }
+
   if (latestAssistantMessage && hasAssistantMessageChanged(sessionPath, latestAssistantMessage)) {
-    const latestUserPrompt = getLatestUserPrompt(thread);
     upsertInboxThreadMessage({
       sessionPath,
       userPrompt: latestUserPrompt,

--- a/desktop/thread-state-db/writes.cts
+++ b/desktop/thread-state-db/writes.cts
@@ -108,7 +108,7 @@ export function upsertInboxThreadPrompt(sessionPath: string, prompt: string | nu
 
 export function beginInboxThreadTurn(sessionPath: string, prompt: string | null) {
   const db = getThreadStateDatabase();
-  db.prepare(
+  const resetInboxItem = db.prepare(
     `
       INSERT INTO inbox_items (
         session_path,
@@ -127,7 +127,29 @@ export function beginInboxThreadTurn(sessionPath: string, prompt: string | null)
         last_assistant_at_ms = NULL,
         updated_at = CURRENT_TIMESTAMP
     `,
-  ).run(sessionPath, prompt);
+  );
+  const resetThreadAssistantSnapshot = db.prepare(
+    `
+      UPDATE threads
+      SET
+        last_assistant_message_json = NULL,
+        last_assistant_preview = NULL,
+        last_assistant_at_ms = NULL,
+        updated_at = CURRENT_TIMESTAMP
+      WHERE session_path = ?
+    `,
+  );
+
+  db.exec("BEGIN");
+
+  try {
+    resetInboxItem.run(sessionPath, prompt);
+    resetThreadAssistantSnapshot.run(sessionPath);
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
 }
 
 export function markInboxThreadRead(sessionPath: string) {

--- a/shared/thread-inbox.ts
+++ b/shared/thread-inbox.ts
@@ -1,0 +1,51 @@
+import type { Message, ProseMessage } from "./desktop-contracts";
+
+type AssistantMessage = ProseMessage & { role: "assistant" };
+
+export function getLatestInboxAssistantMessage(messages: Message[]) {
+  const lastUserMessageIndex = [...messages]
+    .map((message, index) => ({ message, index }))
+    .reverse()
+    .find(({ message }) => message.role === "user")?.index;
+
+  const turnMessages =
+    typeof lastUserMessageIndex === "number" ? messages.slice(lastUserMessageIndex + 1) : messages;
+
+  const latestAssistantMessage = [...turnMessages]
+    .reverse()
+    .find((message): message is AssistantMessage => {
+      if (message.role !== "assistant") {
+        return false;
+      }
+
+      return message.content.some((part) => part.trim().length > 0);
+    });
+
+  if (!latestAssistantMessage) {
+    return null;
+  }
+
+  const content = latestAssistantMessage.content.map((part) => part.trim()).filter(Boolean);
+  if (content.length === 0) {
+    return null;
+  }
+
+  const latestAssistantIndex = turnMessages.lastIndexOf(latestAssistantMessage);
+  const hasLaterTurnWork = turnMessages.slice(latestAssistantIndex + 1).some((message) => {
+    return (
+      message.role === "assistant" ||
+      message.role === "user" ||
+      message.role === "toolResult" ||
+      message.role === "bashExecution"
+    );
+  });
+
+  if (hasLaterTurnWork) {
+    return null;
+  }
+
+  return {
+    content,
+    preview: content[0] ?? null,
+  };
+}

--- a/src/test/thread-inbox.test.ts
+++ b/src/test/thread-inbox.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { getLatestInboxAssistantMessage } from "../../shared/thread-inbox";
+import type { Message } from "../app/types";
+
+describe("thread inbox", () => {
+  it("stores the latest final assistant reply from the current turn", () => {
+    const messages: Message[] = [
+      { id: "user-1", role: "user", content: ["First prompt"] },
+      { id: "assistant-1", role: "assistant", content: ["First reply"] },
+      { id: "user-2", role: "user", content: ["Second prompt"] },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: ["Second reply", "More detail"],
+      },
+    ];
+
+    expect(getLatestInboxAssistantMessage(messages)).toEqual({
+      content: ["Second reply", "More detail"],
+      preview: "Second reply",
+    });
+  });
+
+  it("ignores thinking-only assistant updates for the current turn", () => {
+    const messages: Message[] = [
+      { id: "user-1", role: "user", content: ["First prompt"] },
+      { id: "assistant-1", role: "assistant", content: ["First reply"] },
+      { id: "user-2", role: "user", content: ["Second prompt"] },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: [],
+        thinkingContent: ["Working through the plan"],
+      },
+    ];
+
+    expect(getLatestInboxAssistantMessage(messages)).toBeNull();
+  });
+
+  it("does not fall back to the previous turn's reply when the current turn has no final answer", () => {
+    const messages: Message[] = [
+      { id: "user-1", role: "user", content: ["First prompt"] },
+      { id: "assistant-1", role: "assistant", content: ["First reply"] },
+      { id: "user-2", role: "user", content: ["Second prompt"] },
+      { id: "tool-1", role: "toolResult", toolName: "rg", content: ["match"], isError: false },
+    ];
+
+    expect(getLatestInboxAssistantMessage(messages)).toBeNull();
+  });
+
+  it("ignores assistant messages that are followed by tool work in the same turn", () => {
+    const messages: Message[] = [
+      { id: "user-1", role: "user", content: ["Inspect the config"] },
+      { id: "assistant-1", role: "assistant", content: ["I'll check the file."] },
+      { id: "tool-1", role: "toolResult", toolName: "read", content: ["{}"], isError: false },
+    ];
+
+    expect(getLatestInboxAssistantMessage(messages)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- publish inbox updates at the end of the agent run instead of every assistant `message_end`
- only persist assistant content that is actually the final reply for the current user turn
- clear stale inbox/thread assistant snapshots when a new turn starts without a final reply yet

## Details
This fixes the root cause behind inbox showing intermediary assistant output/thinking as if it were final.

The runtime was treating assistant `message_end` as the publish boundary, but the Pi SDK emits that for intermediate assistant steps too. The inbox now waits for the explicit run-finish event and derives the stored assistant snapshot from the latest completed reply in the current turn only.

## Validation
- pre-commit hooks passed during commit
- pre-push checks passed (`lint`, `typecheck`, `test`, `build`)
- added focused coverage in `src/test/thread-inbox.test.ts`

Closes #33
