### PR TITLE
Enable CEF-backed Windows builds

### DIFF
--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { Utils } from "electrobun/bun";
 import type { DesktopAction } from "../../shared/desktop-actions.ts";
 import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts";
+import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
 import {
   getComposerRequest,
   getProjectId,
@@ -265,7 +266,7 @@ export async function handleProjectDesktopAction(
           });
         }
 
-        if (await isProtectedProjectDeletionTarget(projectId, process.cwd())) {
+        if (await isProtectedProjectDeletionTarget(projectId, getDesktopWorkingDirectory())) {
           return handledAction({
             error: "Cannot delete the active shell project.",
           });

--- a/desktop/project-import.cts
+++ b/desktop/project-import.cts
@@ -1,4 +1,5 @@
 import type { ProjectImportCandidate } from "../shared/desktop-contracts.ts";
+import { getDesktopWorkingDirectory } from "../shared/desktop-working-directory.ts";
 import { setProjectImportState } from "./app-settings.cts";
 import { getOriginUrl, isGitRepository } from "./project-git/project-state.cts";
 import { listProjects, setProjectRepoOrigin } from "./thread-state-db.cts";
@@ -8,14 +9,14 @@ function resolveProjectIds(projectIds: string[]) {
     return [...new Set(projectIds)];
   }
 
-  return listProjects(process.cwd())
+  return listProjects(getDesktopWorkingDirectory())
     .filter((project) => project.threadCount !== 0)
     .map((project) => project.id);
 }
 
 export async function scanKnownProjects(projectIds: string[]): Promise<ProjectImportCandidate[]> {
   const knownProjects = new Map(
-    listProjects(process.cwd()).map((project) => [project.id, project] as const),
+    listProjects(getDesktopWorkingDirectory()).map((project) => [project.id, project] as const),
   );
 
   return await Promise.all(

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -5,6 +5,7 @@ import type {
   ComposerStreamingBehavior,
   ComposerThinkingLevel,
 } from "../../shared/desktop-contracts.ts";
+import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
 import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { loadAppSettings } from "../app-settings.cts";
 import { getPiModule } from "../pi-module.cts";
@@ -111,7 +112,11 @@ export async function setComposerModel(
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
 
   if (!persistedSessionPath) {
-    await setDraftComposerModel(request.projectId ?? process.cwd(), provider, modelId);
+    await setDraftComposerModel(
+      request.projectId ?? getDesktopWorkingDirectory(),
+      provider,
+      modelId,
+    );
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
@@ -136,7 +141,7 @@ export async function setComposerThinkingLevel(
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
 
   if (!persistedSessionPath) {
-    await setDraftComposerThinkingLevel(request.projectId ?? process.cwd(), level);
+    await setDraftComposerThinkingLevel(request.projectId ?? getDesktopWorkingDirectory(), level);
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
@@ -184,7 +189,9 @@ export async function sendComposerPrompt(
   };
 
   if (!persistedSessionPath) {
-    return await runSend(await createRuntimeForNewSession(request.projectId ?? process.cwd()));
+    return await runSend(
+      await createRuntimeForNewSession(request.projectId ?? getDesktopWorkingDirectory()),
+    );
   }
 
   return await withRuntimeMutationLock(
@@ -290,7 +297,7 @@ export async function dequeueComposerPrompt(
 }
 
 export async function startNewThread(request: ComposerStateRequest = {}) {
-  const projectId = request.projectId ?? process.cwd();
+  const projectId = request.projectId ?? getDesktopWorkingDirectory();
   const composer = await buildComposerStateSnapshot({ projectId, sessionPath: null });
   const draft = createLocalThreadDraft(projectId);
 

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -8,6 +8,7 @@ import type {
   ComposerStateRequest,
   ComposerThinkingLevel,
 } from "../../shared/desktop-contracts.ts";
+import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { buildQueuedPrompts } from "./composer-queue";
@@ -143,7 +144,7 @@ export async function createComposerSnapshotSession(request: ComposerStateReques
   } = await getPiModule();
   const cwd = persistedSessionPath
     ? SessionManager.open(persistedSessionPath).getCwd()
-    : (request.projectId ?? process.cwd());
+    : (request.projectId ?? getDesktopWorkingDirectory());
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);

--- a/desktop/skill-creator-session.cts
+++ b/desktop/skill-creator-session.cts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Message, SkillCreatorSessionState } from "../shared/desktop-contracts.ts";
 import { mapAgentMessagesToUiMessages } from "../shared/pi-message-mapper.ts";
@@ -127,8 +128,8 @@ async function createSkillCreatorSession(cwd: string, projectPath?: string | nul
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(cwd, agentDir);
-  const packagedSkillsPath = new URL("../../resources/skills", import.meta.url).pathname;
-  const repoSkillsPath = new URL("../../desktop/resources/skills", import.meta.url).pathname;
+  const packagedSkillsPath = fileURLToPath(new URL("../../resources/skills", import.meta.url));
+  const repoSkillsPath = fileURLToPath(new URL("../../desktop/resources/skills", import.meta.url));
   const bundledSkillsPath = (await pathExists(packagedSkillsPath))
     ? packagedSkillsPath
     : repoSkillsPath;

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -14,6 +14,19 @@ export default {
       "dist/assets": "views/mainview/assets",
       "build/desktop": "build/desktop",
       "desktop/resources": "resources",
+      "node_modules/@mariozechner/pi-coding-agent/package.json":
+        "resources/pi-coding-agent/package.json",
+      "node_modules/@mariozechner/pi-coding-agent/README.md": "resources/pi-coding-agent/README.md",
+      "node_modules/@mariozechner/pi-coding-agent/CHANGELOG.md":
+        "resources/pi-coding-agent/CHANGELOG.md",
+      "node_modules/@mariozechner/pi-coding-agent/docs": "resources/pi-coding-agent/docs",
+      "node_modules/@mariozechner/pi-coding-agent/examples": "resources/pi-coding-agent/examples",
+      "node_modules/@mariozechner/pi-coding-agent/dist/modes/interactive/assets":
+        "resources/pi-coding-agent/dist/modes/interactive/assets",
+      "node_modules/@mariozechner/pi-coding-agent/dist/modes/interactive/theme":
+        "resources/pi-coding-agent/dist/modes/interactive/theme",
+      "node_modules/@mariozechner/pi-coding-agent/dist/core/export-html":
+        "resources/pi-coding-agent/dist/core/export-html",
     },
     watchIgnore: ["dist/**"],
     mac: {
@@ -24,7 +37,8 @@ export default {
       defaultRenderer: "cef",
     },
     win: {
-      bundleCEF: false,
+      bundleCEF: true,
+      defaultRenderer: "cef",
     },
   },
   release: {

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -212,6 +212,7 @@ function spawnLauncherProcess(executablePath, options = {}) {
     cwd: path.dirname(executablePath),
     env: {
       ...process.env,
+      HOWCODE_REPO_ROOT: process.env.HOWCODE_REPO_ROOT || process.cwd(),
       ...(options.env || {}),
     },
   });

--- a/shared/desktop-working-directory.ts
+++ b/shared/desktop-working-directory.ts
@@ -1,0 +1,3 @@
+export function getDesktopWorkingDirectory() {
+  return process.env.HOWCODE_REPO_ROOT || process.cwd();
+}

--- a/src/bun/composer-attachments.ts
+++ b/src/bun/composer-attachments.ts
@@ -6,6 +6,7 @@ import type {
   ComposerFilePickerEntry,
   ComposerFilePickerState,
 } from "../../shared/desktop-contracts";
+import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory";
 
 async function pathExists(targetPath: string) {
   try {
@@ -62,7 +63,9 @@ export async function listComposerAttachmentEntries(request: {
   rootPath?: string | null;
 }): Promise<ComposerFilePickerState> {
   const homePath = os.homedir();
-  const rootPath = path.resolve(request.rootPath ?? request.projectId ?? process.cwd());
+  const rootPath = path.resolve(
+    request.rootPath ?? request.projectId ?? getDesktopWorkingDirectory(),
+  );
   const requestedPath = path.resolve(request.path ?? rootPath);
   const currentPath = isPathWithinRoot(requestedPath, rootPath) ? requestedPath : rootPath;
   const directoryEntries = await readdir(currentPath, { withFileTypes: true });

--- a/src/bun/desktop-runtime-modules.ts
+++ b/src/bun/desktop-runtime-modules.ts
@@ -136,17 +136,17 @@ export type SkillCreatorModule = {
 };
 
 export const piThreads = (await import(
-  new URL("../build/desktop/pi-threads.mjs", import.meta.url).pathname
+  new URL("../build/desktop/pi-threads.mjs", import.meta.url).href
 )) as PiThreadsModule;
 
 export const piSkills = (await import(
-  new URL("../build/desktop/pi-skills.mjs", import.meta.url).pathname
+  new URL("../build/desktop/pi-skills.mjs", import.meta.url).href
 )) as PiSkillsModule;
 
 export const skillCreator = (await import(
-  new URL("../build/desktop/skill-creator-session.mjs", import.meta.url).pathname
+  new URL("../build/desktop/skill-creator-session.mjs", import.meta.url).href
 )) as SkillCreatorModule;
 
 export const terminalManager = (await import(
-  new URL("../build/desktop/terminal-manager.mjs", import.meta.url).pathname
+  new URL("../build/desktop/terminal-manager.mjs", import.meta.url).href
 )) as TerminalManagerModule;

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
 import { BrowserView, BrowserWindow, Utils } from "electrobun/bun";
 import type { DesktopAction } from "../../shared/desktop-actions";
 import type {
@@ -27,6 +29,7 @@ import type {
 } from "../../shared/desktop-contracts";
 import type { PiDesktopRpc } from "../../shared/electrobun-rpc";
 import type { TerminalEvent, TerminalSessionSnapshot } from "../../shared/terminal-contracts";
+import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory";
 import {
   getAttachmentKind,
   isSafeExternalUrl,
@@ -36,11 +39,28 @@ import {
 import { piSkills, piThreads, skillCreator, terminalManager } from "./desktop-runtime-modules";
 import { getMainViewUrl } from "./main-view-url";
 
+function configurePiPackageDir() {
+  const candidates = [
+    path.resolve(import.meta.dir, "../resources/pi-coding-agent"),
+    path.resolve(getDesktopWorkingDirectory(), "node_modules/@mariozechner/pi-coding-agent"),
+  ];
+
+  const packageDir = candidates.find((candidate) =>
+    existsSync(path.join(candidate, "package.json")),
+  );
+  if (packageDir) {
+    process.env.PI_PACKAGE_DIR = packageDir;
+  }
+}
+
+configurePiPackageDir();
+
 const rpc = BrowserView.defineRPC<PiDesktopRpc>({
   maxRequestTime: 300_000,
   handlers: {
     requests: {
-      getShellState: async () => piThreads.loadShellState(process.cwd()) as Promise<ShellState>,
+      getShellState: async () =>
+        piThreads.loadShellState(getDesktopWorkingDirectory()) as Promise<ShellState>,
       getProjectGitState: async ({ projectId }) =>
         (await piThreads.loadProjectGitState(projectId)) as ProjectGitState | null,
       getProjectDiff: async ({ projectId, baseline }) =>
@@ -80,7 +100,7 @@ const rpc = BrowserView.defineRPC<PiDesktopRpc>({
         skillCreator.closeSkillCreatorSession(request) as Promise<{ ok: boolean }>,
       pickComposerAttachments: async ({ projectId }) => {
         const filePaths = await Utils.openFileDialog({
-          startingFolder: projectId ?? process.cwd(),
+          startingFolder: projectId ?? getDesktopWorkingDirectory(),
           canChooseFiles: true,
           canChooseDirectory: false,
           allowsMultipleSelection: true,


### PR DESCRIPTION
## Summary
- enable bundled CEF as the default renderer for Windows builds
- adapt the meaningful packaged-Windows startup fixes from #57 onto current `dev`
- keep packaged desktop/runtime state rooted in the launch repo instead of the installed app directory
- bundle Pi runtime assets and configure `PI_PACKAGE_DIR` so packaged Windows builds can resolve bundled resources correctly

## Verification
- `bun run build:desktop`
- `bun run build:release`
- `bun run build:launcher-artifacts`
- pre-commit checks (`typecheck`, `test`) passed during commit
- pre-push checks (`bun run check`) passed before push

Closes #55
Supersedes #57
