### PR TITLE
Refresh shell index before project import

### DIFF
--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -32,6 +32,7 @@ import {
 } from "../thread-state-db.cts";
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
+import { getProjectImportRefreshError } from "./project-import-refresh.ts";
 import { refreshShellIndex } from "./shell-loader.cts";
 
 async function unlinkIfPresent(filePath: string) {
@@ -311,9 +312,14 @@ export async function handleProjectDesktopAction(
     case "projects.import.scan": {
       const projectIds = getProjectIds(payload);
       const refreshed = await refreshShellIndex(getDesktopWorkingDirectory());
-      if (!refreshed && projectIds.length === 0) {
+      const refreshError = getProjectImportRefreshError({
+        mode: "scan",
+        projectIds,
+        refreshed,
+      });
+      if (refreshError) {
         return handledAction({
-          error: "Could not refresh Pi sessions before scanning projects.",
+          error: refreshError,
         });
       }
 
@@ -324,10 +330,17 @@ export async function handleProjectDesktopAction(
 
     case "projects.import.apply": {
       const projectIds = getProjectIds(payload);
-      const refreshed = await refreshShellIndex(getDesktopWorkingDirectory());
-      if (!refreshed && projectIds.length === 0) {
+      const refreshed = await refreshShellIndex(getDesktopWorkingDirectory(), {
+        emitRefreshEvent: false,
+      });
+      const refreshError = getProjectImportRefreshError({
+        mode: "import",
+        projectIds,
+        refreshed,
+      });
+      if (refreshError) {
         return handledAction({
-          error: "Could not refresh Pi sessions before importing projects.",
+          error: refreshError,
         });
       }
 

--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -309,15 +309,29 @@ export async function handleProjectDesktopAction(
       return handledAction();
 
     case "projects.import.scan": {
-      await refreshShellIndex(getDesktopWorkingDirectory());
+      const projectIds = getProjectIds(payload);
+      const refreshed = await refreshShellIndex(getDesktopWorkingDirectory());
+      if (!refreshed && projectIds.length === 0) {
+        return handledAction({
+          error: "Could not refresh Pi sessions before scanning projects.",
+        });
+      }
+
       return handledAction({
-        projects: await scanKnownProjects(getProjectIds(payload)),
+        projects: await scanKnownProjects(projectIds),
       });
     }
 
     case "projects.import.apply": {
-      await refreshShellIndex(getDesktopWorkingDirectory());
-      return handledAction(await importProjects(getProjectIds(payload)));
+      const projectIds = getProjectIds(payload);
+      const refreshed = await refreshShellIndex(getDesktopWorkingDirectory());
+      if (!refreshed && projectIds.length === 0) {
+        return handledAction({
+          error: "Could not refresh Pi sessions before importing projects.",
+        });
+      }
+
+      return handledAction(await importProjects(projectIds));
     }
 
     default:

--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -32,6 +32,7 @@ import {
 } from "../thread-state-db.cts";
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
+import { refreshShellIndex } from "./shell-loader.cts";
 
 async function unlinkIfPresent(filePath: string) {
   try {
@@ -307,13 +308,17 @@ export async function handleProjectDesktopAction(
       collapseAllProjects();
       return handledAction();
 
-    case "projects.import.scan":
+    case "projects.import.scan": {
+      await refreshShellIndex(getDesktopWorkingDirectory());
       return handledAction({
         projects: await scanKnownProjects(getProjectIds(payload)),
       });
+    }
 
-    case "projects.import.apply":
+    case "projects.import.apply": {
+      await refreshShellIndex(getDesktopWorkingDirectory());
       return handledAction(await importProjects(getProjectIds(payload)));
+    }
 
     default:
       return unhandledAction();

--- a/desktop/pi-threads/project-import-refresh.ts
+++ b/desktop/pi-threads/project-import-refresh.ts
@@ -1,0 +1,19 @@
+export type ProjectImportRefreshMode = "scan" | "import";
+
+export function getProjectImportRefreshError({
+  mode,
+  projectIds,
+  refreshed,
+}: {
+  mode: ProjectImportRefreshMode;
+  projectIds: string[];
+  refreshed: boolean;
+}) {
+  if (refreshed || projectIds.length > 0) {
+    return null;
+  }
+
+  return mode === "scan"
+    ? "Could not refresh Pi sessions before scanning projects."
+    : "Could not refresh Pi sessions before importing projects.";
+}

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -40,7 +40,7 @@ import { setWatchedSessionPath } from "./session-watch.cts";
 export { loadInboxThreadList } from "./thread-loader.cts";
 
 const syncedShellIndexes = new Set<string>();
-const inFlightShellIndexSyncs = new Map<string, Promise<void>>();
+const inFlightShellIndexSyncs = new Map<string, Promise<boolean>>();
 
 type SessionSummary = {
   id: string;
@@ -63,6 +63,7 @@ type SessionFileEntry = {
   cwd?: string;
   message?: {
     role?: string;
+    timestamp?: number;
     content?: string | Array<{ type?: string; text?: string }>;
   };
   name?: string;
@@ -122,16 +123,56 @@ function getMessageText(entry: SessionFileEntry) {
   return "";
 }
 
+function getEntryTimestampMs(entry: SessionFileEntry) {
+  if (typeof entry.message?.timestamp === "number") {
+    return entry.message.timestamp;
+  }
+
+  if (typeof entry.timestamp !== "string") {
+    return null;
+  }
+
+  const timestampMs = Date.parse(entry.timestamp);
+  return Number.isNaN(timestampMs) ? null : timestampMs;
+}
+
+function getSessionModifiedDate(
+  entries: SessionFileEntry[],
+  header: SessionFileEntry,
+  fileModified: Date,
+) {
+  let lastActivityTimeMs: number | null = null;
+
+  for (const entry of entries) {
+    if (
+      entry.type !== "message" ||
+      (entry.message?.role !== "user" && entry.message?.role !== "assistant")
+    ) {
+      continue;
+    }
+
+    const entryTimestampMs = getEntryTimestampMs(entry);
+    if (entryTimestampMs !== null) {
+      lastActivityTimeMs = Math.max(lastActivityTimeMs ?? 0, entryTimestampMs);
+    }
+  }
+
+  if (lastActivityTimeMs !== null) {
+    return new Date(lastActivityTimeMs);
+  }
+
+  const headerTimestampMs =
+    typeof header.timestamp === "string" ? Date.parse(header.timestamp) : Number.NaN;
+  return Number.isNaN(headerTimestampMs) ? fileModified : new Date(headerTimestampMs);
+}
+
 async function readSessionSummary(filePath: string): Promise<SessionSummary | null> {
   let content: string;
   try {
     content = await readFile(filePath, "utf8");
   } catch (error) {
-    if (isNodeErrorWithCode(error, "ENOENT")) {
-      return null;
-    }
-
-    throw error;
+    console.warn(`Failed to read session file while refreshing shell index: ${filePath}`, error);
+    return null;
   }
 
   const entries = content
@@ -165,9 +206,13 @@ async function readSessionSummary(filePath: string): Promise<SessionSummary | nu
     }
   }
 
-  const fileStat = await stat(filePath);
-  const headerTimestamp =
-    typeof header.timestamp === "string" ? Date.parse(header.timestamp) : Number.NaN;
+  let fileStat: Awaited<ReturnType<typeof stat>>;
+  try {
+    fileStat = await stat(filePath);
+  } catch (error) {
+    console.warn(`Failed to stat session file while refreshing shell index: ${filePath}`, error);
+    return null;
+  }
 
   return {
     id: header.id,
@@ -175,7 +220,7 @@ async function readSessionSummary(filePath: string): Promise<SessionSummary | nu
     path: filePath,
     name,
     firstMessage: firstMessage || "(no messages)",
-    modified: Number.isNaN(headerTimestamp) ? fileStat.mtime : new Date(headerTimestamp),
+    modified: getSessionModifiedDate(entries, header, fileStat.mtime),
   };
 }
 
@@ -251,9 +296,11 @@ function scheduleShellIndexSync(cwd: string) {
     .then(() => {
       syncedShellIndexes.add(cwd);
       emitDesktopEvent({ type: "shell-state-refresh" });
+      return true;
     })
     .catch((error) => {
       console.warn("Failed to sync shell index.", error);
+      return false;
     })
     .finally(() => {
       inFlightShellIndexSyncs.delete(cwd);
@@ -265,10 +312,9 @@ function scheduleShellIndexSync(cwd: string) {
 export async function refreshShellIndex(cwd: string, options: { emitRefreshEvent?: boolean } = {}) {
   const inFlightSync = inFlightShellIndexSyncs.get(cwd);
   if (inFlightSync) {
-    try {
-      await inFlightSync;
-    } catch (error) {
-      console.warn("Failed to wait for shell index sync before refresh.", error);
+    const synced = await inFlightSync;
+    if (synced) {
+      return true;
     }
   }
 

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -1,4 +1,4 @@
-import { realpath } from "node:fs/promises";
+import { readFile, readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import type {
   ComposerState,
@@ -56,6 +56,18 @@ type SessionStorage = {
   sessionDir: string | null;
 };
 
+type SessionFileEntry = {
+  type?: string;
+  id?: string;
+  timestamp?: string;
+  cwd?: string;
+  message?: {
+    role?: string;
+    content?: string | Array<{ type?: string; text?: string }>;
+  };
+  name?: string;
+};
+
 function mapSessionSummaryToRecord(cwd: string, session: SessionSummary) {
   return {
     id: session.id,
@@ -76,6 +88,120 @@ async function getSessionStorage(cwd: string): Promise<SessionStorage> {
     agentDir,
     sessionDir: configuredSessionDir ?? null,
   };
+}
+
+function isNodeErrorWithCode(error: unknown, code: string) {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
+async function readDirectoryIfPresent(directoryPath: string) {
+  try {
+    return await readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+function getMessageText(entry: SessionFileEntry) {
+  const content = entry.message?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .filter((block) => block.type === "text" && typeof block.text === "string")
+      .map((block) => block.text)
+      .join(" ");
+  }
+
+  return "";
+}
+
+async function readSessionSummary(filePath: string): Promise<SessionSummary | null> {
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
+      return null;
+    }
+
+    throw error;
+  }
+
+  const entries = content
+    .trim()
+    .split("\n")
+    .flatMap((line) => {
+      if (!line.trim()) {
+        return [];
+      }
+
+      try {
+        return [JSON.parse(line) as SessionFileEntry];
+      } catch {
+        return [];
+      }
+    });
+  const header = entries[0];
+  if (!header || header.type !== "session" || typeof header.id !== "string") {
+    return null;
+  }
+
+  let firstMessage = "";
+  let name: string | undefined;
+  for (const entry of entries) {
+    if (entry.type === "session_info") {
+      name = entry.name?.trim() || undefined;
+    }
+
+    if (!firstMessage && entry.type === "message" && entry.message?.role === "user") {
+      firstMessage = getMessageText(entry);
+    }
+  }
+
+  const fileStat = await stat(filePath);
+  const headerTimestamp =
+    typeof header.timestamp === "string" ? Date.parse(header.timestamp) : Number.NaN;
+
+  return {
+    id: header.id,
+    cwd: typeof header.cwd === "string" ? header.cwd : undefined,
+    path: filePath,
+    name,
+    firstMessage: firstMessage || "(no messages)",
+    modified: Number.isNaN(headerTimestamp) ? fileStat.mtime : new Date(headerTimestamp),
+  };
+}
+
+async function listAllSessionsStrict(): Promise<SessionSummary[]> {
+  const { getAgentDir } = await getPiModule();
+  const sessionsDir = path.join(getAgentDir(), "sessions");
+  const sessionDirectories = (await readDirectoryIfPresent(sessionsDir)).filter((entry) =>
+    entry.isDirectory(),
+  );
+  const sessionFilePaths: string[] = [];
+
+  for (const sessionDirectory of sessionDirectories) {
+    const sessionDirectoryPath = path.join(sessionsDir, sessionDirectory.name);
+    const sessionFiles = await readDirectoryIfPresent(sessionDirectoryPath);
+    sessionFilePaths.push(
+      ...sessionFiles
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .map((entry) => path.join(sessionDirectoryPath, entry.name)),
+    );
+  }
+
+  const sessions = (await Promise.all(sessionFilePaths.map(readSessionSummary))).filter(
+    (session): session is SessionSummary => session !== null,
+  );
+  sessions.sort((left, right) => right.modified.getTime() - left.modified.getTime());
+  return sessions;
 }
 
 async function resolveProjectPathForComparison(projectId: string) {
@@ -108,8 +234,7 @@ async function enrichProjectsWithResolvedIds(projects: Project[]) {
 }
 
 async function syncShellIndex(cwd: string) {
-  const { SessionManager } = await getPiModule();
-  const sessions = (await SessionManager.listAll()) as SessionSummary[];
+  const sessions = await listAllSessionsStrict();
 
   syncSessionSummaries(
     cwd,
@@ -137,7 +262,7 @@ function scheduleShellIndexSync(cwd: string) {
   inFlightShellIndexSyncs.set(cwd, syncPromise);
 }
 
-export async function refreshShellIndex(cwd: string) {
+export async function refreshShellIndex(cwd: string, options: { emitRefreshEvent?: boolean } = {}) {
   const inFlightSync = inFlightShellIndexSyncs.get(cwd);
   if (inFlightSync) {
     try {
@@ -150,7 +275,9 @@ export async function refreshShellIndex(cwd: string) {
   try {
     await syncShellIndex(cwd);
     syncedShellIndexes.add(cwd);
-    emitDesktopEvent({ type: "shell-state-refresh" });
+    if (options.emitRefreshEvent ?? true) {
+      emitDesktopEvent({ type: "shell-state-refresh" });
+    }
     return true;
   } catch (error) {
     console.warn("Failed to refresh shell index.", error);

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -151,8 +151,10 @@ export async function refreshShellIndex(cwd: string) {
     await syncShellIndex(cwd);
     syncedShellIndexes.add(cwd);
     emitDesktopEvent({ type: "shell-state-refresh" });
+    return true;
   } catch (error) {
     console.warn("Failed to refresh shell index.", error);
+    return false;
   }
 }
 

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -140,12 +140,20 @@ function scheduleShellIndexSync(cwd: string) {
 export async function refreshShellIndex(cwd: string) {
   const inFlightSync = inFlightShellIndexSyncs.get(cwd);
   if (inFlightSync) {
-    await inFlightSync;
+    try {
+      await inFlightSync;
+    } catch (error) {
+      console.warn("Failed to wait for shell index sync before refresh.", error);
+    }
   }
 
-  await syncShellIndex(cwd);
-  syncedShellIndexes.add(cwd);
-  emitDesktopEvent({ type: "shell-state-refresh" });
+  try {
+    await syncShellIndex(cwd);
+    syncedShellIndexes.add(cwd);
+    emitDesktopEvent({ type: "shell-state-refresh" });
+  } catch (error) {
+    console.warn("Failed to refresh shell index.", error);
+  }
 }
 
 export async function loadShellState(cwd: string): Promise<ShellState> {

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -1,5 +1,7 @@
-import { readFile, readdir, realpath, stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import type {
   ComposerState,
   ComposerStateRequest,
@@ -137,26 +139,10 @@ function getEntryTimestampMs(entry: SessionFileEntry) {
 }
 
 function getSessionModifiedDate(
-  entries: SessionFileEntry[],
   header: SessionFileEntry,
+  lastActivityTimeMs: number | null,
   fileModified: Date,
 ) {
-  let lastActivityTimeMs: number | null = null;
-
-  for (const entry of entries) {
-    if (
-      entry.type !== "message" ||
-      (entry.message?.role !== "user" && entry.message?.role !== "assistant")
-    ) {
-      continue;
-    }
-
-    const entryTimestampMs = getEntryTimestampMs(entry);
-    if (entryTimestampMs !== null) {
-      lastActivityTimeMs = Math.max(lastActivityTimeMs ?? 0, entryTimestampMs);
-    }
-  }
-
   if (lastActivityTimeMs !== null) {
     return new Date(lastActivityTimeMs);
   }
@@ -167,45 +153,6 @@ function getSessionModifiedDate(
 }
 
 async function readSessionSummary(filePath: string): Promise<SessionSummary | null> {
-  let content: string;
-  try {
-    content = await readFile(filePath, "utf8");
-  } catch (error) {
-    console.warn(`Failed to read session file while refreshing shell index: ${filePath}`, error);
-    return null;
-  }
-
-  const entries = content
-    .trim()
-    .split("\n")
-    .flatMap((line) => {
-      if (!line.trim()) {
-        return [];
-      }
-
-      try {
-        return [JSON.parse(line) as SessionFileEntry];
-      } catch {
-        return [];
-      }
-    });
-  const header = entries[0];
-  if (!header || header.type !== "session" || typeof header.id !== "string") {
-    return null;
-  }
-
-  let firstMessage = "";
-  let name: string | undefined;
-  for (const entry of entries) {
-    if (entry.type === "session_info") {
-      name = entry.name?.trim() || undefined;
-    }
-
-    if (!firstMessage && entry.type === "message" && entry.message?.role === "user") {
-      firstMessage = getMessageText(entry);
-    }
-  }
-
   let fileStat: Awaited<ReturnType<typeof stat>>;
   try {
     fileStat = await stat(filePath);
@@ -214,13 +161,65 @@ async function readSessionSummary(filePath: string): Promise<SessionSummary | nu
     return null;
   }
 
+  let header: SessionFileEntry | undefined;
+  let firstMessage: string | undefined;
+  let name: string | undefined;
+  let lastActivityTimeMs: number | null = null;
+
+  try {
+    const lines = createInterface({
+      input: createReadStream(filePath, { encoding: "utf8" }),
+      crlfDelay: Number.POSITIVE_INFINITY,
+    });
+
+    for await (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+
+      let entry: SessionFileEntry;
+      try {
+        entry = JSON.parse(line) as SessionFileEntry;
+      } catch {
+        continue;
+      }
+
+      header ??= entry;
+
+      if (entry.type === "session_info") {
+        name = entry.name?.trim() || undefined;
+      }
+
+      if (!firstMessage && entry.type === "message" && entry.message?.role === "user") {
+        firstMessage = getMessageText(entry) || undefined;
+      }
+
+      if (
+        entry.type === "message" &&
+        (entry.message?.role === "user" || entry.message?.role === "assistant")
+      ) {
+        const entryTimestampMs = getEntryTimestampMs(entry);
+        if (entryTimestampMs !== null) {
+          lastActivityTimeMs = Math.max(lastActivityTimeMs ?? 0, entryTimestampMs);
+        }
+      }
+    }
+  } catch (error) {
+    console.warn(`Failed to read session file while refreshing shell index: ${filePath}`, error);
+    return null;
+  }
+
+  if (!header || header.type !== "session" || typeof header.id !== "string") {
+    return null;
+  }
+
   return {
     id: header.id,
     cwd: typeof header.cwd === "string" ? header.cwd : undefined,
     path: filePath,
     name,
-    firstMessage: firstMessage || "(no messages)",
-    modified: getSessionModifiedDate(entries, header, fileStat.mtime),
+    firstMessage,
+    modified: getSessionModifiedDate(header, lastActivityTimeMs, fileStat.mtime),
   };
 }
 
@@ -234,7 +233,17 @@ async function listAllSessionsStrict(): Promise<SessionSummary[]> {
 
   for (const sessionDirectory of sessionDirectories) {
     const sessionDirectoryPath = path.join(sessionsDir, sessionDirectory.name);
-    const sessionFiles = await readDirectoryIfPresent(sessionDirectoryPath);
+    let sessionFiles: Awaited<ReturnType<typeof readDirectoryIfPresent>>;
+    try {
+      sessionFiles = await readDirectoryIfPresent(sessionDirectoryPath);
+    } catch (error) {
+      console.warn(
+        `Failed to read session directory while refreshing shell index: ${sessionDirectoryPath}`,
+        error,
+      );
+      continue;
+    }
+
     sessionFilePaths.push(
       ...sessionFiles
         .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -137,6 +137,17 @@ function scheduleShellIndexSync(cwd: string) {
   inFlightShellIndexSyncs.set(cwd, syncPromise);
 }
 
+export async function refreshShellIndex(cwd: string) {
+  const inFlightSync = inFlightShellIndexSyncs.get(cwd);
+  if (inFlightSync) {
+    await inFlightSync;
+  }
+
+  await syncShellIndex(cwd);
+  syncedShellIndexes.add(cwd);
+  emitDesktopEvent({ type: "shell-state-refresh" });
+}
+
 export async function loadShellState(cwd: string): Promise<ShellState> {
   const { SessionManager } = await getPiModule();
   const { agentDir, sessionDir } = await getSessionStorage(cwd);

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -13,7 +13,6 @@ import { useSettingsDictationController } from "./useSettingsDictationController
 
 export function useSettingsController({
   appSettings,
-  projects,
   onAction,
 }: {
   appSettings: AppSettings;
@@ -102,7 +101,7 @@ export function useSettingsController({
 
     try {
       const result = await onAction("projects.import.apply", {
-        projectIds: projects.map((project) => project.id),
+        projectIds: [],
       });
       const error = getActionError(result);
       if (error) {

--- a/src/test/project-import-refresh.test.ts
+++ b/src/test/project-import-refresh.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getProjectImportRefreshError } from "../../desktop/pi-threads/project-import-refresh";
+
+describe("project import refresh gating", () => {
+  it("allows import-all after a successful shell index refresh", () => {
+    expect(
+      getProjectImportRefreshError({ mode: "import", projectIds: [], refreshed: true }),
+    ).toBeNull();
+  });
+
+  it("blocks import-all when the shell index refresh fails", () => {
+    expect(getProjectImportRefreshError({ mode: "import", projectIds: [], refreshed: false })).toBe(
+      "Could not refresh Pi sessions before importing projects.",
+    );
+  });
+
+  it("keeps explicit project imports best-effort when refresh fails", () => {
+    expect(
+      getProjectImportRefreshError({ mode: "scan", projectIds: ["/repo"], refreshed: false }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- adds an explicit shell-index refresh path for user-triggered project import flows
- refreshes Pi session discovery before project import scan/apply so sessions created externally after app launch can land in the local project DB
- keeps the existing post-import shell refresh so the sidebar can pick up newly discovered projects/threads immediately

## Validation
- pre-commit: `bun run typecheck:web && bun run typecheck:desktop && bun run typecheck:electron && bun run typecheck:scripts`, `vitest run`
- pre-push: `bun run lint && bun run typecheck`

Closes #82
