### PR TITLE
Fix packaged Windows desktop startup

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,6 +1,9 @@
 name: Release artifacts
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - "v*"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -3,7 +3,7 @@ name: Release artifacts
 on:
   pull_request:
     branches:
-      - main
+      - dev
   push:
     tags:
       - "v*"

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -22,7 +22,7 @@ import {
   loadProjectDiffStats,
   loadProjectGitState,
 } from "../project-git.cts";
-import { listProjects, syncSessionSummaries } from "../thread-state-db.cts";
+import { ensureProject, listProjects, syncSessionSummaries } from "../thread-state-db.cts";
 import { setWatchedSessionPath } from "./session-watch.cts";
 export { loadInboxThreadList } from "./thread-loader.cts";
 
@@ -101,11 +101,20 @@ async function syncShellIndex(cwd: string) {
   );
 }
 
+function scheduleShellIndexSync(cwd: string) {
+  // Session discovery can be slow on Windows when the agent storage contains many
+  // folders. Keep shell-state reads responsive and converge the DB in the background.
+  void syncShellIndex(cwd).catch((error) => {
+    console.warn("Failed to sync shell index.", error);
+  });
+}
+
 export async function loadShellState(cwd: string): Promise<ShellState> {
   const { SessionManager } = await getPiModule();
   const { agentDir, sessionDir } = await getSessionStorage(cwd);
 
-  await syncShellIndex(cwd);
+  ensureProject(cwd);
+  scheduleShellIndexSync(cwd);
   const composer = await getComposerState({ projectId: cwd });
   const appSettings = loadAppSettings();
   const [resolvedCwd, projects] = await Promise.all([

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -22,9 +22,13 @@ import {
   loadProjectDiffStats,
   loadProjectGitState,
 } from "../project-git.cts";
+import { emitDesktopEvent } from "../runtime/desktop-events.cts";
 import { ensureProject, listProjects, syncSessionSummaries } from "../thread-state-db.cts";
 import { setWatchedSessionPath } from "./session-watch.cts";
 export { loadInboxThreadList } from "./thread-loader.cts";
+
+const syncedShellIndexes = new Set<string>();
+const inFlightShellIndexSyncs = new Map<string, Promise<void>>();
 
 type SessionSummary = {
   id: string;
@@ -102,11 +106,23 @@ async function syncShellIndex(cwd: string) {
 }
 
 function scheduleShellIndexSync(cwd: string) {
-  // Session discovery can be slow on Windows when the agent storage contains many
-  // folders. Keep shell-state reads responsive and converge the DB in the background.
-  void syncShellIndex(cwd).catch((error) => {
-    console.warn("Failed to sync shell index.", error);
-  });
+  if (syncedShellIndexes.has(cwd) || inFlightShellIndexSyncs.has(cwd)) {
+    return;
+  }
+
+  const syncPromise = syncShellIndex(cwd)
+    .then(() => {
+      syncedShellIndexes.add(cwd);
+      emitDesktopEvent({ type: "shell-state-refresh" });
+    })
+    .catch((error) => {
+      console.warn("Failed to sync shell index.", error);
+    })
+    .finally(() => {
+      inFlightShellIndexSyncs.delete(cwd);
+    });
+
+  inFlightShellIndexSyncs.set(cwd, syncPromise);
 }
 
 export async function loadShellState(cwd: string): Promise<ShellState> {

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -362,6 +362,9 @@ export type ThreadData = {
 
 export type DesktopEvent =
   | {
+      type: "shell-state-refresh";
+    }
+  | {
       type: "thread-update";
       reason: "start" | "update" | "end" | "external";
       projectId: string;

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -323,6 +323,11 @@ export function useAppShellEffects({
         desktopEventStateRef.current;
       const visibleSessionPath = getVisibleDesktopSessionPath(latestWorkspaceState);
 
+      if (event.type === "shell-state-refresh") {
+        scheduleShellStateRefresh();
+        return;
+      }
+
       if (event.type === "composer-update") {
         const shouldApplyComposerUpdate = event.sessionPath
           ? event.sessionPath === visibleSessionPath


### PR DESCRIPTION
## Summary
- fix packaged Windows desktop startup by keeping shell-state reads responsive while the session index syncs in the background
- run the release artifact workflow for pull requests targeting the default `dev` branch

## Verification
- `bun run build:desktop`
- `bun run build:release`
- `bun run build:launcher-artifacts`
- `bun add -g howcode`
- `howcode`
