### PR TITLE
Polish secondary view accessibility

### DIFF
--- a/src/app/components/common/SegmentedToggle.tsx
+++ b/src/app/components/common/SegmentedToggle.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { segmentedControlClass, segmentedControlOptionClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
 
@@ -11,6 +12,7 @@ type SegmentedToggleProps<T extends string> = {
   value: T;
   options: readonly SegmentedToggleOption<T>[];
   onChange: (value: T) => void;
+  ariaLabel?: string;
   size?: "default" | "compact";
 };
 
@@ -18,30 +20,41 @@ export function SegmentedToggle<T extends string>({
   value,
   options,
   onChange,
+  ariaLabel,
   size = "default",
 }: SegmentedToggleProps<T>) {
   const compact = size === "compact";
+  const groupName = useId();
 
   return (
-    <div className={cn(segmentedControlClass, compact && "p-[3px]")}>
+    <fieldset className={cn(segmentedControlClass, "m-0 min-w-0", compact && "p-[3px]")}>
+      {ariaLabel ? <legend className="sr-only">{ariaLabel}</legend> : null}
       {options.map((option) => (
-        <button
+        <label
           key={option.value}
-          type="button"
           className={cn(
             segmentedControlOptionClass,
+            "cursor-pointer has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-[color:var(--accent)]",
             compact && "px-2.5 py-1 text-[11.5px] leading-4",
             value === option.value
               ? "bg-[rgba(255,255,255,0.18)] font-medium text-[color:var(--text)] shadow-[inset_0_0_0_1px_rgba(183,186,245,0.5)]"
               : "text-[color:var(--muted)] hover:text-[color:var(--text)]",
+            option.disabled &&
+              "cursor-not-allowed opacity-45 hover:text-[color:var(--muted)] has-[:focus-visible]:outline-0",
           )}
-          onClick={() => onChange(option.value)}
-          aria-pressed={value === option.value}
-          disabled={option.disabled}
         >
+          <input
+            type="radio"
+            name={groupName}
+            value={option.value}
+            checked={value === option.value}
+            disabled={option.disabled}
+            className="sr-only"
+            onChange={() => onChange(option.value)}
+          />
           {option.label}
-        </button>
+        </label>
       ))}
-    </div>
+    </fieldset>
   );
 }

--- a/src/app/features/extensions/ExtensionsView.tsx
+++ b/src/app/features/extensions/ExtensionsView.tsx
@@ -24,6 +24,7 @@ function ExtensionsScopeToggle({
   return (
     <SegmentedToggle
       size="compact"
+      ariaLabel="Extension install scope"
       value={installScope}
       options={[
         { value: "global", label: `Global (${globalInstalledCount})` },

--- a/src/app/features/extensions/components/InstallExtensionsSection.tsx
+++ b/src/app/features/extensions/components/InstallExtensionsSection.tsx
@@ -58,6 +58,7 @@ export function InstallExtensionsSection({
         }}
       >
         <SegmentedToggle
+          ariaLabel="Extension source type"
           value={manualSourceKind}
           options={sourceKindOptions}
           onChange={onManualSourceKindChange}

--- a/src/app/features/skills/SkillsView.tsx
+++ b/src/app/features/skills/SkillsView.tsx
@@ -73,6 +73,7 @@ export function SkillsView({
         actions={
           <SegmentedToggle
             size="compact"
+            ariaLabel="Skill install scope"
             value={controller.installScope}
             options={[
               { value: "global", label: `Global (${controller.globalSkillCount})` },

--- a/src/app/features/skills/components/BrowseSkillsSection.tsx
+++ b/src/app/features/skills/components/BrowseSkillsSection.tsx
@@ -104,7 +104,11 @@ export function BrowseSkillsSection({
   };
 
   const browseSectionContent =
-    submittedSearchInput.length < 2 ? null : skillsQuery.isLoading ? (
+    submittedSearchInput.length < 2 ? (
+      <EmptyStateCard>
+        Search with at least 2 characters to browse installable skills.
+      </EmptyStateCard>
+    ) : skillsQuery.isLoading ? (
       <div className="rounded-xl border border-[color:var(--border)] px-3 py-4 text-[12px] text-[color:var(--muted)]">
         Loading skills…
       </div>
@@ -117,12 +121,10 @@ export function BrowseSkillsSection({
         {catalogItems.map((item) => {
           const installed = installedSkillSlugs.has(normalizeSkillSlug(item.skillId));
           const pendingInstall = isPendingInstall(getCatalogSkillSource(item));
-          const installLabel = pendingInstall
-            ? `Installing ${item.name}`
-            : installed
-              ? `${item.name} installed`
-              : `Install ${item.name}`;
           const selected = selectedCatalogSources.includes(item.identityKey);
+          const selectionLabel = selected
+            ? `Deselect ${item.name}`
+            : `Select ${item.name} for install`;
 
           return (
             <CompactMetaRow
@@ -131,11 +133,15 @@ export function BrowseSkillsSection({
               actions={
                 <span className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[color:var(--muted)]">
                   {pendingInstall ? (
-                    <Sparkles size={14} />
+                    <output aria-label={`Installing ${item.name}`}>
+                      <Sparkles size={14} />
+                    </output>
                   ) : installed ? (
-                    <Check size={14} strokeWidth={2.4} />
+                    <span aria-label={`${item.name} installed`}>
+                      <Check size={14} strokeWidth={2.4} />
+                    </span>
                   ) : (
-                    <Tooltip content={installLabel}>
+                    <Tooltip content={selectionLabel}>
                       <button
                         type="button"
                         className={compactRoundIconButtonClass}
@@ -147,7 +153,7 @@ export function BrowseSkillsSection({
                           );
                         }}
                         aria-pressed={selected}
-                        aria-label={installLabel}
+                        aria-label={selectionLabel}
                       >
                         <span
                           className={cn(

--- a/src/app/views/LandingView.tsx
+++ b/src/app/views/LandingView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type KeyboardEvent, useState } from "react";
 import { MarkdownContent } from "../components/common/MarkdownContent";
 import type { AppSettings, DesktopActionInvoker } from "../desktop/types";
 import type { Project } from "../types";
@@ -82,6 +82,20 @@ export function LandingView({ className }: LandingViewProps) {
   const content = getLandingOverviewContent();
   const [activeSection, setActiveSection] = useState<"roadmap" | "changelog">("roadmap");
   const activeContent = activeSection === "roadmap" ? content.roadmap : content.changelog;
+  const activePanelId = "landing-overview-panel";
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+      return;
+    }
+
+    event.preventDefault();
+    const nextSection = activeSection === "roadmap" ? "changelog" : "roadmap";
+    setActiveSection(nextSection);
+    window.requestAnimationFrame(() => {
+      document.getElementById(`landing-${nextSection}-tab`)?.focus();
+    });
+  };
 
   return (
     <section
@@ -92,11 +106,18 @@ export function LandingView({ className }: LandingViewProps) {
     >
       <div className="grid w-full max-w-[760px] justify-items-center gap-8 text-center">
         <PixelHLogo />
+        <h1 className="sr-only">{content.title}</h1>
 
         <div className="grid w-full max-w-[680px] gap-0">
-          <div className="grid grid-cols-2 border-b border-[rgba(169,178,215,0.08)]">
+          <div
+            className="grid grid-cols-2 border-b border-[rgba(169,178,215,0.08)]"
+            role="tablist"
+            aria-label={content.title}
+          >
             <button
               type="button"
+              id="landing-roadmap-tab"
+              role="tab"
               className={cn(
                 "border-b px-0 py-4 text-center text-[15px] font-medium transition-colors",
                 activeSection === "roadmap"
@@ -104,13 +125,18 @@ export function LandingView({ className }: LandingViewProps) {
                   : "border-transparent text-[color:var(--muted)] hover:text-[color:var(--text)]",
               )}
               onClick={() => setActiveSection("roadmap")}
-              aria-pressed={activeSection === "roadmap"}
+              onKeyDown={handleTabKeyDown}
+              aria-selected={activeSection === "roadmap"}
+              aria-controls={activePanelId}
+              tabIndex={activeSection === "roadmap" ? 0 : -1}
             >
               {content.roadmap.title}
             </button>
 
             <button
               type="button"
+              id="landing-changelog-tab"
+              role="tab"
               className={cn(
                 "border-b px-0 py-4 text-center text-[15px] font-medium transition-colors",
                 activeSection === "changelog"
@@ -118,13 +144,21 @@ export function LandingView({ className }: LandingViewProps) {
                   : "border-transparent text-[color:var(--muted)] hover:text-[color:var(--text)]",
               )}
               onClick={() => setActiveSection("changelog")}
-              aria-pressed={activeSection === "changelog"}
+              onKeyDown={handleTabKeyDown}
+              aria-selected={activeSection === "changelog"}
+              aria-controls={activePanelId}
+              tabIndex={activeSection === "changelog" ? 0 : -1}
             >
               {content.changelog.title}
             </button>
           </div>
 
-          <div className="pt-4 text-left">
+          <div
+            id={activePanelId}
+            className="pt-4 text-left"
+            role="tabpanel"
+            aria-labelledby={`landing-${activeSection}-tab`}
+          >
             <MarkdownContent markdown={activeContent.markdown} className="gap-2 text-[13px]" />
           </div>
         </div>

--- a/src/app/views/settings/SettingsProjectDefaultsSection.tsx
+++ b/src/app/views/settings/SettingsProjectDefaultsSection.tsx
@@ -74,6 +74,7 @@ export function SettingsProjectDefaultsSection({
             </div>
           </div>
           <SegmentedToggle
+            ariaLabel="Send while Pi is responding"
             value={appSettings.composerStreamingBehavior}
             options={
               [
@@ -119,6 +120,7 @@ export function SettingsProjectDefaultsSection({
             </div>
           </div>
           <SegmentedToggle
+            ariaLabel="Project deletion cleanup"
             value={appSettings.projectDeletionMode}
             options={
               [


### PR DESCRIPTION
## Summary
- gives segmented controls native radio-group semantics with labels and keyboard behavior
- adds live-region announcements for Skills and Extensions action errors
- gives the landing overview an h1 and tab semantics for the roadmap/changelog switcher
- adds initial guidance to Skills browse before a valid search is submitted
- clarifies skill selection/install state labels for screen-reader users

## Validation
- `bun run typecheck:web`
- pre-commit: `bun run typecheck:web && bun run typecheck:desktop && bun run typecheck:electron && bun run typecheck:scripts`, `vitest run`
- pre-push: `bun run lint && bun run typecheck`

Closes #92
