### PR TITLE
Fix sherpa-onnx dictation model downloads failing validation

### DIFF
--- a/desktop/dictation/model-download.ts
+++ b/desktop/dictation/model-download.ts
@@ -1,0 +1,80 @@
+export type DownloadMetadata = {
+  contentLength: number | null;
+  etag: string | null;
+};
+
+const MAX_DOWNLOAD_REDIRECTS = 5;
+
+function normalizeEtag(etag: string | null) {
+  if (!etag) {
+    return null;
+  }
+
+  return etag.replace(/^W\//, "").replace(/^"|"$/g, "").trim().toLowerCase() || null;
+}
+
+function parseContentLength(value: string | null) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function getDownloadMetadataFromHeaders(headers: Headers): DownloadMetadata {
+  return {
+    contentLength:
+      parseContentLength(headers.get("x-linked-size")) ??
+      parseContentLength(headers.get("content-length")),
+    etag: normalizeEtag(headers.get("x-linked-etag")) ?? normalizeEtag(headers.get("etag")),
+  };
+}
+
+function mergeDownloadMetadata(current: DownloadMetadata, headers: Headers): DownloadMetadata {
+  const next = getDownloadMetadataFromHeaders(headers);
+
+  return {
+    contentLength: current.contentLength ?? next.contentLength,
+    etag: current.etag ?? next.etag,
+  };
+}
+
+function isRedirectStatus(status: number) {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+export async function fetchDownloadResponse(url: string) {
+  let currentUrl = url;
+  let metadata: DownloadMetadata = {
+    contentLength: null,
+    etag: null,
+  };
+
+  for (let redirectCount = 0; redirectCount <= MAX_DOWNLOAD_REDIRECTS; redirectCount += 1) {
+    const response = await fetch(currentUrl, { redirect: "manual" });
+    metadata = mergeDownloadMetadata(metadata, response.headers);
+
+    if (!isRedirectStatus(response.status)) {
+      if (!response.ok) {
+        throw new Error(
+          `Download failed (${response.status} ${response.statusText}) for ${currentUrl}`,
+        );
+      }
+
+      return {
+        response,
+        metadata,
+      };
+    }
+
+    if (redirectCount === MAX_DOWNLOAD_REDIRECTS) {
+      throw new Error(`Download failed: too many redirects for ${url}`);
+    }
+
+    const location = response.headers.get("location");
+    if (!location) {
+      throw new Error(`Download failed: missing redirect location for ${currentUrl}`);
+    }
+
+    currentUrl = new URL(location, currentUrl).toString();
+  }
+
+  throw new Error(`Download failed: could not resolve ${url}`);
+}

--- a/desktop/dictation/model-download.ts
+++ b/desktop/dictation/model-download.ts
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer";
 export type DownloadMetadata = {
   contentLength: number | null;
   etag: string | null;
+  etagSource: "etag" | "x-linked-etag" | null;
 };
 
 export type DownloadChecksumExpectation = {
@@ -11,7 +12,23 @@ export type DownloadChecksumExpectation = {
   prefix: Buffer | null;
 };
 
-const MAX_DOWNLOAD_REDIRECTS = 5;
+const MAX_DOWNLOAD_REDIRECTS = 20;
+
+function isHashCapableEtag(etag: string | null) {
+  return Boolean(etag && (/^[a-f0-9]{40}$/i.test(etag) || /^[a-f0-9]{64}$/i.test(etag)));
+}
+
+function getEtagSourcePriority(source: DownloadMetadata["etagSource"]) {
+  if (source === "x-linked-etag") {
+    return 2;
+  }
+
+  if (source === "etag") {
+    return 1;
+  }
+
+  return 0;
+}
 
 function normalizeEtag(etag: string | null) {
   if (!etag) {
@@ -27,9 +44,17 @@ function parseContentLength(value: string | null) {
 }
 
 export function getDownloadMetadataFromHeaders(headers: Headers): DownloadMetadata {
+  const xLinkedEtag = normalizeEtag(headers.get("x-linked-etag"));
+  const etag = normalizeEtag(headers.get("etag"));
+
   return {
     contentLength: parseContentLength(headers.get("x-linked-size")),
-    etag: normalizeEtag(headers.get("x-linked-etag")) ?? normalizeEtag(headers.get("etag")),
+    etag: isHashCapableEtag(xLinkedEtag) ? xLinkedEtag : isHashCapableEtag(etag) ? etag : null,
+    etagSource: isHashCapableEtag(xLinkedEtag)
+      ? "x-linked-etag"
+      : isHashCapableEtag(etag)
+        ? "etag"
+        : null,
   };
 }
 
@@ -68,10 +93,14 @@ function mergeDownloadMetadata(
   const fallbackContentLength = options.includeContentLength
     ? parseContentLength(headers.get("content-length"))
     : null;
+  const shouldUseNextEtag =
+    getEtagSourcePriority(next.etagSource) > getEtagSourcePriority(current.etagSource) ||
+    (next.etag !== null && next.etagSource === current.etagSource);
 
   return {
     contentLength: current.contentLength ?? next.contentLength ?? fallbackContentLength,
-    etag: current.etag ?? next.etag,
+    etag: shouldUseNextEtag ? next.etag : current.etag,
+    etagSource: shouldUseNextEtag ? next.etagSource : current.etagSource,
   };
 }
 
@@ -84,6 +113,7 @@ export async function fetchDownloadResponse(url: string) {
   let metadata: DownloadMetadata = {
     contentLength: null,
     etag: null,
+    etagSource: null,
   };
 
   for (let redirectCount = 0; redirectCount <= MAX_DOWNLOAD_REDIRECTS; redirectCount += 1) {

--- a/desktop/dictation/model-download.ts
+++ b/desktop/dictation/model-download.ts
@@ -1,6 +1,14 @@
+import { Buffer } from "node:buffer";
+
 export type DownloadMetadata = {
   contentLength: number | null;
   etag: string | null;
+};
+
+export type DownloadChecksumExpectation = {
+  algorithm: "sha1" | "sha256";
+  expected: string;
+  prefix: Buffer | null;
 };
 
 const MAX_DOWNLOAD_REDIRECTS = 5;
@@ -23,6 +31,32 @@ export function getDownloadMetadataFromHeaders(headers: Headers): DownloadMetada
     contentLength: parseContentLength(headers.get("x-linked-size")),
     etag: normalizeEtag(headers.get("x-linked-etag")) ?? normalizeEtag(headers.get("etag")),
   };
+}
+
+export function getDownloadChecksumExpectations(
+  etag: string | null,
+  contentLength: number,
+): DownloadChecksumExpectation[] {
+  if (!etag) {
+    return [];
+  }
+
+  if (/^[a-f0-9]{64}$/i.test(etag)) {
+    return [{ algorithm: "sha256", expected: etag, prefix: null }];
+  }
+
+  if (/^[a-f0-9]{40}$/i.test(etag)) {
+    return [
+      { algorithm: "sha1", expected: etag, prefix: null },
+      {
+        algorithm: "sha1",
+        expected: etag,
+        prefix: Buffer.from(`blob ${contentLength}\0`),
+      },
+    ];
+  }
+
+  return [];
 }
 
 function mergeDownloadMetadata(

--- a/desktop/dictation/model-download.ts
+++ b/desktop/dictation/model-download.ts
@@ -20,18 +20,23 @@ function parseContentLength(value: string | null) {
 
 export function getDownloadMetadataFromHeaders(headers: Headers): DownloadMetadata {
   return {
-    contentLength:
-      parseContentLength(headers.get("x-linked-size")) ??
-      parseContentLength(headers.get("content-length")),
+    contentLength: parseContentLength(headers.get("x-linked-size")),
     etag: normalizeEtag(headers.get("x-linked-etag")) ?? normalizeEtag(headers.get("etag")),
   };
 }
 
-function mergeDownloadMetadata(current: DownloadMetadata, headers: Headers): DownloadMetadata {
+function mergeDownloadMetadata(
+  current: DownloadMetadata,
+  headers: Headers,
+  options: { includeContentLength: boolean },
+): DownloadMetadata {
   const next = getDownloadMetadataFromHeaders(headers);
+  const fallbackContentLength = options.includeContentLength
+    ? parseContentLength(headers.get("content-length"))
+    : null;
 
   return {
-    contentLength: current.contentLength ?? next.contentLength,
+    contentLength: current.contentLength ?? next.contentLength ?? fallbackContentLength,
     etag: current.etag ?? next.etag,
   };
 }
@@ -49,7 +54,9 @@ export async function fetchDownloadResponse(url: string) {
 
   for (let redirectCount = 0; redirectCount <= MAX_DOWNLOAD_REDIRECTS; redirectCount += 1) {
     const response = await fetch(currentUrl, { redirect: "manual" });
-    metadata = mergeDownloadMetadata(metadata, response.headers);
+    metadata = mergeDownloadMetadata(metadata, response.headers, {
+      includeContentLength: !isRedirectStatus(response.status),
+    });
 
     if (!isRedirectStatus(response.status)) {
       if (!response.ok) {

--- a/desktop/dictation/model-management.cts
+++ b/desktop/dictation/model-management.cts
@@ -24,7 +24,11 @@ import {
   getManagedDictationModelFiles,
   getResolvedDictationModelFiles,
 } from "./model-resolution.cts";
-import { type DownloadMetadata, fetchDownloadResponse } from "./model-download.ts";
+import {
+  getDownloadChecksumExpectations,
+  type DownloadMetadata,
+  fetchDownloadResponse,
+} from "./model-download.ts";
 import { resetRecognizerCache } from "./sherpa-runtime.cts";
 
 function emitDictationDownloadLog(
@@ -46,22 +50,6 @@ function buildHuggingFaceResolveUrl(repo: string, fileName: string) {
   return `https://huggingface.co/${repo}/resolve/main/${encodeURIComponent(fileName)}?download=true`;
 }
 
-function getEtagHashAlgorithm(etag: string | null) {
-  if (!etag) {
-    return null;
-  }
-
-  if (/^[a-f0-9]{64}$/i.test(etag)) {
-    return "sha256" as const;
-  }
-
-  if (/^[a-f0-9]{40}$/i.test(etag)) {
-    return "sha1" as const;
-  }
-
-  return null;
-}
-
 async function validateDownloadedFile(targetPath: string, metadata: DownloadMetadata) {
   const fileStats = await stat(targetPath);
   if (!fileStats.isFile() || fileStats.size <= 0) {
@@ -74,19 +62,33 @@ async function validateDownloadedFile(targetPath: string, metadata: DownloadMeta
     );
   }
 
-  const hashAlgorithm = getEtagHashAlgorithm(metadata.etag);
-  if (!metadata.etag || !hashAlgorithm) {
+  const checksumExpectations = getDownloadChecksumExpectations(metadata.etag, fileStats.size);
+  if (checksumExpectations.length === 0) {
     return;
   }
 
-  const hash = createHash(hashAlgorithm);
+  const hashes = checksumExpectations.map((expectation) => {
+    const hash = createHash(expectation.algorithm);
+    if (expectation.prefix) {
+      hash.update(expectation.prefix);
+    }
+
+    return {
+      expected: expectation.expected,
+      hash,
+    };
+  });
+
   for await (const chunk of createReadStream(targetPath)) {
-    hash.update(chunk);
+    for (const candidate of hashes) {
+      candidate.hash.update(chunk);
+    }
   }
 
-  const fileHash = hash.digest("hex");
-
-  if (fileHash !== metadata.etag) {
+  const matchesChecksum = hashes.some(
+    (candidate) => candidate.hash.digest("hex") === candidate.expected,
+  );
+  if (!matchesChecksum) {
     throw new Error(`Download failed: ${path.basename(targetPath)} checksum mismatch.`);
   }
 }

--- a/desktop/dictation/model-management.cts
+++ b/desktop/dictation/model-management.cts
@@ -24,6 +24,7 @@ import {
   getManagedDictationModelFiles,
   getResolvedDictationModelFiles,
 } from "./model-resolution.cts";
+import { type DownloadMetadata, fetchDownloadResponse } from "./model-download.ts";
 import { resetRecognizerCache } from "./sherpa-runtime.cts";
 
 function emitDictationDownloadLog(
@@ -43,19 +44,6 @@ function emitDictationDownloadLog(
 
 function buildHuggingFaceResolveUrl(repo: string, fileName: string) {
   return `https://huggingface.co/${repo}/resolve/main/${encodeURIComponent(fileName)}?download=true`;
-}
-
-type DownloadMetadata = {
-  contentLength: number | null;
-  etag: string | null;
-};
-
-function normalizeEtag(etag: string | null) {
-  if (!etag) {
-    return null;
-  }
-
-  return etag.replace(/^W\//, "").replace(/^"|"$/g, "").trim().toLowerCase() || null;
 }
 
 function getEtagHashAlgorithm(etag: string | null) {
@@ -86,9 +74,8 @@ async function validateDownloadedFile(targetPath: string, metadata: DownloadMeta
     );
   }
 
-  const normalizedEtag = normalizeEtag(metadata.etag);
-  const hashAlgorithm = getEtagHashAlgorithm(normalizedEtag);
-  if (!normalizedEtag || !hashAlgorithm) {
+  const hashAlgorithm = getEtagHashAlgorithm(metadata.etag);
+  if (!metadata.etag || !hashAlgorithm) {
     return;
   }
 
@@ -99,26 +86,18 @@ async function validateDownloadedFile(targetPath: string, metadata: DownloadMeta
 
   const fileHash = hash.digest("hex");
 
-  if (fileHash !== normalizedEtag) {
+  if (fileHash !== metadata.etag) {
     throw new Error(`Download failed: ${path.basename(targetPath)} checksum mismatch.`);
   }
 }
 
 async function downloadToFile(url: string, targetPath: string) {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Download failed (${response.status} ${response.statusText}) for ${url}`);
-  }
-
+  const { response, metadata } = await fetchDownloadResponse(url);
   if (!response.body) {
     throw new Error(`Download failed: missing response body for ${url}`);
   }
 
   const temporaryPath = `${targetPath}.partial`;
-  const metadata: DownloadMetadata = {
-    contentLength: Number.parseInt(response.headers.get("content-length") ?? "", 10) || null,
-    etag: response.headers.get("etag"),
-  };
 
   try {
     await pipeline(

--- a/src/app/views/landing-overview-content.ts
+++ b/src/app/views/landing-overview-content.ts
@@ -28,23 +28,22 @@ const roadmapMarkdown = `## Next
 - real Chat, Claw, and Work surfaces
 - tighter attachment semantics`;
 
-const changelogMarkdown = `## April 17, 2026
+const changelogMarkdown = `## April 18–19, 2026
+
+- local Whisper dictation landed with managed model installs
+- the desktop shell now runs on Electron instead of Electrobun
+- launch-time layout sizing got fixed up
+- composer attachment flows were polished
+- stuck busy spinners after thread completion were fixed
+
+## April 17, 2026
 
 - CEF builds landed for Linux, Windows, and macOS
 - Settings, Skills, and Extensions now have proper exit affordances
 - GUI-started sessions stream correctly again
 - running indicators stay in sync with real work
 - Inbox now shows final replies only
-- packaged builds now honor extension-provided tool names
-
-## April 14–15, 2026
-
-- prompt queueing and stop behavior landed
-- the terminal moved into a right-side drawer
-- Pi takeover and git ops were cleaned up
-- archived threads moved into the main view
-- projects got a direct new-session action
-- legacy “files changed in turn” noise was removed`;
+- packaged builds now honor extension-provided tool names`;
 
 const landingOverviewContent: LandingOverviewContent = {
   title: "Roadmap & changelog",

--- a/src/test/dictation-model-management.test.ts
+++ b/src/test/dictation-model-management.test.ts
@@ -57,4 +57,42 @@ describe("dictation model download metadata", () => {
     });
     await expect(response.text()).resolves.toBe(fileContents);
   });
+
+  it("uses the final response content length when redirects only expose redirect body sizes", async () => {
+    const fileContents = "token-1\ntoken-2\n";
+    const expectedChecksum = createHash("sha1").update(fileContents).digest("hex");
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: {
+            location: "https://huggingface.co/api/resolve-cache/models/repo/revision/model.txt",
+            "content-length": "227",
+            "x-linked-etag": `"${expectedChecksum}"`,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(fileContents, {
+          status: 200,
+          headers: {
+            etag: `W/\"${expectedChecksum}\"`,
+            "content-length": String(fileContents.length),
+          },
+        }),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { metadata } = await fetchDownloadResponse(
+      "https://huggingface.co/repo/resolve/main/model.txt?download=true",
+    );
+
+    expect(metadata).toEqual({
+      contentLength: fileContents.length,
+      etag: expectedChecksum,
+    });
+  });
 });

--- a/src/test/dictation-model-management.test.ts
+++ b/src/test/dictation-model-management.test.ts
@@ -1,0 +1,60 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchDownloadResponse } from "../../desktop/dictation/model-download";
+
+describe("dictation model download metadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("prefers Hugging Face x-linked checksum metadata over redirected etags", async () => {
+    const fileContents = "tiny whisper model";
+    const expectedChecksum = createHash("sha256").update(fileContents).digest("hex");
+    const redirectedChecksum = createHash("sha256").update("redirect-metadata").digest("hex");
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://download.example.test/tiny.en-encoder.int8.onnx",
+            "x-linked-etag": `"${expectedChecksum}"`,
+            "x-linked-size": String(fileContents.length),
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(fileContents, {
+          status: 200,
+          headers: {
+            etag: `"${redirectedChecksum}"`,
+            "content-length": String(fileContents.length),
+          },
+        }),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { response, metadata } = await fetchDownloadResponse(
+      "https://huggingface.co/repo/resolve/main/model.onnx?download=true",
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://huggingface.co/repo/resolve/main/model.onnx?download=true",
+      { redirect: "manual" },
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://download.example.test/tiny.en-encoder.int8.onnx",
+      { redirect: "manual" },
+    );
+    expect(metadata).toEqual({
+      contentLength: fileContents.length,
+      etag: expectedChecksum,
+    });
+    await expect(response.text()).resolves.toBe(fileContents);
+  });
+});

--- a/src/test/dictation-model-management.test.ts
+++ b/src/test/dictation-model-management.test.ts
@@ -1,6 +1,21 @@
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchDownloadResponse } from "../../desktop/dictation/model-download";
+import {
+  fetchDownloadResponse,
+  getDownloadChecksumExpectations,
+} from "../../desktop/dictation/model-download";
+
+function contentMatchesChecksum(content: string, etag: string) {
+  return getDownloadChecksumExpectations(etag, Buffer.byteLength(content)).some((expectation) => {
+    const hash = createHash(expectation.algorithm);
+    if (expectation.prefix) {
+      hash.update(expectation.prefix);
+    }
+
+    hash.update(content);
+    return hash.digest("hex") === expectation.expected;
+  });
+}
 
 describe("dictation model download metadata", () => {
   afterEach(() => {
@@ -94,5 +109,22 @@ describe("dictation model download metadata", () => {
       contentLength: fileContents.length,
       etag: expectedChecksum,
     });
+  });
+
+  it("accepts Hugging Face git-blob sha1 etags for plain repository files", () => {
+    const fileContents = "token-1\ntoken-2\n";
+    const gitBlobSha1 = createHash("sha1")
+      .update(`blob ${Buffer.byteLength(fileContents)}\0`)
+      .update(fileContents)
+      .digest("hex");
+
+    expect(contentMatchesChecksum(fileContents, gitBlobSha1)).toBe(true);
+  });
+
+  it("accepts raw sha256 etags for xet-backed model files", () => {
+    const fileContents = "model-binary";
+    const sha256 = createHash("sha256").update(fileContents).digest("hex");
+
+    expect(contentMatchesChecksum(fileContents, sha256)).toBe(true);
   });
 });

--- a/src/test/dictation-model-management.test.ts
+++ b/src/test/dictation-model-management.test.ts
@@ -69,6 +69,7 @@ describe("dictation model download metadata", () => {
     expect(metadata).toEqual({
       contentLength: fileContents.length,
       etag: expectedChecksum,
+      etagSource: "x-linked-etag",
     });
     await expect(response.text()).resolves.toBe(fileContents);
   });
@@ -108,6 +109,149 @@ describe("dictation model download metadata", () => {
     expect(metadata).toEqual({
       contentLength: fileContents.length,
       etag: expectedChecksum,
+      etagSource: "x-linked-etag",
+    });
+  });
+
+  it("ignores early non-hash etags and keeps later hash metadata", async () => {
+    const fileContents = "tiny whisper model";
+    const expectedChecksum = createHash("sha256").update(fileContents).digest("hex");
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://huggingface.co/redirect-2",
+            etag: '"not-a-content-hash"',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://download.example.test/model.onnx",
+            "x-linked-etag": `"${expectedChecksum}"`,
+            "x-linked-size": String(fileContents.length),
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(fileContents, {
+          status: 200,
+          headers: {
+            etag: '"another-non-hash-etag"',
+            "content-length": String(fileContents.length),
+          },
+        }),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { metadata } = await fetchDownloadResponse(
+      "https://huggingface.co/repo/resolve/main/model.onnx?download=true",
+    );
+
+    expect(metadata).toEqual({
+      contentLength: fileContents.length,
+      etag: expectedChecksum,
+      etagSource: "x-linked-etag",
+    });
+  });
+
+  it("prefers later x-linked etags over earlier plain etags", async () => {
+    const fileContents = "tiny whisper model";
+    const earlyChecksum = createHash("sha256").update("redirect checksum").digest("hex");
+    const linkedChecksum = createHash("sha256").update(fileContents).digest("hex");
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://huggingface.co/redirect-2",
+            etag: `"${earlyChecksum}"`,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://download.example.test/model.onnx",
+            "x-linked-etag": `"${linkedChecksum}"`,
+            "x-linked-size": String(fileContents.length),
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(fileContents, {
+          status: 200,
+          headers: {
+            etag: `"${earlyChecksum}"`,
+            "content-length": String(fileContents.length),
+          },
+        }),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { metadata } = await fetchDownloadResponse(
+      "https://huggingface.co/repo/resolve/main/model.onnx?download=true",
+    );
+
+    expect(metadata).toEqual({
+      contentLength: fileContents.length,
+      etag: linkedChecksum,
+      etagSource: "x-linked-etag",
+    });
+  });
+
+  it("allows longer redirect chains before failing", async () => {
+    const fileContents = "token-1\ntoken-2\n";
+    const expectedChecksum = createHash("sha1").update(fileContents).digest("hex");
+    const fetchMock = vi.fn();
+
+    for (let index = 0; index < 6; index += 1) {
+      fetchMock.mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: `https://huggingface.co/redirect-${index + 1}`,
+            ...(index === 5
+              ? {
+                  "x-linked-etag": `"${expectedChecksum}"`,
+                }
+              : {}),
+          },
+        }),
+      );
+    }
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(fileContents, {
+        status: 200,
+        headers: {
+          etag: `W/\"${expectedChecksum}\"`,
+          "content-length": String(fileContents.length),
+        },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { metadata } = await fetchDownloadResponse(
+      "https://huggingface.co/repo/resolve/main/model.txt?download=true",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(metadata).toEqual({
+      contentLength: fileContents.length,
+      etag: expectedChecksum,
+      etagSource: "x-linked-etag",
     });
   });
 


### PR DESCRIPTION
## Summary
- fix managed dictation downloads so Hugging Face redirect metadata is interpreted correctly across both Xet-backed model binaries and plain Git-backed token files
- keep checksum and size validation, but make it robust to Hugging Face's real redirect/etag behavior instead of rejecting healthy downloads
- refresh the landing changelog before the build pass used in this flow

## What changed
- added a small download metadata helper for following redirects while preserving the right integrity metadata
- stopped trusting redirect-body `content-length` values for final file validation
- taught checksum validation to accept both raw content hashes and Hugging Face Git blob SHA1 etags
- added regression coverage for:
  - redirected Xet/LFS-style downloads
  - cached token-file redirects with misleading redirect-body sizes
  - Git blob SHA1 checksum validation for plain repo files

## Root cause
Hugging Face serves these curated model assets through more than one backend:
- `.onnx` files are often served through Xet/CAS-style redirects with content hashes
- `tokens.txt` files can come from the repo cache where the exposed etag is the Git blob SHA1, not the raw file SHA1

The old downloader treated those cases as one checksum scheme, which caused valid downloads to fail with `.partial` size/checksum errors.

## Validation
- pre-commit hooks passed on each commit
- pre-push `bun run check` passed, including lint, typecheck, test, and build
- regression tests added in `src/test/dictation-model-management.test.ts`

Closes #78
