### PR TITLE
Follow up project import refresh hardening

### DIFF
--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -32,7 +32,7 @@ import {
 } from "../thread-state-db.cts";
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
-import { getProjectImportRefreshError } from "./project-import-refresh.ts";
+import { resolveProjectImportActionResult } from "./project-import-action.ts";
 import { refreshShellIndex } from "./shell-loader.cts";
 
 async function unlinkIfPresent(filePath: string) {
@@ -311,40 +311,31 @@ export async function handleProjectDesktopAction(
 
     case "projects.import.scan": {
       const projectIds = getProjectIds(payload);
-      const refreshed = await refreshShellIndex(getDesktopWorkingDirectory());
-      const refreshError = getProjectImportRefreshError({
-        mode: "scan",
-        projectIds,
-        refreshed,
-      });
-      if (refreshError) {
-        return handledAction({
-          error: refreshError,
-        });
-      }
-
-      return handledAction({
-        projects: await scanKnownProjects(projectIds),
-      });
+      return handledAction(
+        await resolveProjectImportActionResult({
+          cwd: getDesktopWorkingDirectory(),
+          mode: "scan",
+          projectIds,
+          refreshShellIndex,
+          runAfterRefresh: async (refreshedProjectIds) => ({
+            projects: await scanKnownProjects(refreshedProjectIds),
+          }),
+        }),
+      );
     }
 
     case "projects.import.apply": {
       const projectIds = getProjectIds(payload);
-      const refreshed = await refreshShellIndex(getDesktopWorkingDirectory(), {
-        emitRefreshEvent: false,
-      });
-      const refreshError = getProjectImportRefreshError({
-        mode: "import",
-        projectIds,
-        refreshed,
-      });
-      if (refreshError) {
-        return handledAction({
-          error: refreshError,
-        });
-      }
-
-      return handledAction(await importProjects(projectIds));
+      return handledAction(
+        await resolveProjectImportActionResult({
+          cwd: getDesktopWorkingDirectory(),
+          mode: "import",
+          projectIds,
+          refreshOptions: { emitRefreshEvent: false },
+          refreshShellIndex,
+          runAfterRefresh: importProjects,
+        }),
+      );
     }
 
     default:

--- a/desktop/pi-threads/project-import-action.ts
+++ b/desktop/pi-threads/project-import-action.ts
@@ -1,0 +1,40 @@
+import type { DesktopActionResultData } from "../../shared/desktop-contracts";
+import {
+  getProjectImportRefreshError,
+  type ProjectImportRefreshMode,
+} from "./project-import-refresh";
+
+export type ProjectImportRefreshOptions = {
+  emitRefreshEvent?: boolean;
+};
+
+export async function resolveProjectImportActionResult<T extends DesktopActionResultData>({
+  cwd,
+  mode,
+  projectIds,
+  refreshOptions,
+  refreshShellIndex,
+  runAfterRefresh,
+}: {
+  cwd: string;
+  mode: ProjectImportRefreshMode;
+  projectIds: string[];
+  refreshOptions?: ProjectImportRefreshOptions;
+  refreshShellIndex: (cwd: string, options?: ProjectImportRefreshOptions) => Promise<boolean>;
+  runAfterRefresh: (projectIds: string[]) => Promise<T>;
+}) {
+  const refreshed = await refreshShellIndex(cwd, refreshOptions);
+  const refreshError = getProjectImportRefreshError({
+    mode,
+    projectIds,
+    refreshed,
+  });
+
+  if (refreshError) {
+    return {
+      error: refreshError,
+    } satisfies DesktopActionResultData;
+  }
+
+  return await runAfterRefresh(projectIds);
+}

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -71,6 +71,21 @@ type SessionFileEntry = {
   name?: string;
 };
 
+type SessionSummaryReadResult = {
+  summary: SessionSummary | null;
+  failed: boolean;
+};
+
+type SessionIndexReadResult = {
+  sessions: SessionSummary[];
+  partialFailure: boolean;
+};
+
+type ShellIndexSyncResult = {
+  complete: boolean;
+  didSync: boolean;
+};
+
 function mapSessionSummaryToRecord(cwd: string, session: SessionSummary) {
   return {
     id: session.id,
@@ -152,13 +167,17 @@ function getSessionModifiedDate(
   return Number.isNaN(headerTimestampMs) ? fileModified : new Date(headerTimestampMs);
 }
 
-async function readSessionSummary(filePath: string): Promise<SessionSummary | null> {
+async function readSessionSummary(filePath: string): Promise<SessionSummaryReadResult> {
   let fileStat: Awaited<ReturnType<typeof stat>>;
   try {
     fileStat = await stat(filePath);
   } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
+      return { summary: null, failed: false };
+    }
+
     console.warn(`Failed to stat session file while refreshing shell index: ${filePath}`, error);
-    return null;
+    return { summary: null, failed: true };
   }
 
   let header: SessionFileEntry | undefined;
@@ -205,25 +224,33 @@ async function readSessionSummary(filePath: string): Promise<SessionSummary | nu
       }
     }
   } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
+      return { summary: null, failed: false };
+    }
+
     console.warn(`Failed to read session file while refreshing shell index: ${filePath}`, error);
-    return null;
+    return { summary: null, failed: true };
   }
 
   if (!header || header.type !== "session" || typeof header.id !== "string") {
-    return null;
+    console.warn(`Invalid session header while refreshing shell index: ${filePath}`);
+    return { summary: null, failed: true };
   }
 
   return {
-    id: header.id,
-    cwd: typeof header.cwd === "string" ? header.cwd : undefined,
-    path: filePath,
-    name,
-    firstMessage,
-    modified: getSessionModifiedDate(header, lastActivityTimeMs, fileStat.mtime),
+    summary: {
+      id: header.id,
+      cwd: typeof header.cwd === "string" ? header.cwd : undefined,
+      path: filePath,
+      name,
+      firstMessage,
+      modified: getSessionModifiedDate(header, lastActivityTimeMs, fileStat.mtime),
+    },
+    failed: false,
   };
 }
 
-async function listAllSessionsStrict(): Promise<SessionSummary[]> {
+async function listAllSessionsStrict(): Promise<SessionIndexReadResult> {
   const { getAgentDir } = await getPiModule();
   const sessionsDir = path.join(getAgentDir(), "sessions");
   const sessionDirectories = (await readDirectoryIfPresent(sessionsDir)).filter((entry) =>
@@ -231,31 +258,42 @@ async function listAllSessionsStrict(): Promise<SessionSummary[]> {
   );
   const sessionFilePaths: string[] = [];
 
-  for (const sessionDirectory of sessionDirectories) {
-    const sessionDirectoryPath = path.join(sessionsDir, sessionDirectory.name);
-    let sessionFiles: Awaited<ReturnType<typeof readDirectoryIfPresent>>;
-    try {
-      sessionFiles = await readDirectoryIfPresent(sessionDirectoryPath);
-    } catch (error) {
-      console.warn(
-        `Failed to read session directory while refreshing shell index: ${sessionDirectoryPath}`,
-        error,
-      );
-      continue;
-    }
+  const sessionDirectoryResults = await Promise.all(
+    sessionDirectories.map(async (sessionDirectory) => {
+      const sessionDirectoryPath = path.join(sessionsDir, sessionDirectory.name);
 
-    sessionFilePaths.push(
-      ...sessionFiles
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
-        .map((entry) => path.join(sessionDirectoryPath, entry.name)),
-    );
+      let sessionFiles: Awaited<ReturnType<typeof readDirectoryIfPresent>>;
+      try {
+        sessionFiles = await readDirectoryIfPresent(sessionDirectoryPath);
+      } catch (error) {
+        console.warn(
+          `Failed to read session directory while refreshing shell index: ${sessionDirectoryPath}`,
+          error,
+        );
+        return { filePaths: [], failed: true };
+      }
+
+      return {
+        filePaths: sessionFiles
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+          .map((entry) => path.join(sessionDirectoryPath, entry.name)),
+        failed: false,
+      };
+    }),
+  );
+
+  let partialFailure = sessionDirectoryResults.some((result) => result.failed);
+  for (const result of sessionDirectoryResults) {
+    sessionFilePaths.push(...result.filePaths);
   }
 
-  const sessions = (await Promise.all(sessionFilePaths.map(readSessionSummary))).filter(
-    (session): session is SessionSummary => session !== null,
-  );
+  const sessionResults = await Promise.all(sessionFilePaths.map(readSessionSummary));
+  const sessions = sessionResults
+    .map((result) => result.summary)
+    .filter((session): session is SessionSummary => session !== null);
+  partialFailure ||= sessionResults.some((result) => result.failed);
   sessions.sort((left, right) => right.modified.getTime() - left.modified.getTime());
-  return sessions;
+  return { sessions, partialFailure };
 }
 
 async function resolveProjectPathForComparison(projectId: string) {
@@ -287,28 +325,35 @@ async function enrichProjectsWithResolvedIds(projects: Project[]) {
   );
 }
 
-async function syncShellIndex(cwd: string) {
-  const sessions = await listAllSessionsStrict();
+async function syncShellIndex(cwd: string): Promise<ShellIndexSyncResult> {
+  const { sessions, partialFailure } = await listAllSessionsStrict();
 
   syncSessionSummaries(
     cwd,
     sessions.map((session) => mapSessionSummaryToRecord(cwd, session)),
   );
+
+  return { complete: !partialFailure, didSync: true };
 }
 
-function scheduleShellIndexSync(cwd: string) {
-  if (syncedShellIndexes.has(cwd) || inFlightShellIndexSyncs.has(cwd)) {
-    return;
-  }
-
+function startShellIndexSync(
+  cwd: string,
+  options: { emitRefreshEvent?: boolean; warningLabel: string },
+) {
   const syncPromise = syncShellIndex(cwd)
-    .then(() => {
-      syncedShellIndexes.add(cwd);
-      emitDesktopEvent({ type: "shell-state-refresh" });
-      return true;
+    .then((syncResult) => {
+      if (syncResult.complete) {
+        syncedShellIndexes.add(cwd);
+      }
+
+      if (syncResult.didSync && (options.emitRefreshEvent ?? true)) {
+        emitDesktopEvent({ type: "shell-state-refresh" });
+      }
+
+      return syncResult.complete;
     })
     .catch((error) => {
-      console.warn("Failed to sync shell index.", error);
+      console.warn(options.warningLabel, error);
       return false;
     })
     .finally(() => {
@@ -316,28 +361,27 @@ function scheduleShellIndexSync(cwd: string) {
     });
 
   inFlightShellIndexSyncs.set(cwd, syncPromise);
+  return syncPromise;
+}
+
+function scheduleShellIndexSync(cwd: string) {
+  if (syncedShellIndexes.has(cwd) || inFlightShellIndexSyncs.has(cwd)) {
+    return;
+  }
+
+  void startShellIndexSync(cwd, { warningLabel: "Failed to sync shell index." });
 }
 
 export async function refreshShellIndex(cwd: string, options: { emitRefreshEvent?: boolean } = {}) {
   const inFlightSync = inFlightShellIndexSyncs.get(cwd);
   if (inFlightSync) {
-    const synced = await inFlightSync;
-    if (synced) {
-      return true;
-    }
+    return await inFlightSync;
   }
 
-  try {
-    await syncShellIndex(cwd);
-    syncedShellIndexes.add(cwd);
-    if (options.emitRefreshEvent ?? true) {
-      emitDesktopEvent({ type: "shell-state-refresh" });
-    }
-    return true;
-  } catch (error) {
-    console.warn("Failed to refresh shell index.", error);
-    return false;
-  }
+  return await startShellIndexSync(cwd, {
+    emitRefreshEvent: options.emitRefreshEvent,
+    warningLabel: "Failed to refresh shell index.",
+  });
 }
 
 export async function loadShellState(cwd: string): Promise<ShellState> {

--- a/desktop/project-import.cts
+++ b/desktop/project-import.cts
@@ -9,9 +9,7 @@ function resolveProjectIds(projectIds: string[]) {
     return [...new Set(projectIds)];
   }
 
-  return listProjects(getDesktopWorkingDirectory())
-    .filter((project) => project.threadCount !== 0)
-    .map((project) => project.id);
+  return listProjects(getDesktopWorkingDirectory()).map((project) => project.id);
 }
 
 export async function scanKnownProjects(projectIds: string[]): Promise<ProjectImportCandidate[]> {

--- a/src/app/features/extensions/ExtensionsView.tsx
+++ b/src/app/features/extensions/ExtensionsView.tsx
@@ -67,6 +67,9 @@ export function ExtensionsView(props: ExtensionsViewProps) {
         }
       />
 
+      <output className="sr-only" aria-live="polite">
+        {controller.actionError ?? ""}
+      </output>
       {controller.actionError ? (
         <div className="text-[12px] text-[#f2a7a7]">{controller.actionError}</div>
       ) : null}

--- a/src/app/features/skills/SkillsView.tsx
+++ b/src/app/features/skills/SkillsView.tsx
@@ -93,6 +93,9 @@ export function SkillsView({
         </div>
       ) : null}
 
+      <output className="sr-only" aria-live="polite">
+        {controller.actionError ?? ""}
+      </output>
       {controller.actionError ? (
         <div className="text-[12px] text-[#f2a7a7]">{controller.actionError}</div>
       ) : null}

--- a/src/test/project-import-actions.test.ts
+++ b/src/test/project-import-actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveProjectImportActionResult } from "../../desktop/pi-threads/project-import-action";
+
+describe("project import actions", () => {
+  it("refreshes session discovery before import-all and imports with empty project ids", async () => {
+    const refreshShellIndex = vi.fn().mockResolvedValue(true);
+    const importProjects = vi.fn().mockResolvedValue({
+      checkedProjectCount: 1,
+      importedProjectIds: ["/new-project"],
+      originProjectCount: 0,
+      repoProjectCount: 0,
+    });
+
+    const result = await resolveProjectImportActionResult({
+      cwd: "/active-project",
+      mode: "import",
+      projectIds: [],
+      refreshOptions: { emitRefreshEvent: false },
+      refreshShellIndex,
+      runAfterRefresh: importProjects,
+    });
+
+    expect(refreshShellIndex).toHaveBeenCalledWith("/active-project", {
+      emitRefreshEvent: false,
+    });
+    expect(importProjects).toHaveBeenCalledWith([]);
+    expect(result).toEqual({
+      checkedProjectCount: 1,
+      importedProjectIds: ["/new-project"],
+      originProjectCount: 0,
+      repoProjectCount: 0,
+    });
+  });
+
+  it("blocks import-all when the session refresh fails", async () => {
+    const refreshShellIndex = vi.fn().mockResolvedValue(false);
+    const importProjects = vi.fn();
+
+    const result = await resolveProjectImportActionResult({
+      cwd: "/active-project",
+      mode: "import",
+      projectIds: [],
+      refreshOptions: { emitRefreshEvent: false },
+      refreshShellIndex,
+      runAfterRefresh: importProjects,
+    });
+
+    expect(importProjects).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      error: "Could not refresh Pi sessions before importing projects.",
+    });
+  });
+
+  it("keeps explicit project imports best-effort when the refresh fails", async () => {
+    const refreshShellIndex = vi.fn().mockResolvedValue(false);
+    const importProjects = vi.fn().mockResolvedValue({ importedProjectIds: ["/known-project"] });
+
+    await resolveProjectImportActionResult({
+      cwd: "/active-project",
+      mode: "import",
+      projectIds: ["/known-project"],
+      refreshOptions: { emitRefreshEvent: false },
+      refreshShellIndex,
+      runAfterRefresh: importProjects,
+    });
+
+    expect(importProjects).toHaveBeenCalledWith(["/known-project"]);
+  });
+});


### PR DESCRIPTION
## Summary
- follows up #94 with the review hardening that landed after the original PR was merged
- makes project import refresh failures explicit for import-all while keeping explicit project IDs best-effort
- refreshes Pi session discovery with stricter session enumeration, partial-failure signalling, and safer in-flight refresh handling
- keeps successfully parsed session data, avoids the active-thread-only import-all filter, and adds action-level tests for import-all wiring
- keeps Skills/Extensions action error live regions mounted without adding empty visible layout rows

## Validation
- pre-commit: `bun run typecheck:web && bun run typecheck:desktop && bun run typecheck:electron && bun run typecheck:scripts`, `vitest run`
- pre-push: `bun run lint && bun run typecheck`

Refs #82
