### PR TITLE
Harden composer attachment payloads

### DIFF
--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -20,6 +20,7 @@ import {
 } from "../pi-desktop-runtime.cts";
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
+import { normalizeComposerSendAttachments } from "./composer-attachment-payload";
 
 export async function handleComposerDesktopAction(
   action: DesktopAction,
@@ -44,7 +45,16 @@ export async function handleComposerDesktopAction(
 
     case "composer.send": {
       const text = getComposerText(payload);
-      const attachments = getComposerAttachments(payload);
+      const rawAttachments = getComposerAttachments(payload);
+      const normalizedAttachmentPayload = await normalizeComposerSendAttachments(rawAttachments);
+      const attachments = normalizedAttachmentPayload.attachments;
+      if (normalizedAttachmentPayload.rejected) {
+        return handledAction({
+          error:
+            "Could not send prompt because one or more attached files are no longer available.",
+        });
+      }
+
       if (!text && attachments.length === 0) {
         return handledAction();
       }

--- a/desktop/pi-threads/composer-attachment-payload.ts
+++ b/desktop/pi-threads/composer-attachment-payload.ts
@@ -1,0 +1,154 @@
+import path from "node:path";
+import { stat } from "node:fs/promises";
+import type { ComposerAttachment } from "../../shared/desktop-contracts";
+import {
+  getAttachmentKind,
+  isSafeExternalUrl,
+  normalizeComposerAttachments,
+} from "../../shared/composer-attachments";
+
+const maxConcurrentAttachmentStats = 8;
+function hasControlCharacters(value: string) {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint < 32 || codePoint === 127;
+  });
+}
+
+type StatLike = Pick<Awaited<ReturnType<typeof stat>>, "isDirectory">;
+
+type AttachmentStat = (path: string) => Promise<StatLike>;
+
+type AttachmentPlatform = NodeJS.Platform;
+
+type PreparedLocalAttachmentPath = {
+  normalizedPath: string;
+  statPath: string;
+};
+
+function getLocalAttachmentPathParts(
+  attachmentPath: string,
+  platform: AttachmentPlatform,
+): PreparedLocalAttachmentPath | null {
+  const trimmedPath = attachmentPath.trim();
+  if (!trimmedPath || isSafeExternalUrl(trimmedPath) || hasControlCharacters(trimmedPath)) {
+    return null;
+  }
+
+  if (/^[A-Za-z]:[\\/]/.test(trimmedPath)) {
+    const normalizedPath = path.win32.normalize(trimmedPath);
+    return normalizedPath === path.win32.parse(normalizedPath).root
+      ? null
+      : { normalizedPath, statPath: trimmedPath };
+  }
+
+  if (trimmedPath.startsWith("\\\\") || (platform === "win32" && trimmedPath.startsWith("//"))) {
+    const normalizedPath = path.win32.normalize(trimmedPath);
+    return normalizedPath === path.win32.parse(normalizedPath).root
+      ? null
+      : { normalizedPath, statPath: trimmedPath };
+  }
+
+  if (trimmedPath.startsWith("/")) {
+    const normalizedPath = path.posix.normalize(trimmedPath);
+    return normalizedPath === "/" ? null : { normalizedPath, statPath: trimmedPath };
+  }
+
+  return null;
+}
+
+async function resolveLocalAttachmentKind(
+  attachmentPath: string,
+  statAttachmentPath: AttachmentStat,
+): Promise<ComposerAttachment["kind"] | null> {
+  try {
+    const stats = await statAttachmentPath(attachmentPath);
+    return stats.isDirectory() ? "directory" : getAttachmentKind(attachmentPath);
+  } catch {
+    return null;
+  }
+}
+
+async function statLocalAttachmentPaths(
+  localPaths: PreparedLocalAttachmentPath[],
+  statAttachmentPath: AttachmentStat,
+) {
+  const localAttachmentKinds = new Map<string, ComposerAttachment["kind"] | null>();
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < localPaths.length) {
+      const attachmentPath = localPaths[nextIndex];
+      nextIndex += 1;
+
+      if (!attachmentPath) {
+        continue;
+      }
+
+      localAttachmentKinds.set(
+        attachmentPath.normalizedPath,
+        await resolveLocalAttachmentKind(attachmentPath.statPath, statAttachmentPath),
+      );
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(maxConcurrentAttachmentStats, localPaths.length) }, () =>
+      worker(),
+    ),
+  );
+
+  return localAttachmentKinds;
+}
+
+export async function normalizeComposerSendAttachments(
+  attachments: ComposerAttachment[],
+  options?: { statAttachmentPath?: AttachmentStat; platform?: AttachmentPlatform },
+): Promise<{ attachments: ComposerAttachment[]; rejected: boolean }> {
+  const statAttachmentPath = options?.statAttachmentPath ?? stat;
+  const platform = options?.platform ?? process.platform;
+  const localPathsByNormalizedPath = new Map<string, PreparedLocalAttachmentPath>();
+
+  for (const attachment of attachments) {
+    const pathParts = getLocalAttachmentPathParts(attachment.path, platform);
+    if (pathParts) {
+      localPathsByNormalizedPath.set(pathParts.normalizedPath, pathParts);
+    }
+  }
+
+  const localAttachmentKinds = await statLocalAttachmentPaths(
+    [...localPathsByNormalizedPath.values()],
+    statAttachmentPath,
+  );
+  let rejected = false;
+
+  const normalizedAttachments = normalizeComposerAttachments(
+    attachments.map((attachment) => {
+      const trimmedPath = attachment.path.trim();
+      if (isSafeExternalUrl(trimmedPath)) {
+        return { ...attachment, path: trimmedPath };
+      }
+
+      const pathParts = getLocalAttachmentPathParts(attachment.path, platform);
+      return pathParts ? { ...attachment, path: pathParts.normalizedPath } : attachment;
+    }),
+    {
+      resolveAttachmentKind: (attachmentPath) => {
+        const pathParts = getLocalAttachmentPathParts(attachmentPath, platform);
+        if (!pathParts) {
+          rejected = true;
+          return null;
+        }
+
+        const kind = localAttachmentKinds.get(pathParts.normalizedPath) ?? null;
+        if (kind === null) {
+          rejected = true;
+        }
+
+        return kind;
+      },
+    },
+  );
+
+  return { attachments: normalizedAttachments, rejected };
+}

--- a/docs/mock-features.md
+++ b/docs/mock-features.md
@@ -49,7 +49,7 @@ These are **not** mock anymore, or at least have real persistence behind them:
 
 - Controlled composer state exists in renderer and the surface is now split into prompt-vs-git-ops mock states for easier iteration: `src/app/components/workspace/Composer.tsx`, `src/app/components/workspace/composer/*`
 - Send is wired through real Pi sessions with per-cwd runtimes: `desktop/runtime/*`, `desktop/pi-threads/action-router.cts`
-- File picker attachments are wired and text/image files are sent through the Pi prompt path: `src/electron/main/ipc/request-handlers/system.ts`, `desktop/runtime/attachments.cts`, `src/app/components/workspace/Composer.tsx`
+- File picker attachments are wired as explicit path/reference attachments. howcode does not upload or embed file contents itself; it injects prompt instructions for Pi to read the selected paths or use the referenced URLs, matching Pi-style file-reference semantics: `src/electron/main/ipc/request-handlers/system.ts`, `desktop/runtime/attachments.cts`, `src/app/components/workspace/Composer.tsx`
 - Existing thread continuation is real via runtime session activation: `desktop/runtime/runtime-registry.cts`
 - Streaming thread updates are pushed over Electron IPC messages and rendered live: `src/electron/main/ipc/register-desktop-ipc.ts`, `src/electron/preload/create-desktop-api.ts`, `src/app/app-shell/useAppShellController.ts`
 - Real model + thinking selectors are wired to Pi session state: `desktop/runtime/composer-state.cts`, `src/app/components/workspace/Composer.tsx`
@@ -61,8 +61,8 @@ These are **not** mock anymore, or at least have real persistence behind them:
   - Source of truth: `shared/desktop-actions.ts`, `shared/desktop-action-coverage.ts`, `desktop/pi-threads/action-router.cts`
 
 **Expansion direction:**
-- Add attachment/image flows.
-- Improve attachment handling to match Pi CLI file processing more closely (auto-resize, binary rejection, richer previews).
+- Attachment/image flows are path/reference-based rather than payload uploads; binary and large-file handling belongs to Pi/read-tool behavior, not the howcode composer transport.
+- Improve attachment handling with richer previews or Pi-native image support if/when we intentionally move beyond path/reference semantics.
 - Expand failure UX beyond inline composer text (retry affordances, auth-specific actions).
 - Continue tightening live-turn fidelity beyond the current prose + reasoning + tool rendering.
 - Replace the current mock git ops surface with a git-native worktree/project diff + commit flow instead of extending the current per-turn checkpoint model.

--- a/src/test/composer-attachment-payload.test.ts
+++ b/src/test/composer-attachment-payload.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { normalizeComposerSendAttachments } from "../../desktop/pi-threads/composer-attachment-payload";
+import type { ComposerAttachment } from "../../shared/desktop-contracts";
+
+function createStat(existingPaths: Record<string, "directory" | "file">) {
+  return async (attachmentPath: string) => {
+    const entry = existingPaths[attachmentPath];
+    if (!entry) {
+      throw new Error(`Missing test path: ${attachmentPath}`);
+    }
+
+    return { isDirectory: () => entry === "directory" };
+  };
+}
+
+describe("normalizeComposerSendAttachments", () => {
+  it("trims, dedupes, and reclassifies local attachment payloads before send", async () => {
+    const attachments: ComposerAttachment[] = [
+      { path: " /repo/src ", name: " src ", kind: "text" },
+      { path: "/repo/src", name: "old", kind: "text" },
+      { path: "/repo/src/../screenshot.png", name: "", kind: "text" },
+      { path: "//server/share/image.png", name: "image.png", kind: "text" },
+    ];
+
+    await expect(
+      normalizeComposerSendAttachments(attachments, {
+        platform: "win32",
+        statAttachmentPath: createStat({
+          "/repo/src": "directory",
+          "/repo/src/../screenshot.png": "file",
+          "//server/share/image.png": "file",
+        }),
+      }),
+    ).resolves.toEqual({
+      attachments: [
+        { path: "/repo/src", name: "old", kind: "directory" },
+        { path: "/repo/screenshot.png", name: "screenshot.png", kind: "image" },
+        { path: "\\\\server\\share\\image.png", name: "image.png", kind: "image" },
+      ],
+      rejected: false,
+    });
+  });
+
+  it("reports actual rejected attachments without treating dedupe as rejection", async () => {
+    const attachments: ComposerAttachment[] = [
+      { path: "/repo/file.ts", name: "file.ts", kind: "text" },
+      { path: " /repo/file.ts ", name: "duplicate.ts", kind: "text" },
+      { path: "/repo/missing.txt", name: "missing.txt", kind: "text" },
+      { path: "   ", name: "blank", kind: "text" },
+      { path: "ftp://example.com/file.txt", name: "file.txt", kind: "text" },
+      { path: "relative/file.txt", name: "file.txt", kind: "text" },
+      { path: "////", name: "root", kind: "directory" },
+      { path: "/tmp/..", name: "root", kind: "directory" },
+      { path: "/repo/bad\nname.ts", name: "bad", kind: "text" },
+      { path: "https://example.com/guide", name: "Guide", kind: "image" },
+    ];
+
+    await expect(
+      normalizeComposerSendAttachments(attachments, {
+        platform: "linux",
+        statAttachmentPath: createStat({
+          "/repo/file.ts": "file",
+        }),
+      }),
+    ).resolves.toEqual({
+      attachments: [
+        { path: "/repo/file.ts", name: "duplicate.ts", kind: "text" },
+        { path: "https://example.com/guide", name: "Guide", kind: "text" },
+      ],
+      rejected: true,
+    });
+  });
+
+  it("keeps forward-slash double-root POSIX paths on POSIX platforms", async () => {
+    await expect(
+      normalizeComposerSendAttachments(
+        [{ path: "//server/share/file.ts", name: "file.ts", kind: "text" }],
+        {
+          platform: "linux",
+          statAttachmentPath: createStat({
+            "//server/share/file.ts": "file",
+          }),
+        },
+      ),
+    ).resolves.toEqual({
+      attachments: [{ path: "/server/share/file.ts", name: "file.ts", kind: "text" }],
+      rejected: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize composer attachment payloads at the final `composer.send` boundary
- re-stat local attachment paths before sending, correcting file/folder/image kind and dropping stale or unsupported paths
- document that howcode attachments are Pi-style path/reference prompts, not embedded file uploads

## Testing
- bun run typecheck:web
- bun run typecheck:desktop
- bun run typecheck:electron
- bun run typecheck:scripts
- bun test

Closes #44
