### PR TITLE
Fix GUI-started sessions dropping live thread updates

### DIFF
--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -17,6 +17,32 @@ type QueryClientLike = {
   invalidateQueries: (filters: { queryKey: readonly unknown[] }) => Promise<unknown> | unknown;
 };
 
+type DesktopEventSelectionState = Pick<
+  WorkspaceState,
+  "activeView" | "selectedSessionPath" | "selectedInboxSessionPath"
+>;
+
+export function getVisibleDesktopSessionPath(workspaceState: DesktopEventSelectionState) {
+  return workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
+    ? getPersistedSessionPath(workspaceState.selectedSessionPath)
+    : workspaceState.activeView === "inbox"
+      ? (workspaceState.selectedInboxSessionPath ?? null)
+      : null;
+}
+
+export function shouldAutoOpenStartedThread(
+  reason: Extract<DesktopEvent, { type: "thread-update" }>["reason"],
+  workspaceState: DesktopEventSelectionState,
+) {
+  const visibleSessionPath = getVisibleDesktopSessionPath(workspaceState);
+
+  return (
+    reason === "start" &&
+    (workspaceState.activeView === "code" ||
+      (workspaceState.activeView === "thread" && visibleSessionPath === null))
+  );
+}
+
 export function useAppShellEffects({
   projects,
   collapsedProjectIds,
@@ -232,24 +258,50 @@ export function useAppShellEffects({
     });
   }, [workspaceState.activeView, workspaceState.selectedSessionPath]);
 
+  const desktopEventStateRef = useRef({
+    composerProjectId,
+    workspaceState: {
+      activeView: workspaceState.activeView,
+      selectedSessionPath: workspaceState.selectedSessionPath,
+      selectedInboxSessionPath: workspaceState.selectedInboxSessionPath,
+    } satisfies DesktopEventSelectionState,
+  });
+
+  useEffect(() => {
+    desktopEventStateRef.current = {
+      composerProjectId,
+      workspaceState: {
+        activeView: workspaceState.activeView,
+        selectedSessionPath: workspaceState.selectedSessionPath,
+        selectedInboxSessionPath: workspaceState.selectedInboxSessionPath,
+      },
+    };
+  }, [
+    composerProjectId,
+    workspaceState.activeView,
+    workspaceState.selectedInboxSessionPath,
+    workspaceState.selectedSessionPath,
+  ]);
+
   useEffect(() => {
     if (!window.piDesktop?.subscribe) {
       return;
     }
 
-    const visibleSessionPath =
-      workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
-        ? getPersistedSessionPath(workspaceState.selectedSessionPath)
-        : workspaceState.activeView === "inbox"
-          ? (workspaceState.selectedInboxSessionPath ?? null)
-          : null;
-
+    // Keep the desktop event subscription stable. Re-subscribing on every selection change can
+    // drop in-flight thread updates exactly when a GUI-started thread flips from a local draft
+    // path to a persisted session path, which makes the live stream appear stuck.
     const unsubscribe = window.piDesktop.subscribe((event: DesktopEvent) => {
+      const { composerProjectId: latestComposerProjectId, workspaceState: latestWorkspaceState } =
+        desktopEventStateRef.current;
+      const visibleSessionPath = getVisibleDesktopSessionPath(latestWorkspaceState);
+
       if (event.type === "composer-update") {
         const shouldApplyComposerUpdate = event.sessionPath
           ? event.sessionPath === visibleSessionPath
-          : event.projectId === composerProjectId &&
-            ((workspaceState.activeView !== "thread" && workspaceState.activeView !== "gitops") ||
+          : event.projectId === latestComposerProjectId &&
+            ((latestWorkspaceState.activeView !== "thread" &&
+              latestWorkspaceState.activeView !== "gitops") ||
               visibleSessionPath === null);
 
         if (shouldApplyComposerUpdate) {
@@ -294,12 +346,7 @@ export function useAppShellEffects({
           });
       }
 
-      const shouldAutoOpenStartedThread =
-        event.reason === "start" &&
-        (workspaceState.activeView === "code" ||
-          (workspaceState.activeView === "thread" && visibleSessionPath === null));
-
-      if (shouldAutoOpenStartedThread) {
+      if (shouldAutoOpenStartedThread(event.reason, latestWorkspaceState)) {
         dispatch({
           type: "open-thread",
           projectId: event.projectId,
@@ -309,7 +356,7 @@ export function useAppShellEffects({
       }
 
       if (event.reason === "end" || event.reason === "external") {
-        if (workspaceState.activeView === "gitops") {
+        if (latestWorkspaceState.activeView === "gitops") {
           void queryClient.invalidateQueries({
             queryKey: desktopQueryKeys.projectDiffPrefix(event.projectId),
           });
@@ -323,7 +370,7 @@ export function useAppShellEffects({
           queryKey: desktopQueryKeys.projectCommitsPrefix(event.projectId),
         });
 
-        if (event.projectId === composerProjectId) {
+        if (event.projectId === latestComposerProjectId) {
           void loadProjectGitState(event.projectId).then((nextProjectGitState) => {
             setProjectGitState(nextProjectGitState);
           });
@@ -333,7 +380,6 @@ export function useAppShellEffects({
 
     return unsubscribe;
   }, [
-    composerProjectId,
     dispatch,
     loadProjectGitState,
     loadProjectThreads,
@@ -341,8 +387,5 @@ export function useAppShellEffects({
     scheduleShellStateRefresh,
     setComposerState,
     setProjectGitState,
-    workspaceState.activeView,
-    workspaceState.selectedInboxSessionPath,
-    workspaceState.selectedSessionPath,
   ]);
 }

--- a/src/test/app-shell-effects.test.ts
+++ b/src/test/app-shell-effects.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  getVisibleDesktopSessionPath,
+  shouldAutoOpenStartedThread,
+} from "../app/app-shell/useAppShellEffects";
+
+describe("app shell effects", () => {
+  it("treats local draft threads as having no persisted visible session path", () => {
+    expect(
+      getVisibleDesktopSessionPath({
+        activeView: "thread",
+        selectedSessionPath: "local://%2Frepo/123",
+        selectedInboxSessionPath: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("uses the persisted thread session path when a real thread is visible", () => {
+    expect(
+      getVisibleDesktopSessionPath({
+        activeView: "thread",
+        selectedSessionPath: "/repo/.pi/sessions/thread.jsonl",
+        selectedInboxSessionPath: null,
+      }),
+    ).toBe("/repo/.pi/sessions/thread.jsonl");
+  });
+
+  it("auto-opens a started thread from code view or a local draft thread view", () => {
+    expect(
+      shouldAutoOpenStartedThread("start", {
+        activeView: "code",
+        selectedSessionPath: null,
+        selectedInboxSessionPath: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoOpenStartedThread("start", {
+        activeView: "thread",
+        selectedSessionPath: "local://%2Frepo/123",
+        selectedInboxSessionPath: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not auto-open started threads when a persisted thread is already visible", () => {
+    expect(
+      shouldAutoOpenStartedThread("start", {
+        activeView: "thread",
+        selectedSessionPath: "/repo/.pi/sessions/thread.jsonl",
+        selectedInboxSessionPath: null,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the desktop runtime event subscription stable while thread selection changes
- read the latest visible session/composer context from refs instead of re-subscribing on every selection update
- add focused coverage for local-draft vs persisted-session visibility rules used by GUI-started threads

## Details
This fixes the GUI-started session race behind #32.

A new thread starts life as a local draft session path in the renderer, then flips to a persisted Pi session path once the runtime starts streaming. We were tearing down and recreating the desktop event subscription on those selection changes. That created a narrow gap where the initial `start` / `message_update` events for the persisted session could be missed, leaving the thread view stuck at the initial prompt until the user switched views or refreshed.

The subscription now stays mounted and uses refs for the latest workspace selection state, so thread streaming events are not dropped during that local-draft -> persisted-session transition.

## Validation
- pre-commit hooks passed during commit
- pre-push checks passed (`lint`, `typecheck`, `test`, `build`)
- added focused tests in `src/test/app-shell-effects.test.ts`

Closes #32
