### PR TITLE
Add exit affordances for settings, skills, and extensions views

### DIFF
--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -310,6 +310,10 @@ export function useAppShellController() {
     dispatch({ type: "show-view", view });
   };
 
+  const handleCloseUtilityView = () => {
+    dispatch({ type: "close-utility-view" });
+  };
+
   const handleCollapseAll = () => {
     dispatch({ type: "collapse-all-projects" });
     void handleAction("threads.collapse-all");
@@ -430,6 +434,7 @@ export function useAppShellController() {
     handleCloseSettingsPanel: () => dispatch({ type: "set-settings-panel-open", open: false }),
     handleCloseTakeoverTerminal: closeTakeover,
     handleCloseGitOpsView,
+    handleCloseUtilityView,
     handleOpenWorktreeDiffFile,
     handleLoadEarlierMessages,
     handleDismissInboxThread,

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -9,6 +9,7 @@ import type {
   ProjectGitState,
 } from "../desktop/types";
 import { desktopQueryKeys } from "../query/desktop-query";
+import { isUtilityView } from "../state/workspace";
 import type { WorkspaceAction, WorkspaceState } from "../state/workspace";
 import type { Project } from "../types";
 
@@ -41,6 +42,13 @@ export function shouldAutoOpenStartedThread(
     (workspaceState.activeView === "code" ||
       (workspaceState.activeView === "thread" && visibleSessionPath === null))
   );
+}
+
+export function shouldCloseUtilityViewOnEscape(
+  activeView: WorkspaceState["activeView"],
+  event: Pick<KeyboardEvent, "key" | "defaultPrevented">,
+) {
+  return isUtilityView(activeView) && event.key === "Escape" && !event.defaultPrevented;
 }
 
 export function useAppShellEffects({
@@ -257,6 +265,25 @@ export function useAppShellEffects({
       console.warn("Failed to update watched Pi session.", error);
     });
   }, [workspaceState.activeView, workspaceState.selectedSessionPath]);
+
+  useEffect(() => {
+    if (!isUtilityView(workspaceState.activeView)) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!shouldCloseUtilityViewOnEscape(workspaceState.activeView, event)) {
+        return;
+      }
+
+      dispatch({ type: "close-utility-view" });
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [dispatch, workspaceState.activeView]);
 
   const desktopEventStateRef = useRef({
     composerProjectId,

--- a/src/app/components/common/SegmentedToggle.tsx
+++ b/src/app/components/common/SegmentedToggle.tsx
@@ -11,21 +11,26 @@ type SegmentedToggleProps<T extends string> = {
   value: T;
   options: readonly SegmentedToggleOption<T>[];
   onChange: (value: T) => void;
+  size?: "default" | "compact";
 };
 
 export function SegmentedToggle<T extends string>({
   value,
   options,
   onChange,
+  size = "default",
 }: SegmentedToggleProps<T>) {
+  const compact = size === "compact";
+
   return (
-    <div className={segmentedControlClass}>
+    <div className={cn(segmentedControlClass, compact && "p-[3px]")}>
       {options.map((option) => (
         <button
           key={option.value}
           type="button"
           className={cn(
             segmentedControlOptionClass,
+            compact && "px-2.5 py-1 text-[11.5px] leading-4",
             value === option.value
               ? "bg-[rgba(255,255,255,0.18)] font-medium text-[color:var(--text)] shadow-[inset_0_0_0_1px_rgba(183,186,245,0.5)]"
               : "text-[color:var(--muted)] hover:text-[color:var(--text)]",

--- a/src/app/components/common/ViewHeader.tsx
+++ b/src/app/components/common/ViewHeader.tsx
@@ -1,6 +1,6 @@
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
-import { compactRoundIconButtonClass, viewSubtitleClass, viewTitleClass } from "../../ui/classes";
+import { ghostButtonClass, viewSubtitleClass, viewTitleClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
 
 type ViewHeaderProps = {
@@ -37,12 +37,16 @@ export function ViewHeader({
           {onClose ? (
             <button
               type="button"
-              className={compactRoundIconButtonClass}
+              className={cn(
+                ghostButtonClass,
+                "inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] px-3 py-1.5 text-[13px] text-[color:var(--text)]",
+              )}
               onClick={onClose}
               aria-label={closeLabel}
               title={closeLabel}
             >
               <X size={14} />
+              <span>Close</span>
             </button>
           ) : null}
         </div>

--- a/src/app/components/common/ViewHeader.tsx
+++ b/src/app/components/common/ViewHeader.tsx
@@ -1,6 +1,6 @@
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
-import { ghostButtonClass, viewSubtitleClass, viewTitleClass } from "../../ui/classes";
+import { viewSubtitleClass, viewTitleClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
 
 type ViewHeaderProps = {
@@ -37,16 +37,12 @@ export function ViewHeader({
           {onClose ? (
             <button
               type="button"
-              className={cn(
-                ghostButtonClass,
-                "inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] px-3 py-1.5 text-[13px] text-[color:var(--text)]",
-              )}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] text-[color:var(--text)] transition-colors duration-150 ease-out hover:bg-[rgba(255,255,255,0.07)]"
               onClick={onClose}
               aria-label={closeLabel}
               title={closeLabel}
             >
               <X size={14} />
-              <span>Close</span>
             </button>
           ) : null}
         </div>

--- a/src/app/components/common/ViewHeader.tsx
+++ b/src/app/components/common/ViewHeader.tsx
@@ -1,5 +1,6 @@
+import { X } from "lucide-react";
 import type { ReactNode } from "react";
-import { viewSubtitleClass, viewTitleClass } from "../../ui/classes";
+import { compactRoundIconButtonClass, viewSubtitleClass, viewTitleClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
 
 type ViewHeaderProps = {
@@ -7,10 +8,20 @@ type ViewHeaderProps = {
   meta?: ReactNode;
   subtitle?: ReactNode;
   actions?: ReactNode;
+  onClose?: () => void;
+  closeLabel?: string;
   className?: string;
 };
 
-export function ViewHeader({ title, meta, subtitle, actions, className }: ViewHeaderProps) {
+export function ViewHeader({
+  title,
+  meta,
+  subtitle,
+  actions,
+  onClose,
+  closeLabel = "Close view",
+  className,
+}: ViewHeaderProps) {
   return (
     <div className={cn("flex items-start justify-between gap-3", className)}>
       <div className="min-w-0 grid gap-1">
@@ -20,7 +31,22 @@ export function ViewHeader({ title, meta, subtitle, actions, className }: ViewHe
         </div>
         {subtitle ? <p className={viewSubtitleClass}>{subtitle}</p> : null}
       </div>
-      {actions ? <div className="shrink-0">{actions}</div> : null}
+      {actions || onClose ? (
+        <div className="flex shrink-0 items-center gap-2">
+          {actions ? <div className="shrink-0">{actions}</div> : null}
+          {onClose ? (
+            <button
+              type="button"
+              className={compactRoundIconButtonClass}
+              onClick={onClose}
+              aria-label={closeLabel}
+              title={closeLabel}
+            >
+              <X size={14} />
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -39,6 +39,7 @@ type CodeWorkspaceMainViewProps = {
   composerLayoutVersion: number;
   onAction: DesktopActionInvoker;
   onDismissInboxThread: (thread: InboxThread) => void;
+  onCloseUtilityView: () => void;
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
   onLoadEarlierMessages: () => void;
   onSetExtensionsProjectScopeActive: (active: boolean) => void;
@@ -61,6 +62,7 @@ export function CodeWorkspaceMainView({
   composerLayoutVersion,
   onAction,
   onDismissInboxThread,
+  onCloseUtilityView,
   onOpenThread,
   onLoadEarlierMessages,
   onSetExtensionsProjectScopeActive,
@@ -101,6 +103,7 @@ export function CodeWorkspaceMainView({
         currentModel={currentModel}
         projects={projects}
         onAction={onAction}
+        onClose={onCloseUtilityView}
       />
     );
   }
@@ -124,6 +127,7 @@ export function CodeWorkspaceMainView({
         <ExtensionsView
           projectPath={selectedProjectId || null}
           onSetProjectScopeActive={onSetExtensionsProjectScopeActive}
+          onClose={onCloseUtilityView}
         />
       </Suspense>
     );
@@ -146,6 +150,7 @@ export function CodeWorkspaceMainView({
           projectPath={selectedProjectId || null}
           onSetProjectScopeActive={onSetSkillsProjectScopeActive}
           onAction={onAction}
+          onClose={onCloseUtilityView}
         />
       </Suspense>
     );

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -318,6 +318,7 @@ export function CodeWorkspaceView({
                 onAction={handleAction}
                 onDismissInboxThread={controller.handleDismissInboxThread}
                 onOpenThread={controller.handleThreadOpen}
+                onCloseUtilityView={controller.handleCloseUtilityView}
                 onLoadEarlierMessages={handleLoadEarlierMessages}
                 onSetExtensionsProjectScopeActive={controller.handleSetExtensionsProjectScopeActive}
                 onSetSkillsProjectScopeActive={controller.handleSetSkillsProjectScopeActive}

--- a/src/app/features/extensions/ExtensionsView.tsx
+++ b/src/app/features/extensions/ExtensionsView.tsx
@@ -43,7 +43,7 @@ export function ExtensionsView(props: ExtensionsViewProps) {
   if (!controller.desktopPackagesAvailable) {
     return (
       <ViewShell>
-        <ViewHeader title="Extensions" />
+        <ViewHeader title="Extensions" onClose={props.onClose} closeLabel="Close extensions" />
         <EmptyStateCard>Desktop build required.</EmptyStateCard>
       </ViewShell>
     );
@@ -53,6 +53,8 @@ export function ExtensionsView(props: ExtensionsViewProps) {
     <ViewShell>
       <ViewHeader
         title="Extensions"
+        onClose={props.onClose}
+        closeLabel="Close extensions"
         actions={
           <ExtensionsScopeToggle
             globalInstalledCount={controller.globalInstalledCount}

--- a/src/app/features/extensions/ExtensionsView.tsx
+++ b/src/app/features/extensions/ExtensionsView.tsx
@@ -23,6 +23,7 @@ function ExtensionsScopeToggle({
 }) {
   return (
     <SegmentedToggle
+      size="compact"
       value={installScope}
       options={[
         { value: "global", label: `Global (${globalInstalledCount})` },

--- a/src/app/features/extensions/types.ts
+++ b/src/app/features/extensions/types.ts
@@ -1,6 +1,7 @@
 export type ExtensionsViewProps = {
   projectPath: string | null;
   onSetProjectScopeActive: (active: boolean) => void;
+  onClose: () => void;
 };
 
 export type InstallScope = "global" | "project";

--- a/src/app/features/skills/SkillsView.tsx
+++ b/src/app/features/skills/SkillsView.tsx
@@ -33,10 +33,15 @@ function SkillsMetaLink() {
   );
 }
 
-function DesktopRequiredState() {
+function DesktopRequiredState({ onClose }: { onClose: () => void }) {
   return (
     <ViewShell className="gap-8">
-      <ViewHeader title="Skills" meta={<SkillsMetaLink />} />
+      <ViewHeader
+        title="Skills"
+        meta={<SkillsMetaLink />}
+        onClose={onClose}
+        closeLabel="Close skills"
+      />
       <EmptyStateCard>Desktop build required.</EmptyStateCard>
     </ViewShell>
   );
@@ -47,6 +52,7 @@ export function SkillsView({
   projectPath,
   onSetProjectScopeActive,
   onAction,
+  onClose,
 }: SkillsViewProps) {
   const controller = useSkillsController({
     projectPath,
@@ -54,7 +60,7 @@ export function SkillsView({
   });
 
   if (!controller.desktopSkillsAvailable) {
-    return <DesktopRequiredState />;
+    return <DesktopRequiredState onClose={onClose} />;
   }
 
   return (
@@ -62,6 +68,8 @@ export function SkillsView({
       <ViewHeader
         title="Skills"
         meta={<SkillsMetaLink />}
+        onClose={onClose}
+        closeLabel="Close skills"
         actions={
           <SegmentedToggle
             value={controller.installScope}

--- a/src/app/features/skills/SkillsView.tsx
+++ b/src/app/features/skills/SkillsView.tsx
@@ -72,6 +72,7 @@ export function SkillsView({
         closeLabel="Close skills"
         actions={
           <SegmentedToggle
+            size="compact"
             value={controller.installScope}
             options={[
               { value: "global", label: `Global (${controller.globalSkillCount})` },

--- a/src/app/features/skills/types.ts
+++ b/src/app/features/skills/types.ts
@@ -5,6 +5,7 @@ export type SkillsViewProps = {
   projectPath: string | null;
   onSetProjectScopeActive: (active: boolean) => void;
   onAction: DesktopActionInvoker;
+  onClose: () => void;
 };
 
 export type InstallScope = "global" | "project";

--- a/src/app/hooks/useDismissibleLayer.ts
+++ b/src/app/hooks/useDismissibleLayer.ts
@@ -25,16 +25,18 @@ export function useDismissibleLayer({ open, onDismiss, refs }: UseDismissibleLay
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
         onDismiss();
       }
     };
 
     window.addEventListener("pointerdown", handlePointerDown);
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
 
     return () => {
       window.removeEventListener("pointerdown", handlePointerDown);
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
     };
   }, [onDismiss, open, refs]);
 }

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -201,6 +201,82 @@ describe("workspace state", () => {
     expect(nextState.selectedProjectId).toBe("claw-phone");
   });
 
+  it("restores the previous thread context when closing a utility view", () => {
+    const threadState = workspaceReducer(createInitialWorkspaceState(mockProjects), {
+      type: "open-thread",
+      projectId: "claw-phone",
+      threadId: "thread-1",
+      sessionPath: "/tmp/thread.jsonl",
+    });
+    const settingsState = workspaceReducer(threadState, {
+      type: "show-view",
+      view: "settings",
+    });
+    const restoredState = workspaceReducer(settingsState, {
+      type: "close-utility-view",
+    });
+
+    expect(settingsState.activeView).toBe("settings");
+    expect(settingsState.selectedThreadId).toBeNull();
+    expect(settingsState.selectedSessionPath).toBeNull();
+    expect(settingsState.utilityViewReturnState?.activeView).toBe("thread");
+
+    expect(restoredState.activeView).toBe("thread");
+    expect(restoredState.selectedProjectId).toBe("claw-phone");
+    expect(restoredState.selectedThreadId).toBe("thread-1");
+    expect(restoredState.selectedSessionPath).toBe("/tmp/thread.jsonl");
+    expect(restoredState.utilityViewReturnState).toBeNull();
+  });
+
+  it("keeps the original return target when switching between utility views", () => {
+    const threadState = workspaceReducer(createInitialWorkspaceState(mockProjects), {
+      type: "open-thread",
+      projectId: "claw-phone",
+      threadId: "thread-1",
+      sessionPath: "/tmp/thread.jsonl",
+    });
+    const settingsState = workspaceReducer(threadState, {
+      type: "show-view",
+      view: "settings",
+    });
+    const skillsState = workspaceReducer(settingsState, {
+      type: "show-view",
+      view: "skills",
+    });
+    const restoredState = workspaceReducer(skillsState, {
+      type: "close-utility-view",
+    });
+
+    expect(skillsState.utilityViewReturnState?.activeView).toBe("thread");
+    expect(restoredState.activeView).toBe("thread");
+    expect(restoredState.selectedSessionPath).toBe("/tmp/thread.jsonl");
+  });
+
+  it("restores the previous git ops context when closing a utility view", () => {
+    const gitOpsState = workspaceReducer(
+      {
+        ...createInitialWorkspaceState(mockProjects),
+        activeView: "thread",
+        selectedThreadId: "thread-1",
+        selectedSessionPath: "/tmp/thread.jsonl",
+      },
+      {
+        type: "open-gitops",
+        filePath: "src/app/AppShell.tsx",
+      },
+    );
+    const extensionsState = workspaceReducer(gitOpsState, {
+      type: "show-view",
+      view: "extensions",
+    });
+    const restoredState = workspaceReducer(extensionsState, {
+      type: "close-utility-view",
+    });
+
+    expect(restoredState.activeView).toBe("gitops");
+    expect(restoredState.selectedDiffFilePath).toBe("src/app/AppShell.tsx");
+  });
+
   it("clears thread-specific state when leaving thread view", () => {
     const nextState = workspaceReducer(
       {
@@ -220,6 +296,7 @@ describe("workspace state", () => {
     expect(nextState.selectedThreadId).toBeNull();
     expect(nextState.selectedSessionPath).toBeNull();
     expect(nextState.selectedDiffFilePath).toBeNull();
+    expect(nextState.utilityViewReturnState).toBeNull();
   });
 
   it("opens the archived threads view like any other main view", () => {

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -2,6 +2,20 @@ import { isLocalSessionPath } from "../../../shared/session-paths";
 import type { Project, Thread, View } from "../types";
 
 type NonGitOpsView = Exclude<View, "gitops">;
+export type UtilityView = Extract<View, "settings" | "extensions" | "skills">;
+
+type UtilityViewReturnState = {
+  activeView: View;
+  selectedProjectId: string;
+  selectedInboxSessionPath: string | null;
+  selectedThreadId: string | null;
+  selectedSessionPath: string | null;
+  terminalVisible: boolean;
+  restoreTerminalVisibleOnGitOpsClose: boolean;
+  takeoverVisible: boolean;
+  gitOpsReturnView: NonGitOpsView;
+  selectedDiffFilePath: string | null;
+};
 
 export type WorkspaceState = {
   activeView: View;
@@ -16,6 +30,7 @@ export type WorkspaceState = {
   takeoverOverrides: Record<string, boolean>;
   gitOpsReturnView: NonGitOpsView;
   selectedDiffFilePath: string | null;
+  utilityViewReturnState: UtilityViewReturnState | null;
   settingsOpen: boolean;
   settingsPanelOpen: boolean;
   collapsedProjectIds: Record<string, boolean>;
@@ -24,6 +39,7 @@ export type WorkspaceState = {
 export type WorkspaceAction =
   | { type: "sync-projects"; projects: Project[] }
   | { type: "show-view"; view: NonGitOpsView }
+  | { type: "close-utility-view" }
   | { type: "select-inbox-thread"; sessionPath: string | null }
   | { type: "select-project"; projectId: string }
   | { type: "set-selected-project"; projectId: string }
@@ -44,6 +60,25 @@ export type WorkspaceAction =
   | { type: "set-settings-panel-open"; open: boolean }
   | { type: "toggle-project-collapse"; projectId: string }
   | { type: "collapse-all-projects" };
+
+export function isUtilityView(view: View): view is UtilityView {
+  return view === "settings" || view === "extensions" || view === "skills";
+}
+
+function createUtilityViewReturnState(state: WorkspaceState): UtilityViewReturnState {
+  return {
+    activeView: state.activeView,
+    selectedProjectId: state.selectedProjectId,
+    selectedInboxSessionPath: state.selectedInboxSessionPath,
+    selectedThreadId: state.selectedThreadId,
+    selectedSessionPath: state.selectedSessionPath,
+    terminalVisible: state.terminalVisible,
+    restoreTerminalVisibleOnGitOpsClose: state.restoreTerminalVisibleOnGitOpsClose,
+    takeoverVisible: state.takeoverVisible,
+    gitOpsReturnView: state.gitOpsReturnView,
+    selectedDiffFilePath: state.selectedDiffFilePath,
+  };
+}
 
 function migrateTakeoverOverride(
   takeoverOverrides: Record<string, boolean>,
@@ -129,6 +164,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     takeoverOverrides: {},
     gitOpsReturnView: "code",
     selectedDiffFilePath: null,
+    utilityViewReturnState: null,
     settingsOpen: false,
     settingsPanelOpen: false,
     collapsedProjectIds: Object.fromEntries(
@@ -172,10 +208,18 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
           hasSelectedProject || !state.selectedProjectId ? state.selectedDiffFilePath : null,
         gitOpsReturnView:
           hasSelectedProject || !state.selectedProjectId ? state.gitOpsReturnView : "code",
+        utilityViewReturnState:
+          hasSelectedProject || !state.selectedProjectId ? state.utilityViewReturnState : null,
         collapsedProjectIds,
       };
     }
-    case "show-view":
+    case "show-view": {
+      const utilityViewReturnState = isUtilityView(action.view)
+        ? isUtilityView(state.activeView)
+          ? state.utilityViewReturnState
+          : createUtilityViewReturnState(state)
+        : null;
+
       return {
         ...state,
         ...getTerminalStateForNextView(state, action.view),
@@ -186,6 +230,20 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedSessionPath: action.view === "thread" ? state.selectedSessionPath : null,
         selectedDiffFilePath: action.view === "thread" ? state.selectedDiffFilePath : null,
         takeoverVisible: action.view === "thread" ? state.takeoverVisible : false,
+        utilityViewReturnState,
+      };
+    }
+    case "close-utility-view":
+      if (!state.utilityViewReturnState) {
+        return state;
+      }
+
+      return {
+        ...state,
+        ...state.utilityViewReturnState,
+        settingsOpen: false,
+        settingsPanelOpen: false,
+        utilityViewReturnState: null,
       };
     case "select-inbox-thread":
       return {
@@ -204,6 +262,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedDiffFilePath: null,
         takeoverVisible: false,
         gitOpsReturnView: "code",
+        utilityViewReturnState: null,
       };
     case "set-selected-project":
       return {
@@ -243,6 +302,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         ),
         selectedDiffFilePath: null,
         gitOpsReturnView: "thread",
+        utilityViewReturnState: null,
         collapsedProjectIds: {
           ...state.collapsedProjectIds,
           [action.projectId]: false,
@@ -262,6 +322,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         gitOpsReturnView:
           action.returnView ?? getGitOpsReturnView(state.activeView, state.gitOpsReturnView),
         selectedDiffFilePath: action.filePath ?? null,
+        utilityViewReturnState: null,
       };
     case "close-gitops":
       return {
@@ -271,6 +332,7 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         selectedThreadId: state.gitOpsReturnView === "thread" ? state.selectedThreadId : null,
         selectedSessionPath: state.gitOpsReturnView === "thread" ? state.selectedSessionPath : null,
         selectedDiffFilePath: null,
+        utilityViewReturnState: null,
       };
     case "toggle-terminal":
       if (!state.selectedSessionPath) {

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -14,6 +14,7 @@ type SettingsViewProps = {
   currentModel: ComposerModel | null;
   projects: Project[];
   onAction: DesktopActionInvoker;
+  onClose: () => void;
 };
 
 export function SettingsView({
@@ -22,6 +23,7 @@ export function SettingsView({
   currentModel,
   projects,
   onAction,
+  onClose,
 }: SettingsViewProps) {
   const controller = useSettingsController({ appSettings, projects, onAction });
 
@@ -30,6 +32,8 @@ export function SettingsView({
       <ViewHeader
         title="App settings"
         subtitle="Git commit model, skill creator model, streaming send behavior, project cleanup defaults, Pi TUI defaults, project UI import, and favorite folders."
+        onClose={onClose}
+        closeLabel="Close app settings"
       />
 
       <SettingsModelSection

--- a/src/test/app-shell-effects.test.ts
+++ b/src/test/app-shell-effects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getVisibleDesktopSessionPath,
+  shouldCloseUtilityViewOnEscape,
   shouldAutoOpenStartedThread,
 } from "../app/app-shell/useAppShellEffects";
 
@@ -50,6 +51,27 @@ describe("app shell effects", () => {
         selectedSessionPath: "/repo/.pi/sessions/thread.jsonl",
         selectedInboxSessionPath: null,
       }),
+    ).toBe(false);
+  });
+
+  it("closes settings, skills, and extensions with Escape", () => {
+    expect(
+      shouldCloseUtilityViewOnEscape("settings", { key: "Escape", defaultPrevented: false }),
+    ).toBe(true);
+    expect(
+      shouldCloseUtilityViewOnEscape("extensions", {
+        key: "Escape",
+        defaultPrevented: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCloseUtilityViewOnEscape("skills", { key: "Escape", defaultPrevented: false }),
+    ).toBe(true);
+    expect(
+      shouldCloseUtilityViewOnEscape("thread", { key: "Escape", defaultPrevented: false }),
+    ).toBe(false);
+    expect(
+      shouldCloseUtilityViewOnEscape("settings", { key: "Escape", defaultPrevented: true }),
     ).toBe(false);
   });
 });

--- a/src/test/controller-view-model.test.ts
+++ b/src/test/controller-view-model.test.ts
@@ -34,6 +34,7 @@ describe("deriveControllerViewModel", () => {
         takeoverOverrides: {},
         gitOpsReturnView: "code",
         selectedDiffFilePath: null,
+        utilityViewReturnState: null,
         settingsOpen: false,
         settingsPanelOpen: false,
         collapsedProjectIds: {},


### PR DESCRIPTION
## Summary
- add explicit close affordances to the full-screen Settings, Extensions, and Skills views
- remember the previous workspace context when entering those utility views and restore it on close
- let Escape close those views and return to the prior session/workspace predictably

## Details
This fixes the current dead-end navigation on utility views.

The workspace reducer now captures the previous context when opening Settings, Extensions, or Skills, keeps that return target stable while switching between those utility views, and restores the saved context on close. The renderer adds visible close buttons to the view headers and wires Escape to the same close action.

## Validation
- `bun test src/app/state/workspace.test.ts src/test/app-shell-effects.test.ts src/test/controller-view-model.test.ts`
- `bun run typecheck:web`
- pre-commit hooks passed during commit
- pre-push checks passed (`lint`, `typecheck`, `test`, `build`)

Closes #20
