### PR TITLE
Enable CEF-backed Linux builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,6 @@
 - Prefer `src/bun/index.ts` + `shared/*` contracts over ad-hoc desktop IPC shims.
 - Keep UI changes optimistic and reuse existing patterns over one-offs.
 - For major changes, validate with a commit and leave the repo committed.
-- This repository uses nested AGENTS.md files to flag folder-specific guidelines.
+- This repository uses nested AGENTS.md files to flag folder-specific guidelines. They are loaded automatically. No need to read them.
 - Consider creating new, small AGENTS.md files whenever patterns are observed.
 - AGENTS.md files are here to help you - if they are confusing, they should be edited to suit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 See `docs/roadmap.md` for the broader product direction.
 
+## 0.1.2 - Linux CEF renderer release
+
+- ship Linux builds with bundled CEF and default to the CEF renderer
+- remove the old Linux DMABUF workaround from app startup and the npm launcher
+- document the Linux renderer change and the larger bundle-size tradeoff
+
 ## 0.1.1 - Packaging fix release
 
 - bundle the Pi runtime into packaged desktop builds

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -65,13 +65,7 @@ It is a thin launcher that:
 3. caches it locally
 4. launches the packaged desktop app
 
-On Linux, the npm launcher now sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` up front before starting the app. The previous detect-and-retry approach was too unreliable because the renderer failure can happen after the detached launcher exits or without matching the watched output.
-
-If you launch Linux release assets directly outside the npm launcher, document this manual workaround:
-
-```bash
-WEBKIT_DISABLE_DMABUF_RENDERER=1 ./howcode/bin/launcher
-```
+Linux release builds now bundle CEF and default to the CEF renderer in Electrobun. That removes the old runtime dependence on the `WEBKIT_DISABLE_DMABUF_RENDERER` workaround, but increases Linux artifact size.
 
 ## Repo map
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,9 @@ On first run, the launcher downloads the matching desktop build for your platfor
 
 ### Linux note
 
-The npm launcher now starts Linux builds with:
+Linux release builds now ship with bundled CEF by default, so they no longer depend on the old WebKit DMABUF workaround.
 
-```bash
-WEBKIT_DISABLE_DMABUF_RENDERER=1
-```
-
-If you run a downloaded Linux release asset directly and see a white window, launch it with that env var yourself.
+The tradeoff is a larger Linux download in exchange for a more consistent renderer.
 
 ## Current status
 

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -4,7 +4,7 @@ export default {
   app: {
     name: "howcode",
     identifier: "howcode.desktop.local",
-    version: "0.1.1",
+    version: "0.1.2",
     description: "Desktop shell for Pi focused on fast local coding workflows.",
   },
   build: {
@@ -20,7 +20,8 @@ export default {
       bundleCEF: false,
     },
     linux: {
-      bundleCEF: false,
+      bundleCEF: true,
+      defaultRenderer: "cef",
     },
     win: {
       bundleCEF: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-desktop-mock",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Codex-inspired desktop UI mock for Pi",
   "packageManager": "bun@1.3.9",
@@ -9,7 +9,7 @@
     "dev:clean": "rm -rf build/dev-linux-x64 build/desktop build/dev-server.json",
     "dev:web": "bun run ./scripts/dev-web.ts",
     "dev:desktop:build": "bun --watch ./scripts/build-desktop-backend.ts",
-    "dev:desktop": "sh -c 'until [ -f build/desktop/pi-threads.mjs ] && [ -f build/desktop/terminal-manager.mjs ] && [ -f build/dev-server.json ]; do sleep 0.2; done; WEBKIT_DISABLE_DMABUF_RENDERER=1 electrobun dev --watch'",
+    "dev:desktop": "sh -c 'until [ -f build/desktop/pi-threads.mjs ] && [ -f build/desktop/terminal-manager.mjs ] && [ -f build/dev-server.json ]; do sleep 0.2; done; electrobun dev --watch'",
     "build": "vite build && bun run build:desktop && electrobun build",
     "build:release": "vite build && bun run build:desktop && electrobun build --env=stable",
     "build:desktop": "bun run ./scripts/build-desktop-backend.ts",

--- a/packages/howcode/README.md
+++ b/packages/howcode/README.md
@@ -27,7 +27,7 @@ On first run, it downloads the matching desktop app for your platform from GitHu
 
 - macOS, Linux, and Windows desktop builds
 - local cached installs after first download
-- automatic Linux DMABUF workaround in the npm launcher
+- Linux builds that bundle CEF for a more consistent renderer
 
 ## Project
 
@@ -36,13 +36,9 @@ On first run, it downloads the matching desktop app for your platform from GitHu
 
 ## Linux note
 
-On Linux, the npm launcher sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` automatically before starting the app to avoid the common WebKit/GBM white-screen issue.
+Linux release builds now bundle CEF, so the launcher does not need to inject the old `WEBKIT_DISABLE_DMABUF_RENDERER` workaround anymore.
 
-If you are launching a downloaded Linux release asset manually, use:
-
-```bash
-WEBKIT_DISABLE_DMABUF_RENDERER=1 ./howcode/bin/launcher
-```
+Expect Linux downloads to be larger than the native-webview builds in exchange for more consistent rendering behavior.
 
 ## Cache location
 

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -217,14 +217,7 @@ function spawnLauncherProcess(executablePath, options = {}) {
 }
 
 async function launch(executablePath) {
-  const child = spawnLauncherProcess(executablePath, {
-    env:
-      process.platform === "linux" && !process.env.WEBKIT_DISABLE_DMABUF_RENDERER
-        ? {
-            WEBKIT_DISABLE_DMABUF_RENDERER: "1",
-          }
-        : undefined,
-  });
+  const child = spawnLauncherProcess(executablePath);
 
   child.unref();
 }

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -10,6 +10,7 @@ const packageJson = require("../package.json");
 
 const APP_NAME = packageJson.howcode.appName;
 const RELEASE_BASE_URL = process.env.HOWCODE_BASE_URL || packageJson.howcode.releaseBaseUrl;
+const LINUX_CEF_MIN_VERSION = "0.1.2";
 
 const TARGETS = {
   "darwin:arm64": {
@@ -50,6 +51,48 @@ function readJsonIfPresent(filePath) {
   } catch {
     return null;
   }
+}
+
+function parseSemver(version) {
+  if (typeof version !== "string") {
+    return null;
+  }
+
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return null;
+  }
+
+  return match.slice(1).map((part) => Number.parseInt(part, 10));
+}
+
+function isVersionAtLeast(version, minimumVersion) {
+  const parsedVersion = parseSemver(version);
+  const parsedMinimumVersion = parseSemver(minimumVersion);
+
+  if (!parsedVersion || !parsedMinimumVersion) {
+    return false;
+  }
+
+  for (let index = 0; index < parsedMinimumVersion.length; index += 1) {
+    if (parsedVersion[index] > parsedMinimumVersion[index]) {
+      return true;
+    }
+
+    if (parsedVersion[index] < parsedMinimumVersion[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function shouldInjectLegacyLinuxWebkitWorkaround(target, version) {
+  return (
+    target.os === "linux" &&
+    !process.env.WEBKIT_DISABLE_DMABUF_RENDERER &&
+    !isVersionAtLeast(version, LINUX_CEF_MIN_VERSION)
+  );
 }
 
 function getTarget() {
@@ -216,8 +259,14 @@ function spawnLauncherProcess(executablePath, options = {}) {
   });
 }
 
-async function launch(executablePath) {
-  const child = spawnLauncherProcess(executablePath);
+async function launch(target, executablePath, version) {
+  const child = spawnLauncherProcess(executablePath, {
+    env: shouldInjectLegacyLinuxWebkitWorkaround(target, version)
+      ? {
+          WEBKIT_DISABLE_DMABUF_RENDERER: "1",
+        }
+      : undefined,
+  });
 
   child.unref();
 }
@@ -234,7 +283,7 @@ async function main() {
     releaseInfo = await resolveLatestRelease(target);
   } catch (error) {
     if (current?.executablePath && fs.existsSync(current.executablePath)) {
-      await launch(current.executablePath);
+      await launch(target, current.executablePath, current.version);
       return;
     }
 
@@ -247,7 +296,7 @@ async function main() {
   }
 
   await pruneOldVersions(cacheRoot, paths.installDir);
-  await launch(paths.executablePath);
+  await launch(target, paths.executablePath, releaseInfo.version);
 }
 
 module.exports = {

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -10,6 +10,7 @@ const packageJson = require("../package.json");
 
 const APP_NAME = packageJson.howcode.appName;
 const RELEASE_BASE_URL = process.env.HOWCODE_BASE_URL || packageJson.howcode.releaseBaseUrl;
+const DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 
 const TARGETS = {
   "darwin:arm64": {
@@ -108,9 +109,9 @@ async function fetchJson(url) {
   }
 }
 
-async function downloadFile(url, filePath) {
+async function downloadFile(url, filePath, timeoutMs = DOWNLOAD_TIMEOUT_MS) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 60_000);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetch(url, { signal: controller.signal });

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -10,7 +10,6 @@ const packageJson = require("../package.json");
 
 const APP_NAME = packageJson.howcode.appName;
 const RELEASE_BASE_URL = process.env.HOWCODE_BASE_URL || packageJson.howcode.releaseBaseUrl;
-const LINUX_CEF_MIN_VERSION = "0.1.2";
 
 const TARGETS = {
   "darwin:arm64": {
@@ -51,48 +50,6 @@ function readJsonIfPresent(filePath) {
   } catch {
     return null;
   }
-}
-
-function parseSemver(version) {
-  if (typeof version !== "string") {
-    return null;
-  }
-
-  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match) {
-    return null;
-  }
-
-  return match.slice(1).map((part) => Number.parseInt(part, 10));
-}
-
-function isVersionAtLeast(version, minimumVersion) {
-  const parsedVersion = parseSemver(version);
-  const parsedMinimumVersion = parseSemver(minimumVersion);
-
-  if (!parsedVersion || !parsedMinimumVersion) {
-    return false;
-  }
-
-  for (let index = 0; index < parsedMinimumVersion.length; index += 1) {
-    if (parsedVersion[index] > parsedMinimumVersion[index]) {
-      return true;
-    }
-
-    if (parsedVersion[index] < parsedMinimumVersion[index]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function shouldInjectLegacyLinuxWebkitWorkaround(target, version) {
-  return (
-    target.os === "linux" &&
-    !process.env.WEBKIT_DISABLE_DMABUF_RENDERER &&
-    !isVersionAtLeast(version, LINUX_CEF_MIN_VERSION)
-  );
 }
 
 function getTarget() {
@@ -259,14 +216,8 @@ function spawnLauncherProcess(executablePath, options = {}) {
   });
 }
 
-async function launch(target, executablePath, version) {
-  const child = spawnLauncherProcess(executablePath, {
-    env: shouldInjectLegacyLinuxWebkitWorkaround(target, version)
-      ? {
-          WEBKIT_DISABLE_DMABUF_RENDERER: "1",
-        }
-      : undefined,
-  });
+async function launch(executablePath) {
+  const child = spawnLauncherProcess(executablePath);
 
   child.unref();
 }
@@ -283,7 +234,7 @@ async function main() {
     releaseInfo = await resolveLatestRelease(target);
   } catch (error) {
     if (current?.executablePath && fs.existsSync(current.executablePath)) {
-      await launch(target, current.executablePath, current.version);
+      await launch(current.executablePath);
       return;
     }
 
@@ -296,7 +247,7 @@ async function main() {
   }
 
   await pruneOldVersions(cacheRoot, paths.installDir);
-  await launch(target, paths.executablePath, releaseInfo.version);
+  await launch(paths.executablePath);
 }
 
 module.exports = {

--- a/packages/howcode/package.json
+++ b/packages/howcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "howcode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Desktop coding app for Pi with projects, terminal, git, and diff workflows.",
   "license": "MIT",
   "author": "Igor Warzocha",

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -36,10 +36,6 @@ import {
 import { piSkills, piThreads, skillCreator, terminalManager } from "./desktop-runtime-modules";
 import { getMainViewUrl } from "./main-view-url";
 
-if (process.platform === "linux" && !process.env.WEBKIT_DISABLE_DMABUF_RENDERER) {
-  process.env.WEBKIT_DISABLE_DMABUF_RENDERER = "1";
-}
-
 const rpc = BrowserView.defineRPC<PiDesktopRpc>({
   maxRequestTime: 300_000,
   handlers: {


### PR DESCRIPTION
## Summary
- enable bundled CEF for Linux Electrobun builds and default Linux to the CEF renderer
- remove the old Linux WebKit DMABUF workaround from app startup, dev startup, and the npm launcher
- update docs and changelog for the Linux renderer change and version bump to 0.1.2

## Details
- set `build.linux.bundleCEF = true` and `build.linux.defaultRenderer = "cef"`
- remove Linux `WEBKIT_DISABLE_DMABUF_RENDERER` injection from:
  - `src/bun/index.ts`
  - `package.json` dev desktop script
  - `packages/howcode/lib/howcode.js`
- update release/user docs to describe the Linux CEF path and larger bundle tradeoff
- keep macOS and Windows on native renderers; follow-up platform work lives in #55 and #56
- include the repo-level `AGENTS.md` wording tweak requested during this branch

## Validation
- `bun run build:release`
- `bun run build:launcher-artifacts`
- pre-commit hooks ran successfully during commit:
  - `bun run typecheck:web`
  - `bun run typecheck:bun`
  - `bun run typecheck:desktop`
  - `vitest run`
- verified packaged Linux build metadata shows `defaultRenderer: "cef"`
- verified Linux release artifacts were emitted for version `0.1.2`

## Notes
- Linux launcher archive grew to about 215 MB after bundling CEF, as expected
- this is an intentional hard cut for the current small tester group rather than a compatibility bridge for older cached Linux installs

Closes #54
Refs #55
Refs #56
