### PR TITLE
Replace the landing home with a roadmap/changelog hub

### DIFF
--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -27,6 +27,7 @@ Do not treat every issue as immediately buildable. First decide whether it is a 
 - Open the PR back into `dev`, not `main`, unless the user explicitly says otherwise.
 - If the issue asks for discussion first or is clearly not actionable yet, stop and explain instead of forcing implementation.
 - Only use auto-closing keywords such as `Closes #123` for issues that are fully resolved by the PR. Use `Refs #123` for anything partial.
+- Before any build or release pass in this flow, refresh the landing changelog in `src/app/views/landing-overview-content.ts` from recent merged PRs / `origin/dev` commits so the shipped app does not carry stale release notes.
 
 ## When to use
 - The user gives issue numbers like `#123` or `123`.
@@ -125,6 +126,12 @@ Branch naming should be issue-oriented and easy to trace, for example `issue-123
 3. Repeat until the review comes back clean or the remaining tradeoffs are explicitly accepted.
 4. If the user shares review findings in chat instead of rerunning the command, resolve them the same way.
 
+### 6.5. Refresh the landing changelog before builds
+1. If you are about to make a build, package, release artifact, or other ship-intended output, update `src/app/views/landing-overview-content.ts` first.
+2. Base the changelog on actual merged PRs and recent `origin/dev` commits, not memory.
+3. Keep it terse and user-facing; do not dump issue numbers or internal workflow noise into the app UI.
+4. If nothing user-visible changed since the last refresh, say so explicitly instead of inventing changelog churn.
+
 ### 7. Open a clean PR with good hygiene
 1. Push the branch if needed.
 2. Create a PR targeting `dev`.
@@ -187,6 +194,7 @@ gh pr view <pr-number-or-url> --comments
 - The PR targets `dev` explicitly.
 - The PR body clearly distinguishes `Closes` from `Refs`.
 - The user's `/review` findings were addressed or explicitly called out.
+- If the flow included a build or release pass, `src/app/views/landing-overview-content.ts` was refreshed first from real merged PRs / `origin/dev` history.
 - Codex was asked for review.
 - The PR link was returned to the user after posting the review request.
 - Codex feedback was triaged instead of accepted blindly when the user asked for feedback handling.

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -157,7 +157,7 @@ export function CodeWorkspaceMainView({
   }
 
   return (
-    <div className="grid h-full content-start justify-items-center px-4 pb-6">
+    <div className="grid h-full content-start justify-items-center overflow-y-auto px-4 pb-6">
       <LandingView
         appSettings={appSettings}
         className={workspaceContentClass}

--- a/src/app/views/LandingView.tsx
+++ b/src/app/views/LandingView.tsx
@@ -1,19 +1,9 @@
-import { Check, ChevronDown, Folder, Search, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { PiLogoMark } from "../components/common/PiLogoMark";
-import { SurfacePanel } from "../components/common/SurfacePanel";
-import { TextButton } from "../components/common/TextButton";
+import { useState } from "react";
+import { MarkdownContent } from "../components/common/MarkdownContent";
 import type { AppSettings, DesktopActionInvoker } from "../desktop/types";
-import { useAnimatedPresence } from "../hooks/useAnimatedPresence";
-import { useDismissibleLayer } from "../hooks/useDismissibleLayer";
 import type { Project } from "../types";
-import {
-  menuOptionClass,
-  popoverPanelClass,
-  settingsInputClass,
-  toolbarButtonClass,
-} from "../ui/classes";
 import { cn } from "../utils/cn";
+import { getLandingOverviewContent } from "./landing-overview-content";
 
 type LandingViewProps = {
   appSettings: AppSettings;
@@ -25,237 +15,118 @@ type LandingViewProps = {
   onSelectProject: (projectId: string) => void;
 };
 
-export function LandingView({
-  appSettings,
-  projectName,
-  projects,
-  selectedProjectId,
-  className,
-  onAction,
-  onSelectProject,
-}: LandingViewProps) {
-  const [projectMenuOpen, setProjectMenuOpen] = useState(false);
-  const [projectQuery, setProjectQuery] = useState("");
-  const [importBusy, setImportBusy] = useState(false);
-  const [importStatusMessage, setImportStatusMessage] = useState<string | null>(null);
-  const [importErrorMessage, setImportErrorMessage] = useState<string | null>(null);
-  const projectButtonRef = useRef<HTMLButtonElement>(null);
-  const projectMenuRef = useRef<HTMLDivElement>(null);
-  const projectSearchInputRef = useRef<HTMLInputElement>(null);
-  const projectMenuPresent = useAnimatedPresence(projectMenuOpen);
-  const latestProject = projects[0] ?? null;
-  const visibleProjects = projects.filter((project) =>
-    project.name.toLowerCase().includes(projectQuery.trim().toLowerCase()),
-  );
-
-  const startNewThreadInProject = async (projectId: string) => {
-    onSelectProject(projectId);
-    await onAction("thread.new", { projectId });
-    setProjectMenuOpen(false);
-    setProjectQuery("");
-  };
-
-  useDismissibleLayer({
-    open: projectMenuOpen,
-    onDismiss: () => setProjectMenuOpen(false),
-    refs: [projectButtonRef, projectMenuRef],
-  });
-
-  useEffect(() => {
-    if (!projectMenuOpen) {
-      return;
-    }
-
-    projectSearchInputRef.current?.focus();
-  }, [projectMenuOpen]);
-
-  const showProjectImportNotice = appSettings.projectImportState === null;
-  const projectIds = projects.map((project) => project.id);
-
-  const handleImportProjectUi = async () => {
-    setImportBusy(true);
-    setImportErrorMessage(null);
-    setImportStatusMessage("Scanning projects for UI info…");
-
-    try {
-      const result = await onAction("projects.import.apply", { projectIds });
-      const error = typeof result?.result?.error === "string" ? result.result.error : null;
-
-      if (error) {
-        setImportErrorMessage(error);
-        setImportStatusMessage(null);
-        return;
+function PixelHLogo() {
+  const pixelRows = [
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [1, 2, 3, 0, 0, 0, 0, 0, 3, 2, 1],
+    [1, 2, 3, 0, 0, 0, 0, 0, 3, 2, 1],
+    [1, 2, 3, 0, 0, 0, 0, 0, 3, 2, 1],
+    [2, 3, 4, 0, 0, 0, 0, 0, 4, 3, 2],
+    [2, 3, 4, 2, 3, 4, 3, 2, 4, 3, 2],
+    [3, 4, 5, 3, 4, 5, 4, 3, 5, 4, 3],
+    [2, 3, 4, 2, 3, 4, 3, 2, 4, 3, 2],
+    [2, 3, 4, 0, 0, 0, 0, 0, 4, 3, 2],
+    [1, 2, 3, 0, 0, 0, 0, 0, 3, 2, 1],
+    [1, 2, 3, 0, 0, 0, 0, 0, 3, 2, 1],
+    [1, 2, 3, 0, 0, 0, 0, 0, 3, 2, 1],
+    [2, 3, 4, 0, 0, 0, 0, 0, 4, 3, 2],
+    [2, 3, 4, 0, 0, 0, 0, 0, 4, 3, 2],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  ];
+  const fills = {
+    1: "#727894",
+    2: "#969db7",
+    3: "#a9b1ea",
+    4: "#b9bff3",
+    5: "#d5daed",
+  } as const;
+  const cell = 52;
+  const pixels = pixelRows.flatMap((row, rowIndex) =>
+    row.flatMap((value, columnIndex) => {
+      if (value === 0) {
+        return [];
       }
 
-      const checkedProjectCount =
-        typeof result?.result?.checkedProjectCount === "number"
-          ? result.result.checkedProjectCount
-          : projectIds.length;
-      const originProjectCount =
-        typeof result?.result?.originProjectCount === "number"
-          ? result.result.originProjectCount
-          : 0;
+      const x = columnIndex * cell + 114;
+      const y = rowIndex * cell + 10;
 
-      setImportStatusMessage(
-        checkedProjectCount > 0
-          ? `Scanned ${checkedProjectCount} · Found ${originProjectCount} origins`
-          : "Nothing to scan",
-      );
-    } finally {
-      setImportBusy(false);
-    }
-  };
+      return [
+        {
+          key: `${x}:${y}`,
+          x,
+          y,
+          fill: fills[value as keyof typeof fills],
+        },
+      ];
+    }),
+  );
+
+  return (
+    <svg viewBox="0 0 800 800" aria-label="Howcode logo" role="img" className="h-[120px] w-[92px]">
+      {pixels.map((pixel) => (
+        <rect
+          key={pixel.key}
+          x={pixel.x}
+          y={pixel.y}
+          width={cell}
+          height={cell}
+          rx="0"
+          fill={pixel.fill}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export function LandingView({ className }: LandingViewProps) {
+  const content = getLandingOverviewContent();
+  const [activeSection, setActiveSection] = useState<"roadmap" | "changelog">("roadmap");
+  const activeContent = activeSection === "roadmap" ? content.roadmap : content.changelog;
 
   return (
     <section
       className={cn(
-        "grid w-full content-start place-items-center gap-1 pt-[33vh] text-center text-[color:var(--muted)]",
+        "mx-auto flex w-full justify-center px-6 pt-[clamp(6rem,24vh,16rem)]",
         className,
       )}
     >
-      <div className="grid h-16 w-16 place-items-center rounded-full text-[color:var(--accent)]">
-        <PiLogoMark className="h-[42px] w-[42px]" />
-      </div>
-      <h1 className="m-0 text-[clamp(36px,6vw,54px)] font-medium tracking-[-0.04em] text-[color:var(--accent)]">
-        Let’s build
-      </h1>
+      <div className="grid w-full max-w-[760px] justify-items-center gap-8 text-center">
+        <PixelHLogo />
 
-      {showProjectImportNotice ? (
-        <SurfacePanel className="relative mt-3 grid w-full max-w-[460px] gap-2 rounded-3xl border-[color:var(--border-strong)] bg-[rgba(45,48,64,0.62)] p-4 pr-10 text-left">
-          <button
-            type="button"
-            className="absolute top-3 right-3 inline-flex h-6 w-6 items-center justify-center rounded-full text-[color:var(--muted)] transition-colors hover:bg-[rgba(255,255,255,0.05)] hover:text-[color:var(--text)]"
-            onClick={() => {
-              void onAction("settings.update", {
-                key: "projectImportState",
-                imported: false,
-              });
-            }}
-            aria-label="Dismiss import notice"
-          >
-            <X size={14} />
-          </button>
-
-          <div className="grid gap-1 pr-2">
-            <div className="text-[14px] font-medium text-[color:var(--text)]">Import projects</div>
-            <p className="m-0 text-[12.5px] leading-5 text-[color:var(--muted)]">
-              This will scan your projects for UI information in the app. Recommended on first
-              launch. Accessible later in settings menu.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 text-[12px]">
+        <div className="grid w-full max-w-[680px] gap-0">
+          <div className="grid grid-cols-2 border-b border-[rgba(169,178,215,0.08)]">
             <button
               type="button"
               className={cn(
-                toolbarButtonClass,
-                "shrink-0 whitespace-nowrap rounded-full border border-[color:var(--border)] px-2.5 text-[color:var(--text)] disabled:cursor-not-allowed disabled:opacity-45",
+                "border-b px-0 py-4 text-center text-[15px] font-medium transition-colors",
+                activeSection === "roadmap"
+                  ? "border-[color:var(--accent)] text-[color:var(--text)]"
+                  : "border-transparent text-[color:var(--muted)] hover:text-[color:var(--text)]",
               )}
-              onClick={() => {
-                void handleImportProjectUi();
-              }}
-              disabled={importBusy}
+              onClick={() => setActiveSection("roadmap")}
+              aria-pressed={activeSection === "roadmap"}
             >
-              {importBusy ? "Importing…" : "Import now"}
+              {content.roadmap.title}
             </button>
-            {importStatusMessage ? (
-              <span className="truncate text-[color:var(--muted)]" title={importStatusMessage}>
-                {importStatusMessage}
-              </span>
-            ) : null}
-            {importErrorMessage ? (
-              <span className="truncate text-[#f2a7a7]" title={importErrorMessage}>
-                {importErrorMessage}
-              </span>
-            ) : null}
-          </div>
-        </SurfacePanel>
-      ) : null}
 
-      <div className="mt-3 grid w-full max-w-[460px] grid-cols-2 gap-1.5 max-sm:grid-cols-1">
-        <TextButton
-          className="inline-flex h-11 w-full min-w-0 items-center justify-center rounded-2xl border border-transparent bg-transparent px-4 text-[15px] text-[color:var(--text)] transition-colors hover:border-[color:var(--border-strong)] hover:bg-[rgba(255,255,255,0.05)] disabled:cursor-not-allowed disabled:opacity-45"
-          onClick={() => {
-            if (latestProject) {
-              void startNewThreadInProject(latestProject.id);
-            }
-          }}
-          disabled={!latestProject}
-        >
-          {latestProject?.name ?? projectName}
-        </TextButton>
-
-        <div className="relative">
-          <TextButton
-            ref={projectButtonRef}
-            className="inline-flex h-11 w-full min-w-0 items-center justify-center gap-2 whitespace-nowrap rounded-2xl border border-transparent bg-transparent px-4 text-[15px] text-[color:var(--text)] transition-colors hover:border-[color:var(--border-strong)] hover:bg-[rgba(255,255,255,0.05)]"
-            onClick={() => setProjectMenuOpen((open) => !open)}
-            aria-haspopup="menu"
-            aria-expanded={projectMenuOpen}
-            aria-controls="landing-project-menu"
-          >
-            Select project
-            <ChevronDown size={16} />
-          </TextButton>
-
-          {projectMenuPresent ? (
-            <SurfacePanel
-              ref={projectMenuRef}
-              id="landing-project-menu"
-              role="menu"
-              aria-label="Select project"
-              data-open={projectMenuOpen ? "true" : "false"}
+            <button
+              type="button"
               className={cn(
-                "motion-popover absolute top-[calc(100%+10px)] left-1/2 z-20 grid h-[378px] w-[min(800px,calc(100vw-32px))] grid-rows-[44px_minmax(0,1fr)] overflow-hidden rounded-[20px] p-0 text-left shadow-[0_18px_40px_rgba(0,0,0,0.28)] -translate-x-1/2",
-                popoverPanelClass,
+                "border-b px-0 py-4 text-center text-[15px] font-medium transition-colors",
+                activeSection === "changelog"
+                  ? "border-[color:var(--accent)] text-[color:var(--text)]"
+                  : "border-transparent text-[color:var(--muted)] hover:text-[color:var(--text)]",
               )}
+              onClick={() => setActiveSection("changelog")}
+              aria-pressed={activeSection === "changelog"}
             >
-              <div className="grid h-11 grid-cols-[16px_minmax(0,1fr)] items-center gap-2 border-b border-[rgba(169,178,215,0.08)] px-3 py-2">
-                <Search size={14} className="text-[color:var(--muted)]" />
-                <input
-                  ref={projectSearchInputRef}
-                  value={projectQuery}
-                  onChange={(event) => setProjectQuery(event.target.value)}
-                  placeholder="Find project"
-                  className={cn(settingsInputClass, "h-8 border-0 bg-transparent px-0 py-0")}
-                  aria-label="Find project"
-                />
-              </div>
+              {content.changelog.title}
+            </button>
+          </div>
 
-              <div className="relative min-h-0 overflow-y-auto p-1">
-                <div className="grid grid-cols-3 gap-1 max-md:grid-cols-2 max-sm:grid-cols-1">
-                  {visibleProjects.map((project) => {
-                    const active = project.id === selectedProjectId;
-
-                    return (
-                      <button
-                        key={project.id}
-                        type="button"
-                        className={cn(
-                          menuOptionClass,
-                          "min-w-0 grid-cols-[16px_minmax(0,1fr)] text-[color:var(--text)]",
-                          active && "bg-[rgba(255,255,255,0.06)]",
-                        )}
-                        onClick={() => void startNewThreadInProject(project.id)}
-                        title={project.name}
-                        role="menuitem"
-                      >
-                        <span className="inline-flex items-center justify-center text-[color:var(--muted)]">
-                          {active ? <Check size={14} /> : <Folder size={14} />}
-                        </span>
-                        <span className="truncate">{project.name}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-                {visibleProjects.length === 0 ? (
-                  <div className="px-2 py-8 text-center text-[12px] text-[color:var(--muted)]">
-                    No matching projects.
-                  </div>
-                ) : null}
-              </div>
-            </SurfacePanel>
-          ) : null}
+          <div className="pt-4 text-left">
+            <MarkdownContent markdown={activeContent.markdown} className="gap-2 text-[13px]" />
+          </div>
         </div>
       </div>
     </section>

--- a/src/app/views/landing-overview-content.ts
+++ b/src/app/views/landing-overview-content.ts
@@ -1,0 +1,63 @@
+type LandingOverviewSection = {
+  markdown: string;
+};
+
+type LandingOverviewContent = {
+  title: string;
+  roadmap: {
+    title: string;
+    markdown: string;
+  };
+  changelog: {
+    title: string;
+    markdown: string;
+  };
+};
+
+const roadmapMarkdown = `## Next
+
+- command palette
+- manage projects view
+- drag/drop and paste attachments
+- composer context meter
+
+## Later
+
+- in-app updates and restart
+- dictation that does not suck
+- real Chat, Claw, and Work surfaces
+- tighter attachment semantics`;
+
+const changelogMarkdown = `## April 17, 2026
+
+- CEF builds landed for Linux, Windows, and macOS
+- Settings, Skills, and Extensions now have proper exit affordances
+- GUI-started sessions stream correctly again
+- running indicators stay in sync with real work
+- Inbox now shows final replies only
+- packaged builds now honor extension-provided tool names
+
+## April 14–15, 2026
+
+- prompt queueing and stop behavior landed
+- the terminal moved into a right-side drawer
+- Pi takeover and git ops were cleaned up
+- archived threads moved into the main view
+- projects got a direct new-session action
+- legacy “files changed in turn” noise was removed`;
+
+const landingOverviewContent: LandingOverviewContent = {
+  title: "Roadmap & changelog",
+  roadmap: {
+    title: "Roadmap",
+    markdown: roadmapMarkdown,
+  },
+  changelog: {
+    title: "Changelog",
+    markdown: changelogMarkdown,
+  },
+};
+
+export function getLandingOverviewContent() {
+  return landingOverviewContent;
+}


### PR DESCRIPTION
## Summary
- replace the old landing/project-launcher surface with a centered roadmap/changelog hub
- add a custom pixel H mark and mutually exclusive roadmap/changelog tabs with terse inline content
- keep the landing anchor stable in the upper third of the viewport and teach the GitHub issue flow skill to refresh changelog content before build/release passes

## Validation
- pre-commit hooks
- `bun run typecheck:web`
- `bun run typecheck:bun`
- `bun run typecheck:desktop`
- `vitest run`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

Closes #12
