### PR TITLE
Enable CEF-backed macOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@
 
 See `docs/roadmap.md` for the broader product direction.
 
-## 0.1.2 - Linux CEF renderer release
+## 0.1.2 - CEF renderer rollout
 
-- ship Linux builds with bundled CEF and default to the CEF renderer
+- ship macOS, Linux, and Windows builds with bundled CEF and default to the CEF renderer
 - remove the old Linux DMABUF workaround from app startup and the npm launcher
-- document the Linux renderer change and the larger bundle-size tradeoff
+- document the renderer change and the larger bundle-size tradeoff
 
 ## 0.1.1 - Packaging fix release
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -65,7 +65,7 @@ It is a thin launcher that:
 3. caches it locally
 4. launches the packaged desktop app
 
-Linux release builds now bundle CEF and default to the CEF renderer in Electrobun. That removes the old runtime dependence on the `WEBKIT_DISABLE_DMABUF_RENDERER` workaround, but increases Linux artifact size.
+Desktop release builds now bundle CEF and default to the CEF renderer in Electrobun on macOS, Linux, and Windows. That removes the old Linux runtime dependence on the `WEBKIT_DISABLE_DMABUF_RENDERER` workaround, but increases artifact size.
 
 ## Repo map
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ howcode
 
 On first run, the launcher downloads the matching desktop build for your platform and caches it locally.
 
-### Linux note
+### Renderer note
 
-Linux release builds now ship with bundled CEF by default, so they no longer depend on the old WebKit DMABUF workaround.
+Release builds now ship with bundled CEF by default on macOS, Linux, and Windows.
 
-The tradeoff is a larger Linux download in exchange for a more consistent renderer.
+The tradeoff is larger downloads in exchange for a more consistent renderer.
 
 ## Current status
 

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -30,7 +30,8 @@ export default {
     },
     watchIgnore: ["dist/**"],
     mac: {
-      bundleCEF: false,
+      bundleCEF: true,
+      defaultRenderer: "cef",
     },
     linux: {
       bundleCEF: true,

--- a/packages/howcode/README.md
+++ b/packages/howcode/README.md
@@ -27,18 +27,18 @@ On first run, it downloads the matching desktop app for your platform from GitHu
 
 - macOS, Linux, and Windows desktop builds
 - local cached installs after first download
-- Linux builds that bundle CEF for a more consistent renderer
+- desktop builds that bundle CEF for a more consistent renderer
 
 ## Project
 
 - App repo: https://github.com/IgorWarzocha/howcode
 - Issues: https://github.com/IgorWarzocha/howcode/issues
 
-## Linux note
+## Renderer note
 
-Linux release builds now bundle CEF, so the launcher does not need to inject the old `WEBKIT_DISABLE_DMABUF_RENDERER` workaround anymore.
+Release builds now bundle CEF on macOS, Linux, and Windows. The launcher no longer needs to inject the old Linux `WEBKIT_DISABLE_DMABUF_RENDERER` workaround.
 
-Expect Linux downloads to be larger than the native-webview builds in exchange for more consistent rendering behavior.
+Expect downloads to be larger than the native-webview builds in exchange for more consistent rendering behavior.
 
 ## Cache location
 


### PR DESCRIPTION
## Summary
- enable bundled CEF for macOS builds in Electrobun and default macOS to the CEF renderer
- update public/docs copy to describe the CEF renderer rollout across macOS, Linux, and Windows
- keep the release notes aligned with the now-cross-platform CEF strategy

## Validation
- `bun run build:release`
- `bun run build:launcher-artifacts`
- pre-commit hooks during `git commit`
- pre-push `bun run check`

## Notes
- Local validation here only produced Linux artifacts, but it confirmed the config/build flow still works after enabling macOS CEF.
- A real packaged macOS smoke test is still needed to fully validate runtime behavior on macOS hardware.

Refs #56
