### PR TITLE
Guard Skills project scope without project path

### DIFF
--- a/src/app/features/skills/SkillsView.tsx
+++ b/src/app/features/skills/SkillsView.tsx
@@ -76,12 +76,22 @@ export function SkillsView({
             value={controller.installScope}
             options={[
               { value: "global", label: `Global (${controller.globalSkillCount})` },
-              { value: "project", label: `Project (${controller.projectSkillCount})` },
+              {
+                value: "project",
+                label: `Project (${controller.projectSkillCount})`,
+                disabled: !controller.projectScopeAvailable,
+              },
             ]}
             onChange={controller.setInstallScope}
           />
         }
       />
+
+      {!controller.projectScopeAvailable ? (
+        <div className="text-[12px] text-[color:var(--muted)]">
+          Project skills are unavailable until a project path is available.
+        </div>
+      ) : null}
 
       {controller.actionError ? (
         <div className="text-[12px] text-[#f2a7a7]">{controller.actionError}</div>

--- a/src/app/features/skills/hooks/useSkillsController.ts
+++ b/src/app/features/skills/hooks/useSkillsController.ts
@@ -23,11 +23,13 @@ export function useSkillsController({
   onSetProjectScopeActive: (active: boolean) => void;
 }) {
   const queryClient = useQueryClient();
+  const normalizedProjectPath = projectPath?.trim() ? projectPath : null;
   const [installScope, setInstallScope] = useState<InstallScope>("global");
   const [installedOpen, setInstalledOpen] = useState(true);
   const [pendingActions, setPendingActions] = useState<PendingAction[]>([]);
   const [actionError, setActionError] = useState<string | null>(null);
   const desktopSkillsAvailable = isDesktopSkillsAvailable();
+  const projectScopeAvailable = normalizedProjectPath !== null;
 
   const configuredSkillsQuery = useQuery({
     queryKey: desktopQueryKeys.configuredPiSkills(projectPath),
@@ -54,12 +56,18 @@ export function useSkillsController({
   );
 
   useEffect(() => {
-    onSetProjectScopeActive(installScope === "project");
+    if (!projectScopeAvailable && installScope === "project") {
+      setInstallScope("global");
+    }
+  }, [installScope, projectScopeAvailable]);
+
+  useEffect(() => {
+    onSetProjectScopeActive(projectScopeAvailable && installScope === "project");
 
     return () => {
       onSetProjectScopeActive(false);
     };
-  }, [installScope, onSetProjectScopeActive]);
+  }, [installScope, onSetProjectScopeActive, projectScopeAvailable]);
 
   const invalidateConfiguredSkillsCaches = (skills?: PiConfiguredSkill[]) => {
     if (skills) {
@@ -92,6 +100,11 @@ export function useSkillsController({
   };
 
   const handleInstall = async (source: string) => {
+    if (installScope === "project" && !normalizedProjectPath) {
+      setActionError("Select a project first.");
+      return false;
+    }
+
     const normalizedSource = source.trim();
     const pendingAction = { kind: "install" as const, source: normalizedSource };
 
@@ -102,7 +115,7 @@ export function useSkillsController({
       const result = await installPiSkillQuery({
         source: normalizedSource,
         local: installScope === "project",
-        projectPath,
+        projectPath: normalizedProjectPath,
       });
 
       if (result?.configuredSkills) {
@@ -154,6 +167,7 @@ export function useSkillsController({
     invalidateConfiguredSkillsCaches,
     isPendingInstall: (source: string) => isPending("install", source),
     isPendingRemove: (installedPath: string) => isPending("remove", installedPath),
+    projectScopeAvailable,
     projectSkillCount,
     setActionError,
     setInstallScope,


### PR DESCRIPTION
## Summary
- mirrors the Extensions project-scope guard in the Skills controller
- forces Skills back to Global when no valid project path is available
- prevents project/local skill installs from being called without a project path
- disables the Project scope option and explains why it is unavailable

## Validation
- pre-commit: `bun run typecheck:web && bun run typecheck:desktop && bun run typecheck:electron && bun run typecheck:scripts`, `vitest run`
- pre-push: `bun run lint && bun run typecheck`

Closes #91
