### PR TITLE
Force fresh project import refresh

### DIFF
--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -316,6 +316,7 @@ export async function handleProjectDesktopAction(
           cwd: getDesktopWorkingDirectory(),
           mode: "scan",
           projectIds,
+          refreshOptions: { force: true },
           refreshShellIndex,
           runAfterRefresh: async (refreshedProjectIds) => ({
             projects: await scanKnownProjects(refreshedProjectIds),
@@ -331,7 +332,7 @@ export async function handleProjectDesktopAction(
           cwd: getDesktopWorkingDirectory(),
           mode: "import",
           projectIds,
-          refreshOptions: { emitRefreshEvent: false },
+          refreshOptions: { emitRefreshEvent: false, force: true },
           refreshShellIndex,
           runAfterRefresh: importProjects,
         }),

--- a/desktop/pi-threads/project-import-action.ts
+++ b/desktop/pi-threads/project-import-action.ts
@@ -6,6 +6,7 @@ import {
 
 export type ProjectImportRefreshOptions = {
   emitRefreshEvent?: boolean;
+  force?: boolean;
 };
 
 export async function resolveProjectImportActionResult<T extends DesktopActionResultData>({

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -372,10 +372,19 @@ function scheduleShellIndexSync(cwd: string) {
   void startShellIndexSync(cwd, { warningLabel: "Failed to sync shell index." });
 }
 
-export async function refreshShellIndex(cwd: string, options: { emitRefreshEvent?: boolean } = {}) {
+export async function refreshShellIndex(
+  cwd: string,
+  options: { emitRefreshEvent?: boolean; force?: boolean } = {},
+) {
   const inFlightSync = inFlightShellIndexSyncs.get(cwd);
-  if (inFlightSync) {
+  if (inFlightSync && !options.force) {
     return await inFlightSync;
+  }
+
+  if (inFlightSync) {
+    // User-triggered project import needs a fresh filesystem pass. The background
+    // startup sync may have snapshotted sessions before a Pi CLI project was created.
+    await inFlightSync;
   }
 
   return await startShellIndexSync(cwd, {

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -385,6 +385,11 @@ export async function refreshShellIndex(
     // User-triggered project import needs a fresh filesystem pass. The background
     // startup sync may have snapshotted sessions before a Pi CLI project was created.
     await inFlightSync;
+
+    const forcedInFlightSync = inFlightShellIndexSyncs.get(cwd);
+    if (forcedInFlightSync) {
+      return await forcedInFlightSync;
+    }
   }
 
   return await startShellIndexSync(cwd, {

--- a/src/test/project-import-actions.test.ts
+++ b/src/test/project-import-actions.test.ts
@@ -15,13 +15,14 @@ describe("project import actions", () => {
       cwd: "/active-project",
       mode: "import",
       projectIds: [],
-      refreshOptions: { emitRefreshEvent: false },
+      refreshOptions: { emitRefreshEvent: false, force: true },
       refreshShellIndex,
       runAfterRefresh: importProjects,
     });
 
     expect(refreshShellIndex).toHaveBeenCalledWith("/active-project", {
       emitRefreshEvent: false,
+      force: true,
     });
     expect(importProjects).toHaveBeenCalledWith([]);
     expect(result).toEqual({


### PR DESCRIPTION
## Summary
- force user-triggered project import scan/apply to run a fresh shell-index pass instead of reusing an in-flight startup sync
- keeps the existing suppressed refresh event for apply, then lets renderer post-action refresh pull the updated project list
- covers the forced refresh option in the project import action test

## Validation
- bunx vitest run src/test/project-import-actions.test.ts src/test/project-import-refresh.test.ts
- bun run typecheck:desktop
- pre-commit: typecheck:web, typecheck:desktop, typecheck:electron, typecheck:scripts, vitest run

Closes #97
Refs #81