### PR TITLE
Fix stuck busy spinner after thread end

### DIFF
--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -3,7 +3,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ComposerState, ThreadData } from "../../shared/desktop-contracts.ts";
 import { getPreviousMessageCount } from "../../shared/pi-message-mapper.ts";
 import { getLatestInboxAssistantMessage } from "../../shared/thread-inbox.ts";
-import { buildThreadData } from "../../shared/thread-data.ts";
+import { buildThreadData, setThreadStreamingState } from "../../shared/thread-data.ts";
 import {
   beginInboxThreadTurn,
   getThreadAssistantSnapshot,
@@ -76,6 +76,17 @@ function getLatestUserPrompt(thread: ThreadData) {
   return prompt.length > 0 ? prompt : null;
 }
 
+export function normalizeThreadDataForReason(
+  thread: ThreadData,
+  reason: RuntimeThreadReason | "external",
+): ThreadData {
+  if (reason !== "end" && reason !== "external") {
+    return thread;
+  }
+
+  return setThreadStreamingState(thread, false);
+}
+
 export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThreadReason) {
   const sessionPath = runtime.session.sessionFile;
   if (!sessionPath) {
@@ -84,10 +95,12 @@ export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThr
 
   markInternalThreadUpdate(sessionPath);
 
-  const thread = buildLiveThreadData(runtime);
-  if (!thread) {
+  const liveThread = buildLiveThreadData(runtime);
+  if (!liveThread) {
     return;
   }
+
+  const thread = normalizeThreadDataForReason(liveThread, reason);
 
   const threadId = runtime.session.sessionId;
   const projectId = runtime.cwd;
@@ -164,6 +177,8 @@ export async function publishExternalThreadUpdate({
   thread: ThreadData;
   threadId: string;
 }) {
+  thread = normalizeThreadDataForReason(thread, "external");
+
   rememberLiveThread(sessionPath, thread);
   rememberSessionPath(sessionPath, projectId);
   upsertThreadSummary({

--- a/shared/thread-data.ts
+++ b/shared/thread-data.ts
@@ -25,3 +25,7 @@ export function buildThreadData({
     isStreaming,
   };
 }
+
+export function setThreadStreamingState(thread: ThreadData, isStreaming: boolean): ThreadData {
+  return thread.isStreaming === isStreaming ? thread : { ...thread, isStreaming };
+}

--- a/src/test/thread-publisher.test.ts
+++ b/src/test/thread-publisher.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadData } from "../../shared/desktop-contracts";
+import { setThreadStreamingState } from "../../shared/thread-data";
+
+function buildThreadData(isStreaming: boolean): ThreadData {
+  return {
+    sessionPath: "/tmp/thread.jsonl",
+    title: "Thread",
+    messages: [],
+    previousMessageCount: 0,
+    isStreaming,
+  };
+}
+
+describe("setThreadStreamingState", () => {
+  it("can force a stale streaming snapshot idle", () => {
+    expect(setThreadStreamingState(buildThreadData(true), false).isStreaming).toBe(false);
+  });
+
+  it("preserves identity when the requested state already matches", () => {
+    const thread = buildThreadData(false);
+    expect(setThreadStreamingState(thread, false)).toBe(thread);
+  });
+
+  it("can opt back into streaming when needed", () => {
+    expect(setThreadStreamingState(buildThreadData(false), true).isStreaming).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- force `end` and `external` thread updates to publish idle snapshots even if the runtime still reports a stale streaming flag
- reuse a shared thread streaming-state helper to avoid duplicating snapshot mutation logic
- add regression coverage for the streaming-state helper used by thread publishing

## Details
The desktop UI treats live thread state as authoritative for busy/running indicators. In the stuck-spinner case, an `end` update could preserve a stale `isStreaming: true` snapshot and cache it as the live thread, which then continued to override the persisted `running = false` state.

This change normalizes thread snapshots for `end` and `external` reasons before they are cached or emitted, ensuring those terminal updates are always published as idle.

## Validation
- pre-commit hooks ran full typecheck and test suites during commit
- `bun x vitest run src/test/thread-publisher.test.ts src/test/thread-data.test.ts src/test/thread-running-state.test.ts`
