### PR TITLE
Fix packaged Windows desktop startup

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,6 +1,9 @@
 name: Release artifacts
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - "v*"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -3,7 +3,7 @@ name: Release artifacts
 on:
   pull_request:
     branches:
-      - main
+      - dev
   push:
     tags:
       - "v*"

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -19,7 +19,7 @@ import {
   loadProjectDiffStats,
   loadProjectGitState,
 } from "../project-git.cts";
-import { listProjects, syncSessionSummaries } from "../thread-state-db.cts";
+import { ensureProject, listProjects, syncSessionSummaries } from "../thread-state-db.cts";
 import { setWatchedSessionPath } from "./session-watch.cts";
 export { loadInboxThreadList } from "./thread-loader.cts";
 
@@ -69,11 +69,20 @@ async function syncShellIndex(cwd: string) {
   );
 }
 
+function scheduleShellIndexSync(cwd: string) {
+  // Session discovery can be slow on Windows when the agent storage contains many
+  // folders. Keep shell-state reads responsive and converge the DB in the background.
+  void syncShellIndex(cwd).catch((error) => {
+    console.warn("Failed to sync shell index.", error);
+  });
+}
+
 export async function loadShellState(cwd: string): Promise<ShellState> {
   const { SessionManager } = await getPiModule();
   const { agentDir, sessionDir } = await getSessionStorage(cwd);
 
-  await syncShellIndex(cwd);
+  ensureProject(cwd);
+  scheduleShellIndexSync(cwd);
   const composer = await getComposerState({ projectId: cwd });
   const appSettings = loadAppSettings();
 

--- a/desktop/project-import.cts
+++ b/desktop/project-import.cts
@@ -8,14 +8,14 @@ function resolveProjectIds(projectIds: string[]) {
     return [...new Set(projectIds)];
   }
 
-  return listProjects(process.cwd())
+  return listProjects()
     .filter((project) => project.threadCount !== 0)
     .map((project) => project.id);
 }
 
 export async function scanKnownProjects(projectIds: string[]): Promise<ProjectImportCandidate[]> {
   const knownProjects = new Map(
-    listProjects(process.cwd()).map((project) => [project.id, project] as const),
+    listProjects().map((project) => [project.id, project] as const),
   );
 
   return await Promise.all(

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -26,6 +26,10 @@ import {
   subscribeDesktopEvents,
 } from "./thread-publisher.cts";
 
+function getDesktopWorkingDirectory() {
+  return process.env.HOWCODE_REPO_ROOT || process.cwd();
+}
+
 async function emitComposerUpdate(request: ComposerStateRequest = {}) {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   const runtimePromise = persistedSessionPath
@@ -103,7 +107,7 @@ export async function setComposerModel(
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
 
   if (!persistedSessionPath) {
-    await setDraftComposerModel(request.projectId ?? process.cwd(), provider, modelId);
+    await setDraftComposerModel(request.projectId ?? getDesktopWorkingDirectory(), provider, modelId);
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
@@ -128,7 +132,7 @@ export async function setComposerThinkingLevel(
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
 
   if (!persistedSessionPath) {
-    await setDraftComposerThinkingLevel(request.projectId ?? process.cwd(), level);
+    await setDraftComposerThinkingLevel(request.projectId ?? getDesktopWorkingDirectory(), level);
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
@@ -146,7 +150,7 @@ export async function sendComposerPrompt(
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   const runtime = persistedSessionPath
     ? await getOrCreateRuntimeForSessionPath(persistedSessionPath, { suspendDisposal: true })
-    : await createRuntimeForNewSession(request.projectId ?? process.cwd());
+    : await createRuntimeForNewSession(request.projectId ?? getDesktopWorkingDirectory());
   const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
   const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;
 
@@ -167,7 +171,7 @@ export async function sendComposerPrompt(
 }
 
 export async function startNewThread(request: ComposerStateRequest = {}) {
-  const projectId = request.projectId ?? process.cwd();
+  const projectId = request.projectId ?? getDesktopWorkingDirectory();
   const composer = await buildComposerStateSnapshot({ projectId, sessionPath: null });
   const draft = createLocalThreadDraft(projectId);
 

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -11,6 +11,10 @@ import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import type { PiRuntime } from "./types.cts";
 
+function getDesktopWorkingDirectory() {
+  return process.env.HOWCODE_REPO_ROOT || process.cwd();
+}
+
 export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
 
 type ComposerSourceModel = NonNullable<AgentSession["model"]>;
@@ -134,7 +138,7 @@ export async function createComposerSnapshotSession(request: ComposerStateReques
   } = await getPiModule();
   const cwd = persistedSessionPath
     ? SessionManager.open(persistedSessionPath).getCwd()
-    : (request.projectId ?? process.cwd());
+    : (request.projectId ?? getDesktopWorkingDirectory());
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);

--- a/desktop/skill-creator-session.cts
+++ b/desktop/skill-creator-session.cts
@@ -127,8 +127,8 @@ async function createSkillCreatorSession(cwd: string, projectPath?: string | nul
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(cwd, agentDir);
-  const packagedSkillsPath = new URL("../../resources/skills", import.meta.url).pathname;
-  const repoSkillsPath = new URL("../../desktop/resources/skills", import.meta.url).pathname;
+  const packagedSkillsPath = new URL("../../resources/skills", import.meta.url);
+  const repoSkillsPath = new URL("../../desktop/resources/skills", import.meta.url);
   const bundledSkillsPath = (await pathExists(packagedSkillsPath))
     ? packagedSkillsPath
     : repoSkillsPath;

--- a/desktop/thread-state-db/queries.cts
+++ b/desktop/thread-state-db/queries.cts
@@ -24,11 +24,8 @@ import type {
   ThreadRow,
   TurnDiffRow,
 } from "./types.cts";
-import { ensureProject } from "./writes.cts";
-
-export function listProjects(cwd: string): Project[] {
+export function listProjects(cwd?: string | null): Project[] {
   const db = getThreadStateDatabase();
-  ensureProject(cwd);
 
   const rows = db
     .prepare(
@@ -63,7 +60,7 @@ export function listProjects(cwd: string): Project[] {
           projects.name COLLATE NOCASE ASC
       `,
     )
-    .all(cwd) as ProjectRow[];
+    .all(cwd ?? null) as ProjectRow[];
 
   return rows.map(mapProjectRow);
 }

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -14,6 +14,13 @@ export default {
       "dist/assets": "views/mainview/assets",
       "build/desktop": "build/desktop",
       "desktop/resources": "resources",
+      "node_modules/@mariozechner/pi-coding-agent/package.json": "resources/pi-coding-agent/package.json",
+      "node_modules/@mariozechner/pi-coding-agent/README.md": "resources/pi-coding-agent/README.md",
+      "node_modules/@mariozechner/pi-coding-agent/CHANGELOG.md": "resources/pi-coding-agent/CHANGELOG.md",
+      "node_modules/@mariozechner/pi-coding-agent/docs": "resources/pi-coding-agent/docs",
+      "node_modules/@mariozechner/pi-coding-agent/examples": "resources/pi-coding-agent/examples",
+      "node_modules/@mariozechner/pi-coding-agent/dist/modes/interactive/theme": "resources/pi-coding-agent/dist/modes/interactive/theme",
+      "node_modules/@mariozechner/pi-coding-agent/dist/core/export-html": "resources/pi-coding-agent/dist/core/export-html",
     },
     watchIgnore: ["dist/**"],
     mac: {

--- a/src/bun/composer-attachments.ts
+++ b/src/bun/composer-attachments.ts
@@ -7,6 +7,10 @@ import type {
   ComposerFilePickerState,
 } from "../../shared/desktop-contracts";
 
+function getDesktopWorkingDirectory() {
+  return process.env.HOWCODE_REPO_ROOT || process.cwd();
+}
+
 async function pathExists(targetPath: string) {
   try {
     await stat(targetPath);
@@ -62,7 +66,7 @@ export async function listComposerAttachmentEntries(request: {
   rootPath?: string | null;
 }): Promise<ComposerFilePickerState> {
   const homePath = os.homedir();
-  const rootPath = path.resolve(request.rootPath ?? request.projectId ?? process.cwd());
+  const rootPath = path.resolve(request.rootPath ?? request.projectId ?? getDesktopWorkingDirectory());
   const requestedPath = path.resolve(request.path ?? rootPath);
   const currentPath = isPathWithinRoot(requestedPath, rootPath) ? requestedPath : rootPath;
   const directoryEntries = await readdir(currentPath, { withFileTypes: true });

--- a/src/bun/desktop-runtime-modules.ts
+++ b/src/bun/desktop-runtime-modules.ts
@@ -124,18 +124,18 @@ export type SkillCreatorModule = {
   closeSkillCreatorSession: (request: { sessionId: string }) => Promise<{ ok: boolean }>;
 };
 
-export const piThreads = (await import(
-  new URL("../build/desktop/pi-threads.mjs", import.meta.url).pathname
-)) as PiThreadsModule;
+const piThreadsModuleUrl = new URL("../build/desktop/pi-threads.mjs", import.meta.url).href;
+const piSkillsModuleUrl = new URL("../build/desktop/pi-skills.mjs", import.meta.url).href;
+const skillCreatorModuleUrl = new URL(
+  "../build/desktop/skill-creator-session.mjs",
+  import.meta.url,
+).href;
+const terminalManagerModuleUrl = new URL("../build/desktop/terminal-manager.mjs", import.meta.url).href;
 
-export const piSkills = (await import(
-  new URL("../build/desktop/pi-skills.mjs", import.meta.url).pathname
-)) as PiSkillsModule;
+export const piThreads = (await import(piThreadsModuleUrl)) as PiThreadsModule;
 
-export const skillCreator = (await import(
-  new URL("../build/desktop/skill-creator-session.mjs", import.meta.url).pathname
-)) as SkillCreatorModule;
+export const piSkills = (await import(piSkillsModuleUrl)) as PiSkillsModule;
 
-export const terminalManager = (await import(
-  new URL("../build/desktop/terminal-manager.mjs", import.meta.url).pathname
-)) as TerminalManagerModule;
+export const skillCreator = (await import(skillCreatorModuleUrl)) as SkillCreatorModule;
+
+export const terminalManager = (await import(terminalManagerModuleUrl)) as TerminalManagerModule;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
 import { BrowserView, BrowserWindow, Utils } from "electrobun/bun";
 import type { DesktopAction } from "../../shared/desktop-actions";
 import type {
@@ -37,6 +39,24 @@ import {
 import { piSkills, piThreads, skillCreator, terminalManager } from "./desktop-runtime-modules";
 import { getMainViewUrl } from "./main-view-url";
 
+function getDesktopWorkingDirectory() {
+  return process.env.HOWCODE_REPO_ROOT || process.cwd();
+}
+
+function configurePiPackageDir() {
+  const candidates = [
+    path.resolve(import.meta.dir, "../resources/pi-coding-agent"),
+    path.resolve(getDesktopWorkingDirectory(), "node_modules/@mariozechner/pi-coding-agent"),
+  ];
+
+  const packageDir = candidates.find((candidate) => existsSync(path.join(candidate, "package.json")));
+  if (packageDir) {
+    process.env.PI_PACKAGE_DIR = packageDir;
+  }
+}
+
+configurePiPackageDir();
+
 if (process.platform === "linux" && !process.env.WEBKIT_DISABLE_DMABUF_RENDERER) {
   process.env.WEBKIT_DISABLE_DMABUF_RENDERER = "1";
 }
@@ -45,7 +65,8 @@ const rpc = BrowserView.defineRPC<PiDesktopRpc>({
   maxRequestTime: 300_000,
   handlers: {
     requests: {
-      getShellState: async () => piThreads.loadShellState(process.cwd()) as Promise<ShellState>,
+      getShellState: async () =>
+        piThreads.loadShellState(getDesktopWorkingDirectory()) as Promise<ShellState>,
       getProjectGitState: async ({ projectId }) =>
         (await piThreads.loadProjectGitState(projectId)) as ProjectGitState | null,
       getProjectDiff: async ({ projectId, baseline }) =>
@@ -85,7 +106,7 @@ const rpc = BrowserView.defineRPC<PiDesktopRpc>({
         skillCreator.closeSkillCreatorSession(request) as Promise<{ ok: boolean }>,
       pickComposerAttachments: async ({ projectId }) => {
         const filePaths = await Utils.openFileDialog({
-          startingFolder: projectId ?? process.cwd(),
+          startingFolder: projectId ?? getDesktopWorkingDirectory(),
           canChooseFiles: true,
           canChooseDirectory: false,
           allowsMultipleSelection: true,


### PR DESCRIPTION
## Summary
- fix desktop module loading on Windows by importing packaged Bun modules via file URLs instead of `.pathname` paths
- keep packaged desktop state rooted in the intended repo and avoid treating the installed app directory as an imported project
- bundle `@mariozechner/pi-coding-agent` runtime assets in the desktop package so the packaged app can initialize cleanly on Windows
- run the release build workflow for pull requests targeting the repo default branch

## Verification
- `bun run build:desktop`
- `bun run build:release`
- `bun run build:launcher-artifacts`
- verified the packaged Windows app reaches the UI and persists `projectImportState=true` instead of hanging on `Scanning projects for UI info...`
