### PR TITLE
Add dev web desktop bridge

### DIFF
--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -1,6 +1,5 @@
 import { readdir, realpath, rm, unlink } from "node:fs/promises";
 import path from "node:path";
-import { shell } from "electron";
 import type { DesktopAction } from "../../shared/desktop-actions.ts";
 import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts";
 import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
@@ -15,6 +14,7 @@ import { selectProjectRuntime } from "../pi-desktop-runtime.cts";
 import { createProject } from "../project-create.cts";
 import { getOriginUrl } from "../project-git/project-state.cts";
 import { importProjects, scanKnownProjects } from "../project-import.cts";
+import { openPathWithSystem } from "../system-open-path.cts";
 import { listTerminals } from "../terminal/manager.cts";
 import {
   archiveProjectThreads,
@@ -208,7 +208,7 @@ export async function handleProjectDesktopAction(
         return handledAction();
       }
 
-      if ((await shell.openPath(projectId)) !== "") {
+      if (!(await openPathWithSystem(projectId))) {
         throw new Error(`Unable to open path: ${projectId}`);
       }
 

--- a/desktop/system-open-path.cts
+++ b/desktop/system-open-path.cts
@@ -1,0 +1,47 @@
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+function getOpenCommand() {
+  if (process.platform === "darwin") {
+    return { command: "open", args: [] };
+  }
+
+  if (process.platform === "win32") {
+    return { command: "rundll32.exe", args: ["url.dll,FileProtocolHandler"] };
+  }
+
+  return { command: "xdg-open", args: [] };
+}
+
+export async function openPathWithSystem(targetPath: string) {
+  const { command, args } = getOpenCommand();
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const child = spawn(command, [...args, targetPath], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+
+    const finish = (ok: boolean) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve(ok);
+    };
+
+    child.once("error", () => {
+      finish(false);
+    });
+    child.once("exit", (code) => {
+      finish(code === 0);
+    });
+
+    setTimeout(() => {
+      child.kill();
+      finish(false);
+    }, 10_000).unref();
+  });
+}

--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -1,0 +1,271 @@
+import { stat } from "node:fs/promises";
+import http from "node:http";
+
+import { getAttachmentKind, isSafeExternalUrl } from "../shared/composer-attachments";
+import { getDesktopWorkingDirectory } from "../shared/desktop-working-directory";
+import type {
+  DesktopEventMap,
+  DesktopRequestChannel,
+  DesktopRequestHandlerMap,
+} from "../shared/desktop-ipc";
+import { listComposerAttachmentEntries } from "../src/desktop-host/composer-attachments";
+import * as piThreads from "../desktop/pi-threads.cts";
+import * as piSkills from "../desktop/pi-skills.cts";
+import * as skillCreator from "../desktop/skill-creator-session.cts";
+import * as terminalManager from "../desktop/terminal/manager.cts";
+import { openPathWithSystem } from "../desktop/system-open-path.cts";
+
+const host = process.env.HOWCODE_DEV_WEB_BRIDGE_HOST || "127.0.0.1";
+const port = Number(process.env.HOWCODE_DEV_WEB_BRIDGE_PORT || 0);
+const bridgeToken = process.env.HOWCODE_DEV_WEB_BRIDGE_TOKEN || "";
+
+const desktopEventClients = new Set<http.ServerResponse>();
+const terminalEventClients = new Set<http.ServerResponse>();
+const sseClients = new Set<http.ServerResponse>();
+
+function sendSseEvent<TChannel extends keyof DesktopEventMap>(
+  clients: Set<http.ServerResponse>,
+  channel: TChannel,
+  event: DesktopEventMap[TChannel],
+) {
+  const payload = JSON.stringify({ channel, event });
+  for (const client of clients) {
+    client.write(`event: ${channel}\n`);
+    client.write(`data: ${payload}\n\n`);
+  }
+}
+
+piThreads.subscribeDesktopEvents((event) => {
+  sendSseEvent(desktopEventClients, "desktopEvent", event);
+});
+terminalManager.subscribeTerminalEvents((event) => {
+  sendSseEvent(terminalEventClients, "terminalEvent", event);
+});
+
+const handlers: DesktopRequestHandlerMap = {
+  getShellState: () => piThreads.loadShellState(getDesktopWorkingDirectory()),
+  getProjectGitState: ({ projectId }) => piThreads.loadProjectGitState(projectId),
+  getProjectDiff: ({ projectId, baseline }) =>
+    piThreads.loadProjectDiff(projectId, baseline ?? null),
+  getProjectDiffStats: ({ projectId, baseline }) =>
+    piThreads.loadProjectDiffStats(projectId, baseline ?? null),
+  captureProjectDiffBaseline: ({ projectId }) => piThreads.captureProjectDiffBaseline(projectId),
+  listProjectCommits: ({ projectId, limit }) =>
+    piThreads.listProjectCommits(projectId, limit ?? null),
+  searchPiPackages: (request) => piThreads.searchPiPackages(request),
+  getConfiguredPiPackages: (request) => piThreads.listConfiguredPiPackages(request),
+  installPiPackage: (request) => piThreads.installPiPackage(request),
+  removePiPackage: (request) => piThreads.removePiPackage(request),
+  searchPiSkills: (request) => piSkills.searchPiSkills(request),
+  getConfiguredPiSkills: (request) => piSkills.listConfiguredPiSkills(request),
+  installPiSkill: (request) => piSkills.installPiSkill(request),
+  removePiSkill: (request) => piSkills.removePiSkill(request),
+  startSkillCreatorSession: (request) => skillCreator.startSkillCreatorSession(request),
+  continueSkillCreatorSession: (request) => skillCreator.continueSkillCreatorSession(request),
+  closeSkillCreatorSession: (request) => skillCreator.closeSkillCreatorSession(request),
+  pickComposerAttachments: () => [],
+  readClipboardSnapshot: () => ({ formats: [], valuesByFormat: {} }),
+  readClipboardFilePaths: () => ({ filePaths: [], text: null }),
+  getAttachmentKindsForPaths: async ({ paths }) => {
+    const uniquePaths = [...new Set(Array.isArray(paths) ? paths : [])].filter(
+      (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+    );
+    const entries = await Promise.all(
+      uniquePaths.map(async (candidate) => {
+        try {
+          const stats = await stat(candidate);
+          return [
+            candidate,
+            stats.isDirectory() ? "directory" : getAttachmentKind(candidate),
+          ] as const;
+        } catch {
+          return [candidate, null] as const;
+        }
+      }),
+    );
+    return Object.fromEntries(entries);
+  },
+  listComposerAttachmentEntries: (request) => listComposerAttachmentEntries(request),
+  getComposerState: (request) => piThreads.loadComposerState(request),
+  getDictationState: () => piThreads.getDictationState(),
+  listDictationModels: () => piThreads.listDictationModels(),
+  installDictationModel: (request) => piThreads.installDictationModel(request),
+  removeDictationModel: (request) => piThreads.removeDictationModel(request),
+  transcribeDictation: (request) => piThreads.transcribeDictation(request),
+  getProjectThreads: ({ projectId }) => piThreads.loadProjectThreads(projectId),
+  getInboxThreads: () => piThreads.loadInboxThreadList(),
+  getArchivedThreads: () => piThreads.loadArchivedThreadList(),
+  getThread: ({ sessionPath, historyCompactions = 0 }) =>
+    piThreads.loadThread(sessionPath, { historyCompactions }),
+  watchSession: async ({ sessionPath }) => {
+    await piThreads.setWatchedSessionPath(sessionPath);
+    return { ok: true };
+  },
+  invokeAction: async ({ action, payload = {} }) => {
+    try {
+      const result = await piThreads.handleDesktopAction(action, payload);
+      return {
+        ok: true,
+        at: new Date().toISOString(),
+        payload: { action, payload },
+        result: result ?? null,
+      };
+    } catch (error) {
+      console.error("dev:web invokeAction failed", { action, payload, error });
+      return {
+        ok: false,
+        at: new Date().toISOString(),
+        payload: { action, payload },
+        result: {
+          error: error instanceof Error ? error.message : "Desktop action failed unexpectedly.",
+        },
+      };
+    }
+  },
+  listTerminals: () => terminalManager.listTerminals(),
+  terminalOpen: (request) => terminalManager.openTerminal(request),
+  terminalWrite: async ({ sessionId, data }) => {
+    await terminalManager.writeTerminal(sessionId, data);
+    return { ok: true };
+  },
+  terminalResize: async ({ sessionId, cols, rows }) => {
+    await terminalManager.resizeTerminal(sessionId, cols, rows);
+    return { ok: true };
+  },
+  terminalClose: async (request) => {
+    await terminalManager.closeTerminal(request);
+    return { ok: true };
+  },
+  openExternal: async ({ url }) => ({
+    ok: isSafeExternalUrl(url) && (await openPathWithSystem(url)),
+  }),
+  openPath: async ({ path: targetPath }) => ({ ok: await openPathWithSystem(targetPath) }),
+};
+
+async function readJsonBody(request: http.IncomingMessage) {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+}
+
+function sendJson(response: http.ServerResponse, statusCode: number, payload: unknown) {
+  response.statusCode = statusCode;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+async function handleBridgeRequest(
+  channel: DesktopRequestChannel,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+) {
+  const handler = handlers[channel];
+  if (!handler) {
+    sendJson(response, 404, { error: `Unknown desktop request channel: ${channel}` });
+    return;
+  }
+
+  try {
+    const params = await readJsonBody(request);
+    const result = await (handler as (params: unknown) => Promise<unknown> | unknown)(params);
+    sendJson(response, 200, result ?? null);
+  } catch (error) {
+    console.error("dev:web bridge request failed", { channel, error });
+    sendJson(response, 500, {
+      error: error instanceof Error ? error.message : "Desktop bridge request failed.",
+    });
+  }
+}
+
+function hasValidBridgeToken(request: http.IncomingMessage) {
+  return (
+    bridgeToken.length > 0 && request.headers["x-howcode-dev-web-bridge-token"] === bridgeToken
+  );
+}
+
+function handleBridgeEvents(
+  channel: keyof DesktopEventMap,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+) {
+  response.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache, no-transform",
+    connection: "keep-alive",
+  });
+  response.write("retry: 1000\n\n");
+
+  const clients = channel === "terminalEvent" ? terminalEventClients : desktopEventClients;
+  clients.add(response);
+  sseClients.add(response);
+  request.on("close", () => {
+    clients.delete(response);
+    sseClients.delete(response);
+  });
+}
+
+const server = http.createServer((request, response) => {
+  const requestUrl = new URL(request.url ?? "/", `http://${host}`);
+
+  if (!hasValidBridgeToken(request)) {
+    sendJson(response, 403, { error: "Invalid dev:web bridge token." });
+    return;
+  }
+
+  if (requestUrl.pathname.startsWith("/__howcode/events/")) {
+    const channel = requestUrl.pathname.slice("/__howcode/events/".length);
+    if (channel !== "desktopEvent" && channel !== "terminalEvent") {
+      sendJson(response, 404, { error: `Unknown desktop event channel: ${channel}` });
+      return;
+    }
+
+    handleBridgeEvents(channel, request, response);
+    return;
+  }
+
+  if (requestUrl.pathname.startsWith("/__howcode/request/")) {
+    if (request.method !== "POST") {
+      sendJson(response, 405, { error: "Desktop bridge requests must use POST." });
+      return;
+    }
+
+    const channel = requestUrl.pathname.slice("/__howcode/request/".length);
+    void handleBridgeRequest(channel as DesktopRequestChannel, request, response);
+    return;
+  }
+
+  sendJson(response, 404, { error: "Unknown dev:web bridge endpoint." });
+});
+
+server.listen(port, host, () => {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("dev:web bridge did not expose a numeric port.");
+  }
+
+  console.log(`HOWCODE_DEV_WEB_BRIDGE_READY ${JSON.stringify({ host, port: address.port })}`);
+});
+
+function shutdown() {
+  for (const client of sseClients) {
+    client.end();
+    client.destroy();
+  }
+  sseClients.clear();
+  desktopEventClients.clear();
+  terminalEventClients.clear();
+
+  server.close(() => process.exit(0));
+  server.closeAllConnections();
+  setTimeout(() => process.exit(0), 750).unref();
+}
+
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/scripts/dev-web.ts
+++ b/scripts/dev-web.ts
@@ -1,9 +1,13 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import crypto from "node:crypto";
 import { rmSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import { createRequire } from "node:module";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { createServer } from "vite";
+import { createServer, type ViteDevServer } from "vite";
 
 import {
   DEV_SERVER_HOST,
@@ -11,7 +15,186 @@ import {
   DEV_SERVER_START_PORT,
 } from "../shared/dev-server";
 
-const devServerMetadataPath = path.join(process.cwd(), DEV_SERVER_METADATA_RELATIVE_PATH);
+const projectRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const electronPath = require("electron") as string;
+const devServerMetadataPath = path.join(projectRoot, DEV_SERVER_METADATA_RELATIVE_PATH);
+const bridgeBuildPath = path.join(projectRoot, "build", "dev-web-bridge.mjs");
+const bridgeToken = crypto.randomUUID();
+
+let bridge: { child: ChildProcess; port: number } | null = null;
+let server: ViteDevServer | null = null;
+let isShuttingDown = false;
+let trustedRendererHost: string | null = null;
+
+async function buildDevWebBridge() {
+  await mkdir(path.dirname(bridgeBuildPath), { recursive: true });
+  const result = await Bun.build({
+    entrypoints: [path.join(projectRoot, "scripts", "dev-web-bridge-node.ts")],
+    outdir: path.dirname(bridgeBuildPath),
+    naming: path.basename(bridgeBuildPath),
+    target: "node",
+    format: "esm",
+    packages: "external",
+    sourcemap: "linked",
+    throw: true,
+  });
+
+  console.log(`Built dev:web bridge (${result.outputs.length} output(s)).`);
+}
+
+async function shutdown(exitCode = 0) {
+  if (isShuttingDown) {
+    return;
+  }
+
+  isShuttingDown = true;
+
+  try {
+    bridge?.child.kill();
+    await removeDevServerMetadata();
+    await server?.close();
+  } finally {
+    process.exit(exitCode);
+  }
+}
+
+async function startDevWebBridge() {
+  await buildDevWebBridge();
+
+  const child = spawn(electronPath, [bridgeBuildPath], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      HOWCODE_REPO_ROOT: process.env.HOWCODE_REPO_ROOT || projectRoot,
+      HOWCODE_DEV_WEB_BRIDGE_HOST: DEV_SERVER_HOST,
+      HOWCODE_DEV_WEB_BRIDGE_PORT: "0",
+      HOWCODE_DEV_WEB_BRIDGE_TOKEN: bridgeToken,
+      ELECTRON_RUN_AS_NODE: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stderr?.on("data", (chunk) => {
+    process.stderr.write(chunk);
+  });
+
+  return new Promise<{ child: ChildProcess; port: number }>((resolve, reject) => {
+    let stdoutBuffer = "";
+    let settled = false;
+
+    const fail = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(error);
+    };
+
+    child.once("error", fail);
+    child.once("exit", (code, signal) => {
+      if (!settled) {
+        fail(new Error(`dev:web bridge exited before startup (code=${code}, signal=${signal}).`));
+        return;
+      }
+
+      console.error(`dev:web bridge exited unexpectedly (code=${code}, signal=${signal}).`);
+      void shutdown(1);
+    });
+
+    child.stdout?.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdoutBuffer += text;
+      process.stdout.write(text);
+
+      const lines = stdoutBuffer.split("\n");
+      stdoutBuffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.startsWith("HOWCODE_DEV_WEB_BRIDGE_READY ")) {
+          continue;
+        }
+
+        const payload = JSON.parse(line.slice("HOWCODE_DEV_WEB_BRIDGE_READY ".length)) as {
+          port?: number;
+        };
+        if (typeof payload.port !== "number") {
+          fail(new Error("dev:web bridge reported an invalid port."));
+          return;
+        }
+
+        settled = true;
+        resolve({ child, port: payload.port });
+        return;
+      }
+    });
+  });
+}
+
+function proxyDevWebBridgeRequest(
+  bridgePort: number,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+) {
+  const proxyRequest = http.request(
+    {
+      hostname: DEV_SERVER_HOST,
+      port: bridgePort,
+      method: request.method,
+      path: request.url,
+      headers: {
+        ...request.headers,
+        "x-howcode-dev-web-bridge-token": bridgeToken,
+      },
+    },
+    (proxyResponse) => {
+      response.writeHead(proxyResponse.statusCode ?? 500, proxyResponse.headers);
+      proxyResponse.pipe(response);
+      response.on("close", () => {
+        if (!proxyResponse.destroyed) {
+          proxyResponse.destroy();
+        }
+      });
+    },
+  );
+
+  proxyRequest.on("error", (error) => {
+    if (response.headersSent) {
+      response.destroy(error);
+      return;
+    }
+
+    response.statusCode = 502;
+    response.setHeader("content-type", "application/json; charset=utf-8");
+    response.end(JSON.stringify({ error: error.message }));
+  });
+
+  request.on("close", () => {
+    if (!request.complete) {
+      proxyRequest.destroy();
+    }
+  });
+
+  request.pipe(proxyRequest);
+}
+
+function isTrustedBrowserRequest(request: http.IncomingMessage) {
+  if (!trustedRendererHost || request.headers.host !== trustedRendererHost) {
+    return false;
+  }
+
+  const origin = request.headers.origin;
+  if (typeof origin !== "string") {
+    return true;
+  }
+
+  try {
+    const originUrl = new URL(origin);
+    return originUrl.host === trustedRendererHost;
+  } catch {
+    return false;
+  }
+}
 
 async function writeDevServerMetadata(url: string, port: number) {
   await mkdir(path.dirname(devServerMetadataPath), { recursive: true });
@@ -33,35 +216,10 @@ async function removeDevServerMetadata() {
   await rm(devServerMetadataPath, { force: true });
 }
 
-const server = await createServer({
-  configFile: path.join(process.cwd(), "vite.config.ts"),
-  server: {
-    host: DEV_SERVER_HOST,
-    port: DEV_SERVER_START_PORT,
-    strictPort: false,
-  },
-});
-
-let isShuttingDown = false;
-
-async function shutdown(exitCode = 0) {
-  if (isShuttingDown) {
-    return;
-  }
-
-  isShuttingDown = true;
-
-  try {
-    await removeDevServerMetadata();
-    await server.close();
-  } finally {
-    process.exit(exitCode);
-  }
-}
-
 process.once("SIGINT", () => void shutdown());
 process.once("SIGTERM", () => void shutdown());
 process.once("exit", () => {
+  bridge?.child.kill();
   try {
     rmSync(devServerMetadataPath, { force: true });
   } catch {
@@ -70,6 +228,62 @@ process.once("exit", () => {
 });
 
 try {
+  bridge = await startDevWebBridge();
+
+  server = await createServer({
+    configFile: path.join(projectRoot, "vite.config.ts"),
+    server: {
+      host: DEV_SERVER_HOST,
+      port: DEV_SERVER_START_PORT,
+      strictPort: false,
+    },
+  });
+
+  const bridgeMiddleware = (
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    next: () => void,
+  ) => {
+    const requestUrl = new URL(request.url ?? "/", "http://localhost");
+
+    if (requestUrl.pathname === "/__howcode/config") {
+      if (!isTrustedBrowserRequest(request)) {
+        response.statusCode = 403;
+        response.end("Forbidden");
+        return;
+      }
+
+      response.setHeader("content-type", "application/json; charset=utf-8");
+      response.end(JSON.stringify({ bridgeToken }));
+      return;
+    }
+
+    if (
+      requestUrl.pathname.startsWith("/__howcode/events") ||
+      requestUrl.pathname.startsWith("/__howcode/request/")
+    ) {
+      if (!isTrustedBrowserRequest(request)) {
+        response.statusCode = 403;
+        response.end("Forbidden");
+        return;
+      }
+
+      proxyDevWebBridgeRequest(bridge?.port ?? 0, request, response);
+      return;
+    }
+
+    next();
+  };
+
+  (
+    server.middlewares as unknown as {
+      stack: Array<{ route: string; handle: typeof bridgeMiddleware }>;
+    }
+  ).stack.unshift({
+    route: "",
+    handle: bridgeMiddleware,
+  });
+
   const listenPromise = server.listen();
   let listenError: unknown = null;
 
@@ -91,10 +305,15 @@ try {
   }
 
   const { port } = address as AddressInfo;
+  trustedRendererHost = `${DEV_SERVER_HOST}:${port}`;
   await writeDevServerMetadata(`http://${DEV_SERVER_HOST}:${port}`, port);
   server.printUrls();
+  console.warn(
+    "\n[howcode] dev:web local desktop bridge is enabled for project sync/import. `bun run dev` remains the preferred full desktop dev loop.\n",
+  );
   await listenPromise;
 } catch (error) {
+  bridge?.child.kill();
   await removeDevServerMetadata();
   throw error;
 }

--- a/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
+++ b/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
@@ -1,6 +1,7 @@
 import { Clock3, FolderPlus, Github, ListFilter, Search, SquareTerminal, Star } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AppSettings, DesktopActionInvoker } from "../../../desktop/types";
+import { useDesktopBridgeAvailable } from "../../../hooks/useDesktopBridge";
 import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
 import type { Project, View } from "../../../types";
 import { cn } from "../../../utils/cn";
@@ -70,6 +71,7 @@ export function SidebarProjectsSection({
   const [projectNameDraft, setProjectNameDraft] = useState("");
   const [createBusy, setCreateBusy] = useState(false);
   const [createErrorMessage, setCreateErrorMessage] = useState<string | null>(null);
+  const desktopBridgeAvailable = useDesktopBridgeAvailable();
   const createButtonRef = useRef<HTMLButtonElement>(null);
   const createPanelRef = useRef<HTMLDialogElement>(null);
 
@@ -296,6 +298,11 @@ export function SidebarProjectsSection({
           onThreadOpen={onThreadOpen}
           onToggleProjectCollapse={onToggleProjectCollapse}
         />
+      ) : !desktopBridgeAvailable ? (
+        <div className="px-2.5 py-2 text-[12px] leading-5 text-[color:var(--muted-2)]">
+          Project sync needs the desktop bridge. Restart the dev server or use{" "}
+          <code>bun run dev</code>.
+        </div>
       ) : (
         <div
           className={cn(

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -1,0 +1,182 @@
+import type { DesktopAction } from "../../shared/desktop-actions";
+import type {
+  AnyDesktopActionPayload,
+  ComposerAttachment,
+  DesktopEvent,
+} from "../../shared/desktop-contracts";
+import type {
+  DesktopEventChannel,
+  DesktopEventMap,
+  DesktopRequestChannel,
+  DesktopRequestMap,
+} from "../../shared/desktop-ipc";
+import type { TerminalEvent, TerminalOpenRequest } from "../../shared/terminal-contracts";
+
+let bridgeTokenPromise: Promise<string> | null = null;
+
+function getBridgeToken() {
+  bridgeTokenPromise ??= fetch("/__howcode/config")
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error("Unable to load dev:web bridge config.");
+      }
+      return response.json() as Promise<{ bridgeToken?: string }>;
+    })
+    .then((config) => {
+      if (!config.bridgeToken) {
+        throw new Error("dev:web bridge config did not include a token.");
+      }
+      return config.bridgeToken;
+    })
+    .catch((error) => {
+      bridgeTokenPromise = null;
+      throw error;
+    });
+
+  return bridgeTokenPromise;
+}
+
+async function invokeRequest<K extends DesktopRequestChannel>(
+  channel: K,
+  params: DesktopRequestMap[K]["params"],
+) {
+  const bridgeToken = await getBridgeToken();
+  const response = await fetch(`/__howcode/request/${channel}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-howcode-dev-web-bridge-token": bridgeToken,
+    },
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(payload?.error ?? `Desktop bridge request failed: ${channel}`);
+  }
+
+  return (await response.json()) as DesktopRequestMap[K]["response"];
+}
+
+type EventSubscription = {
+  eventSource: EventSource;
+  listeners: Set<(event: MessageEvent<string>) => void>;
+};
+
+const eventSubscriptions = new Map<DesktopEventChannel, EventSubscription>();
+
+function getEventSubscription(channel: DesktopEventChannel) {
+  const current = eventSubscriptions.get(channel);
+  if (current) {
+    return current;
+  }
+
+  const subscription: EventSubscription = {
+    eventSource: new EventSource(`/__howcode/events/${channel}`),
+    listeners: new Set(),
+  };
+  eventSubscriptions.set(channel, subscription);
+  return subscription;
+}
+
+function subscribeToEvent<K extends DesktopEventChannel>(
+  channel: K,
+  listener: (event: DesktopEventMap[K]) => void,
+) {
+  const subscription = getEventSubscription(channel);
+  const wrappedListener = (event: MessageEvent<string>) => {
+    const payload = JSON.parse(event.data) as {
+      channel: K;
+      event: DesktopEventMap[K];
+    };
+    listener(payload.event);
+  };
+
+  subscription.listeners.add(wrappedListener);
+  subscription.eventSource.addEventListener(channel, wrappedListener);
+  return () => {
+    subscription.eventSource.removeEventListener(channel, wrappedListener);
+    subscription.listeners.delete(wrappedListener);
+    if (subscription.listeners.size === 0) {
+      subscription.eventSource.close();
+      eventSubscriptions.delete(channel);
+    }
+  };
+}
+
+export function installDevWebDesktopBridge() {
+  if (window.piDesktop) {
+    return;
+  }
+
+  window.__howcodeDevWebBridge = true;
+
+  window.piDesktop = {
+    getShellState: () => invokeRequest("getShellState", {}),
+    getProjectGitState: (projectId: string) => invokeRequest("getProjectGitState", { projectId }),
+    getProjectDiff: (projectId: string, baseline = null) =>
+      invokeRequest("getProjectDiff", { projectId, baseline }),
+    getProjectDiffStats: (projectId: string, baseline = null) =>
+      invokeRequest("getProjectDiffStats", { projectId, baseline }),
+    captureProjectDiffBaseline: (projectId: string) =>
+      invokeRequest("captureProjectDiffBaseline", { projectId }),
+    listProjectCommits: (projectId: string, limit: number | null = null) =>
+      invokeRequest("listProjectCommits", { projectId, limit }),
+    searchPiPackages: (request = {}) => invokeRequest("searchPiPackages", request),
+    getConfiguredPiPackages: (request = {}) => invokeRequest("getConfiguredPiPackages", request),
+    installPiPackage: (request) => invokeRequest("installPiPackage", request),
+    removePiPackage: (request) => invokeRequest("removePiPackage", request),
+    searchPiSkills: (request = {}) => invokeRequest("searchPiSkills", request),
+    getConfiguredPiSkills: (request = {}) => invokeRequest("getConfiguredPiSkills", request),
+    installPiSkill: (request) => invokeRequest("installPiSkill", request),
+    removePiSkill: (request) => invokeRequest("removePiSkill", request),
+    startSkillCreatorSession: (request) => invokeRequest("startSkillCreatorSession", request),
+    continueSkillCreatorSession: (request) => invokeRequest("continueSkillCreatorSession", request),
+    closeSkillCreatorSession: (sessionId: string) =>
+      invokeRequest("closeSkillCreatorSession", { sessionId }),
+    pickComposerAttachments: () => Promise.resolve([] satisfies ComposerAttachment[]),
+    readClipboardSnapshot: (formats: string[] | null = null) =>
+      invokeRequest("readClipboardSnapshot", { formats }),
+    readClipboardFilePaths: () => invokeRequest("readClipboardFilePaths", {}),
+    getAttachmentKindsForPaths: (paths: string[]) =>
+      invokeRequest("getAttachmentKindsForPaths", { paths }),
+    getPathForFile: () => null,
+    listComposerAttachmentEntries: (request = {}) =>
+      invokeRequest("listComposerAttachmentEntries", request),
+    getComposerState: (request = {}) => invokeRequest("getComposerState", request),
+    getDictationState: () => invokeRequest("getDictationState", {}),
+    listDictationModels: () => invokeRequest("listDictationModels", {}),
+    installDictationModel: (modelId: "tiny.en" | "base.en" | "small.en") =>
+      invokeRequest("installDictationModel", { modelId }),
+    removeDictationModel: (modelId: "tiny.en" | "base.en" | "small.en") =>
+      invokeRequest("removeDictationModel", { modelId }),
+    transcribeDictation: (request) => invokeRequest("transcribeDictation", request),
+    getProjectThreads: (projectId: string) => invokeRequest("getProjectThreads", { projectId }),
+    getInboxThreads: () => invokeRequest("getInboxThreads", {}),
+    getArchivedThreads: () => invokeRequest("getArchivedThreads", {}),
+    getThread: (sessionPath: string, historyCompactions = 0) =>
+      invokeRequest("getThread", { sessionPath, historyCompactions }),
+    watchSession: async (sessionPath: string | null) => {
+      await invokeRequest("watchSession", { sessionPath });
+    },
+    invokeAction: (action: DesktopAction, payload: AnyDesktopActionPayload = {}) =>
+      invokeRequest("invokeAction", { action, payload }),
+    listTerminals: () => invokeRequest("listTerminals", {}),
+    openTerminal: (request: TerminalOpenRequest) => invokeRequest("terminalOpen", request),
+    writeTerminal: async (sessionId: string, data: string) => {
+      await invokeRequest("terminalWrite", { sessionId, data });
+    },
+    resizeTerminal: async (request) => {
+      await invokeRequest("terminalResize", request);
+    },
+    closeTerminal: async (request) => {
+      await invokeRequest("terminalClose", request);
+    },
+    openExternal: (url: string) => invokeRequest("openExternal", { url }).then(({ ok }) => ok),
+    openPath: (path: string) => invokeRequest("openPath", { path }).then(({ ok }) => ok),
+    subscribe: (listener: (event: DesktopEvent) => void) =>
+      subscribeToEvent("desktopEvent", listener),
+    subscribeTerminal: (listener: (event: TerminalEvent) => void) =>
+      subscribeToEvent("terminalEvent", listener),
+  };
+}

--- a/src/app/hooks/useDesktopBridge.ts
+++ b/src/app/hooks/useDesktopBridge.ts
@@ -1,8 +1,54 @@
+import { useEffect, useState } from "react";
 import type { DesktopAction } from "../desktop/actions";
 import type { DesktopActionInvoker, DesktopActionResult } from "../desktop/types";
 
-function hasDesktopBridge() {
-  return typeof window.piDesktop?.invokeAction === "function";
+export const desktopBridgeUnavailableMessage =
+  "Desktop bridge is unavailable. Restart the dev server or run `bun run dev` for the full desktop app.";
+
+export function hasDesktopBridge() {
+  return typeof window !== "undefined" && typeof window.piDesktop?.invokeAction === "function";
+}
+
+export function useDesktopBridgeAvailable() {
+  const [available, setAvailable] = useState(() => {
+    if (!hasDesktopBridge()) {
+      return false;
+    }
+
+    return !window.__howcodeDevWebBridge;
+  });
+
+  useEffect(() => {
+    if (!hasDesktopBridge()) {
+      setAvailable(false);
+      return;
+    }
+
+    if (!window.__howcodeDevWebBridge) {
+      setAvailable(true);
+      return;
+    }
+
+    let cancelled = false;
+    setAvailable(false);
+    void fetch("/__howcode/config", { cache: "no-store" })
+      .then((response) => {
+        if (!cancelled) {
+          setAvailable(response.ok);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAvailable(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return available;
 }
 
 export function useDesktopBridge() {
@@ -10,23 +56,31 @@ export function useDesktopBridge() {
     action: DesktopAction,
     payload = {},
   ): Promise<DesktopActionResult | null> => {
-    if (!window.piDesktop) {
-      return null;
-    }
-
     if (!hasDesktopBridge()) {
       return {
         ok: false,
         at: new Date().toISOString(),
         payload: { action, payload },
         result: {
-          error: "Desktop bridge is unavailable.",
+          error: desktopBridgeUnavailableMessage,
+        },
+      };
+    }
+
+    const desktopBridge = window.piDesktop;
+    if (!desktopBridge) {
+      return {
+        ok: false,
+        at: new Date().toISOString(),
+        payload: { action, payload },
+        result: {
+          error: desktopBridgeUnavailableMessage,
         },
       };
     }
 
     try {
-      return await window.piDesktop.invokeAction(action, payload);
+      return await desktopBridge.invokeAction(action, payload);
     } catch (error) {
       return {
         ok: false,

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -87,6 +87,7 @@ export function SettingsView({
 
       <SettingsProjectImportSection
         importBusy={controller.importBusy}
+        desktopBridgeAvailable={controller.desktopBridgeAvailable}
         importErrorMessage={controller.importErrorMessage}
         importStatusMessage={controller.importStatusMessage}
         importedState={appSettings.projectImportState}

--- a/src/app/views/settings/SettingsProjectImportSection.tsx
+++ b/src/app/views/settings/SettingsProjectImportSection.tsx
@@ -4,6 +4,7 @@ import { cn } from "../../utils/cn";
 
 export function SettingsProjectImportSection({
   importBusy,
+  desktopBridgeAvailable,
   importErrorMessage,
   importStatusMessage,
   importedState,
@@ -11,6 +12,7 @@ export function SettingsProjectImportSection({
   onShowFirstLaunchReminderAgain,
 }: {
   importBusy: boolean;
+  desktopBridgeAvailable: boolean;
   importErrorMessage: string | null;
   importStatusMessage: string | null;
   importedState: boolean | null;
@@ -29,7 +31,7 @@ export function SettingsProjectImportSection({
           type="button"
           className={cn(primaryButtonClass, "px-3 disabled:cursor-not-allowed disabled:opacity-45")}
           onClick={onImport}
-          disabled={importBusy}
+          disabled={importBusy || !desktopBridgeAvailable}
         >
           {importBusy ? "Importing…" : importedState ? "Run again" : "Import now"}
         </button>
@@ -46,6 +48,12 @@ export function SettingsProjectImportSection({
 
       {importStatusMessage ? (
         <div className="text-[12px] text-[color:var(--muted)]">{importStatusMessage}</div>
+      ) : null}
+      {!desktopBridgeAvailable ? (
+        <div className="text-[12px] text-[color:var(--muted)]">
+          Project sync needs the desktop bridge. Restart the dev server or use{" "}
+          <code>bun run dev</code>.
+        </div>
       ) : null}
       {importErrorMessage ? (
         <div className="text-[12px] text-[#f2a7a7]">{importErrorMessage}</div>

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -4,6 +4,10 @@ import { useAnimatedPresence } from "../../hooks/useAnimatedPresence";
 import { useDismissibleLayer } from "../../hooks/useDismissibleLayer";
 import type { Project } from "../../types";
 import {
+  desktopBridgeUnavailableMessage,
+  useDesktopBridgeAvailable,
+} from "../../hooks/useDesktopBridge";
+import {
   buildModelSelectionPayload,
   getActionError,
   getModelSettingValue,
@@ -36,6 +40,7 @@ export function useSettingsController({
   const skillCreatorMenuPresent = useAnimatedPresence(skillCreatorMenuOpen);
 
   const dictation = useSettingsDictationController({ appSettings, onAction });
+  const desktopBridgeAvailable = useDesktopBridgeAvailable();
 
   useEffect(() => {
     setPreferredProjectLocationDraft(appSettings.preferredProjectLocation ?? "");
@@ -95,6 +100,12 @@ export function useSettingsController({
   };
 
   const handleImportProjectUi = async () => {
+    if (!desktopBridgeAvailable) {
+      setImportStatusMessage(null);
+      setImportErrorMessage(desktopBridgeUnavailableMessage);
+      return;
+    }
+
     setImportBusy(true);
     setImportStatusMessage("Scanning projects for UI info…");
     setImportErrorMessage(null);
@@ -134,6 +145,7 @@ export function useSettingsController({
     importBusy,
     importErrorMessage,
     importStatusMessage,
+    desktopBridgeAvailable,
     installDictationModel: dictation.installDictationModel,
     preferredProjectLocationDraft,
     refreshDictationState: dictation.refreshDictationState,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,10 +5,12 @@ import "@wterm/react/css";
 import "@fontsource-variable/inter";
 import "./styles.css";
 import App from "./App";
+import { installDevWebDesktopBridge } from "./app/dev-web-bridge";
 import { queryClient } from "./app/query/query-client";
 
 if (import.meta.env.DEV) {
   void import("react-grab");
+  installDevWebDesktopBridge();
 }
 
 try {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,6 +42,7 @@ import type {
 
 declare global {
   interface Window {
+    __howcodeDevWebBridge?: boolean;
     piDesktop?: {
       getShellState: () => Promise<ShellState>;
       getProjectGitState?: (projectId: string) => Promise<ProjectGitState | null>;

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
+    "allowImportingTsExtensions": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- add a dev:web local bridge process that runs under Electron-as-Node so native runtime modules like better-sqlite3 load correctly
- proxy `/__howcode/request/*` and `/__howcode/events` through Vite, and install a browser `window.piDesktop` shim in dev
- wire project sync/import, shell state, threads, actions, terminal requests/events, and filesystem-backed attachment helpers through the bridge
- keep clear fallback messaging if the bridge is unavailable

## Validation
- biome on touched files
- typecheck:web
- typecheck:scripts
- typecheck:desktop
- pre-commit hook ran typecheck:web, typecheck:desktop, typecheck:electron, typecheck:scripts, and full vitest run
- manually built the bridge and verified `getShellState` + `projects.import.apply` over HTTP with Electron-as-Node

Closes #81