### PR TITLE
Keep thread running indicators in sync with live runtime state

### DIFF
--- a/desktop/thread-state-db/queries.cts
+++ b/desktop/thread-state-db/queries.cts
@@ -4,7 +4,10 @@ import type {
   Project,
   Thread,
 } from "../../shared/desktop-contracts.ts";
-import { getEffectiveThreadRunningState } from "../../shared/thread-running-state.ts";
+import {
+  getEffectiveThreadRunningState,
+  sortInboxThreadsByPriority,
+} from "../../shared/thread-running-state.ts";
 import { getThreadStateDatabase } from "./db.cts";
 import {
   mapArchivedThreadRow,
@@ -91,7 +94,7 @@ export function hasRunningProjectThread(projectId: string) {
           session_path AS sessionPath,
           running AS running
         FROM threads
-        WHERE cwd = ? AND archived = 0
+        WHERE cwd = ?
       `,
     )
     .all(projectId) as Array<{ sessionPath: string; running: number }>;
@@ -163,11 +166,15 @@ export function listInboxThreads(): InboxThread[] {
     )
     .all() as InboxThreadRow[];
 
-  return rows.map((row) =>
-    mapInboxThreadRow({
-      ...row,
-      running: getEffectiveThreadRunningState(row.running, getLiveThread(row.sessionPath)) ? 1 : 0,
-    }),
+  return sortInboxThreadsByPriority(
+    rows.map((row) =>
+      mapInboxThreadRow({
+        ...row,
+        running: getEffectiveThreadRunningState(row.running, getLiveThread(row.sessionPath))
+          ? 1
+          : 0,
+      }),
+    ),
   );
 }
 

--- a/desktop/thread-state-db/queries.cts
+++ b/desktop/thread-state-db/queries.cts
@@ -4,6 +4,7 @@ import type {
   Project,
   Thread,
 } from "../../shared/desktop-contracts.ts";
+import { getEffectiveThreadRunningState } from "../../shared/thread-running-state.ts";
 import { getThreadStateDatabase } from "./db.cts";
 import {
   mapArchivedThreadRow,
@@ -21,6 +22,7 @@ import type {
   ThreadPathRow,
   ThreadRow,
 } from "./types.cts";
+import { getLiveThread } from "../runtime/live-thread-store.cts";
 import { ensureProject } from "./writes.cts";
 
 export function listProjects(cwd: string): Project[] {
@@ -82,18 +84,21 @@ export function hasProject(projectId: string) {
 
 export function hasRunningProjectThread(projectId: string) {
   const db = getThreadStateDatabase();
-  const row = db
+  const rows = db
     .prepare(
       `
-        SELECT id
+        SELECT
+          session_path AS sessionPath,
+          running AS running
         FROM threads
-        WHERE cwd = ? AND running = 1
-        LIMIT 1
+        WHERE cwd = ? AND archived = 0
       `,
     )
-    .get(projectId) as { id?: string } | undefined;
+    .all(projectId) as Array<{ sessionPath: string; running: number }>;
 
-  return typeof row?.id === "string";
+  return rows.some((row) =>
+    getEffectiveThreadRunningState(row.running, getLiveThread(row.sessionPath)),
+  );
 }
 
 export function listProjectThreads(projectId: string): Thread[] {
@@ -118,7 +123,12 @@ export function listProjectThreads(projectId: string): Thread[] {
     )
     .all(projectId) as ThreadRow[];
 
-  return rows.map(mapThreadRow);
+  return rows.map((row) =>
+    mapThreadRow({
+      ...row,
+      running: getEffectiveThreadRunningState(row.running, getLiveThread(row.sessionPath)) ? 1 : 0,
+    }),
+  );
 }
 
 export function listInboxThreads(): InboxThread[] {
@@ -153,7 +163,12 @@ export function listInboxThreads(): InboxThread[] {
     )
     .all() as InboxThreadRow[];
 
-  return rows.map(mapInboxThreadRow);
+  return rows.map((row) =>
+    mapInboxThreadRow({
+      ...row,
+      running: getEffectiveThreadRunningState(row.running, getLiveThread(row.sessionPath)) ? 1 : 0,
+    }),
+  );
 }
 
 export function listArchivedThreads(): ArchivedThread[] {

--- a/desktop/thread-state-db/schema.cts
+++ b/desktop/thread-state-db/schema.cts
@@ -232,5 +232,11 @@ export function ensureThreadStateSchema(database: Database) {
     database.exec("ALTER TABLE inbox_items ADD COLUMN last_user_prompt TEXT");
   }
 
+  database.exec(`
+    UPDATE threads
+    SET running = 0
+    WHERE running != 0
+  `);
+
   schemaReady = true;
 }

--- a/shared/thread-running-state.ts
+++ b/shared/thread-running-state.ts
@@ -1,0 +1,12 @@
+import type { ThreadData } from "./desktop-contracts";
+
+export function getEffectiveThreadRunningState(
+  persistedRunning: boolean | number,
+  liveThread: Pick<ThreadData, "isStreaming"> | null,
+) {
+  if (liveThread) {
+    return liveThread.isStreaming;
+  }
+
+  return Boolean(persistedRunning);
+}

--- a/shared/thread-running-state.ts
+++ b/shared/thread-running-state.ts
@@ -1,4 +1,4 @@
-import type { ThreadData } from "./desktop-contracts";
+import type { InboxThread, ThreadData } from "./desktop-contracts";
 
 export function getEffectiveThreadRunningState(
   persistedRunning: boolean | number,
@@ -9,4 +9,24 @@ export function getEffectiveThreadRunningState(
   }
 
   return Boolean(persistedRunning);
+}
+
+export function sortInboxThreadsByPriority(threads: InboxThread[]) {
+  return [...threads].sort((left, right) => {
+    if (left.unread !== right.unread) {
+      return left.unread ? -1 : 1;
+    }
+
+    if (left.running !== right.running) {
+      return left.running ? -1 : 1;
+    }
+
+    const leftActivity = left.lastActivityMs ?? 0;
+    const rightActivity = right.lastActivityMs ?? 0;
+    if (leftActivity !== rightActivity) {
+      return rightActivity - leftActivity;
+    }
+
+    return left.title.localeCompare(right.title, undefined, { sensitivity: "base" });
+  });
 }

--- a/src/test/thread-running-state.test.ts
+++ b/src/test/thread-running-state.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getEffectiveThreadRunningState } from "../../shared/thread-running-state";
+
+describe("thread running state", () => {
+  it("uses the live runtime state when available", () => {
+    expect(getEffectiveThreadRunningState(false, { isStreaming: true })).toBe(true);
+    expect(getEffectiveThreadRunningState(true, { isStreaming: false })).toBe(false);
+  });
+
+  it("falls back to the persisted state when no live runtime state is known", () => {
+    expect(getEffectiveThreadRunningState(true, null)).toBe(true);
+    expect(getEffectiveThreadRunningState(false, null)).toBe(false);
+  });
+});

--- a/src/test/thread-running-state.test.ts
+++ b/src/test/thread-running-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getEffectiveThreadRunningState } from "../../shared/thread-running-state";
+import type { InboxThread } from "../../shared/desktop-contracts";
+import {
+  getEffectiveThreadRunningState,
+  sortInboxThreadsByPriority,
+} from "../../shared/thread-running-state";
 
 describe("thread running state", () => {
   it("uses the live runtime state when available", () => {
@@ -10,5 +14,58 @@ describe("thread running state", () => {
   it("falls back to the persisted state when no live runtime state is known", () => {
     expect(getEffectiveThreadRunningState(true, null)).toBe(true);
     expect(getEffectiveThreadRunningState(false, null)).toBe(false);
+  });
+
+  it("sorts inbox threads by unread, effective running state, then activity", () => {
+    const threads: InboxThread[] = [
+      {
+        threadId: "idle-newer",
+        title: "Idle newer",
+        projectId: "/tmp/project",
+        projectName: "project",
+        sessionPath: "/tmp/idle-newer",
+        age: "1m",
+        lastActivityMs: 200,
+        prompt: null,
+        content: [],
+        preview: null,
+        running: false,
+        unread: false,
+      },
+      {
+        threadId: "running",
+        title: "Running",
+        projectId: "/tmp/project",
+        projectName: "project",
+        sessionPath: "/tmp/running",
+        age: "2m",
+        lastActivityMs: 100,
+        prompt: null,
+        content: [],
+        preview: null,
+        running: true,
+        unread: false,
+      },
+      {
+        threadId: "unread",
+        title: "Unread",
+        projectId: "/tmp/project",
+        projectName: "project",
+        sessionPath: "/tmp/unread",
+        age: "3m",
+        lastActivityMs: 50,
+        prompt: null,
+        content: [],
+        preview: null,
+        running: false,
+        unread: true,
+      },
+    ];
+
+    expect(sortInboxThreadsByPriority(threads).map((thread) => thread.threadId)).toEqual([
+      "unread",
+      "running",
+      "idle-newer",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- resolve thread/inbox running indicators against the live runtime state when it exists
- clear stale persisted `threads.running` flags on app startup so old sessions do not reopen as falsely busy
- cover the running-state resolution logic with focused tests

## Details
This fixes the drift where the UI could show a thread as idle while the agent was still working, or show an old session as busy again when revisiting it.

The root issue was that we were trusting the persisted `threads.running` bit too much. That value can be stale across app restarts, and it can also temporarily disagree with the in-memory live runtime. The desktop query layer now prefers the live thread's `isStreaming` state when available, while startup clears any stale persisted busy flags left behind from a previous app run.

## Validation
- pre-commit hooks passed during commit
- pre-push checks passed (`lint`, `typecheck`, `test`, `build`)
- added `src/test/thread-running-state.test.ts`

Closes #41
