### PR TITLE
Fix launch-time white bar and incorrect initial layout sizing

### DIFF
--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -6,6 +6,7 @@ import type { ProjectDiffBaseline } from "../desktop/types";
 import { useAnimatedPresence } from "../hooks/useAnimatedPresence";
 import { AppShellOverlays } from "./AppShellOverlays";
 import { AppShellWorkspace } from "./AppShellWorkspace";
+import { appShellRootClass } from "./layout-classes";
 import type { AppShellController } from "./useAppShellController";
 import { useAppShellLayoutState } from "./useAppShellLayoutState";
 
@@ -77,7 +78,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
 
   return (
     <>
-      <div className="relative flex h-screen overflow-hidden bg-[color:var(--workspace)] text-[color:var(--text)]">
+      <div className={appShellRootClass}>
         <div className="relative w-[300px] max-w-[calc(100vw-1rem)] min-w-0 shrink-0">
           <Sidebar
             projects={projects}

--- a/src/app/app-shell/layout-classes.ts
+++ b/src/app/app-shell/layout-classes.ts
@@ -1,0 +1,7 @@
+// Use the rooted app height instead of viewport units here.
+// In the embedded desktop webview, `100vh`/`h-screen` can come up slightly wrong
+// on first paint and only settle after the first resize event, which leaves a
+// white strip at the bottom and mis-sizes the workspace. `#root` already tracks
+// the real content area, so `h-full` keeps the shell aligned from launch.
+export const appShellRootClass =
+  "relative flex h-full min-h-0 overflow-hidden bg-[color:var(--workspace)] text-[color:var(--text)]";

--- a/src/test/app-shell-layout.test.ts
+++ b/src/test/app-shell-layout.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { appShellRootClass } from "../app/app-shell/layout-classes";
+
+describe("app shell layout", () => {
+  it("uses the rooted app height instead of viewport units", () => {
+    expect(appShellRootClass).toContain("h-full");
+    expect(appShellRootClass).toContain("min-h-0");
+    expect(appShellRootClass).not.toContain("h-screen");
+  });
+});


### PR DESCRIPTION
## Summary
- switch the app shell root from viewport height sizing to rooted full-height sizing
- keep the shell aligned with the embedded desktop content area on first paint
- add a regression test covering the app shell sizing class

## Validation
- bun test src/test/app-shell-layout.test.ts
- pre-commit hook: bun run typecheck:web && bun run typecheck:desktop && bun run typecheck:electron && bun run typecheck:scripts
- pre-commit hook: vitest run

Closes #67