### PR TITLE
Add Pi-backed slash command picker

### DIFF
--- a/desktop/pi-desktop-runtime.cts
+++ b/desktop/pi-desktop-runtime.cts
@@ -11,3 +11,4 @@ export {
   stopComposerRun,
   subscribeDesktopEvents,
 } from "./runtime/composer-service.cts";
+export { getComposerSlashCommands } from "./runtime/slash-commands.cts";

--- a/desktop/pi-packages/mutations.cts
+++ b/desktop/pi-packages/mutations.cts
@@ -2,6 +2,7 @@ import type { PiPackageMutationResult } from "../../shared/desktop-contracts.ts"
 import { listConfiguredPiPackages } from "./configured.cts";
 import { normalizePiPackageSource } from "./helpers.ts";
 import { getPiPackageServices } from "./services.cts";
+import { markRuntimeSettingsStaleForProject } from "../runtime/runtime-registry.cts";
 
 export async function installPiPackage(request: {
   source: string;
@@ -17,6 +18,7 @@ export async function installPiPackage(request: {
 
   const { packageManager } = await getPiPackageServices(request.projectPath);
   await packageManager.installAndPersist(normalizedSource, request.local ? { local: true } : {});
+  await markRuntimeSettingsStaleForProject(request.local ? request.projectPath : null);
 
   return {
     source: request.source,
@@ -40,6 +42,7 @@ export async function removePiPackage(request: {
 
   const { packageManager } = await getPiPackageServices(request.projectPath);
   await packageManager.removeAndPersist(source, request.local ? { local: true } : {});
+  await markRuntimeSettingsStaleForProject(request.local ? request.projectPath : null);
 
   return {
     source,

--- a/desktop/pi-threads.cts
+++ b/desktop/pi-threads.cts
@@ -18,6 +18,7 @@ export {
   captureProjectDiffBaseline,
   listDictationModels,
   loadComposerState,
+  loadComposerSlashCommands,
   listProjectCommits,
   loadProjectDiff,
   loadProjectDiffStats,

--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -11,6 +11,7 @@ import {
   getComposerText,
   getComposerThinkingLevel,
 } from "../../shared/pi-thread-action-payloads.ts";
+import { markRuntimeSettingsStale } from "../runtime/runtime-registry.cts";
 import {
   dequeueComposerPrompt,
   sendComposerPrompt,
@@ -90,6 +91,11 @@ export async function handleComposerDesktopAction(
       });
 
       return handledAction({ dequeuedText });
+    }
+
+    case "composer.reload-settings": {
+      await markRuntimeSettingsStale(getComposerRequest(payload).sessionPath);
+      return handledAction();
     }
 
     default:

--- a/desktop/pi-threads/shell-loader.cts
+++ b/desktop/pi-threads/shell-loader.cts
@@ -26,6 +26,7 @@ import { normalizeThreadTitle } from "../../shared/pi-message-mapper.ts";
 import { loadAppSettings } from "../app-settings.cts";
 import {
   getComposerState,
+  getComposerSlashCommands,
   subscribeDesktopEvents as subscribeRuntimeEvents,
 } from "../pi-desktop-runtime.cts";
 import { getPiModule } from "../pi-module.cts";
@@ -430,6 +431,10 @@ export async function loadComposerState(
   request: ComposerStateRequest = {},
 ): Promise<ComposerState> {
   return getComposerState(request);
+}
+
+export async function loadComposerSlashCommands(request: ComposerStateRequest = {}) {
+  return getComposerSlashCommands(request);
 }
 
 export async function getDictationState(): Promise<DictationState> {

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -120,18 +120,20 @@ export async function setComposerModel(
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
-  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
-    suspendDisposal: true,
+  return await withRuntimeMutationLock(persistedSessionPath, async () => {
+    const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+      suspendDisposal: true,
+    });
+    const model = runtime.session.modelRegistry.find(provider, modelId);
+
+    if (!model) {
+      throw new Error(`Unknown Pi model: ${provider}/${modelId}`);
+    }
+
+    await runtime.session.setModel(model);
+    scheduleRuntimeDisposalForRuntime(runtime);
+    return emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });
-  const model = runtime.session.modelRegistry.find(provider, modelId);
-
-  if (!model) {
-    throw new Error(`Unknown Pi model: ${provider}/${modelId}`);
-  }
-
-  await runtime.session.setModel(model);
-  scheduleRuntimeDisposalForRuntime(runtime);
-  return emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
 }
 
 export async function setComposerThinkingLevel(
@@ -145,12 +147,14 @@ export async function setComposerThinkingLevel(
     return emitComposerUpdate({ ...request, sessionPath: null });
   }
 
-  const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
-    suspendDisposal: true,
+  await withRuntimeMutationLock(persistedSessionPath, async () => {
+    const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+      suspendDisposal: true,
+    });
+    runtime.session.setThinkingLevel(level);
+    scheduleRuntimeDisposalForRuntime(runtime);
+    await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });
-  runtime.session.setThinkingLevel(level);
-  scheduleRuntimeDisposalForRuntime(runtime);
-  return emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
 }
 
 export async function sendComposerPrompt(

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -2,6 +2,7 @@ import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { buildComposerState } from "./composer-state.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
+import { createRuntimeSettingsRefreshController, isRuntimeBusy } from "./settings-refresh.ts";
 import { publishComposerUpdate, publishThreadUpdate } from "./thread-publisher.cts";
 import type { PiRuntime } from "./types.cts";
 
@@ -14,6 +15,17 @@ type RuntimeRecord = {
 
 const runtimeRecords = new Map<string, RuntimeRecord>();
 const runtimeMutationTails = new Map<string, Promise<void>>();
+const settingsRefreshController = createRuntimeSettingsRefreshController({
+  getCachedRuntimeForSessionPath,
+  getRuntimeRecords: () =>
+    [...runtimeRecords.entries()].map(([runtimeKey, record]) => ({
+      runtimeKey,
+      runtimePromise: record.runtimePromise,
+    })),
+  withRuntimeMutationLock,
+  buildComposerState,
+  publishComposerUpdate,
+});
 
 function clearRuntimeDisposeTimeout(runtimeKey: string) {
   const record = runtimeRecords.get(runtimeKey);
@@ -46,7 +58,7 @@ function scheduleRuntimeDisposal(runtimeKey: string) {
 
       try {
         const runtime = await record.runtimePromise;
-        if (runtime.session.isStreaming) {
+        if (isRuntimeBusy(runtime)) {
           scheduleRuntimeDisposal(runtimeKey);
           return;
         }
@@ -61,6 +73,26 @@ function scheduleRuntimeDisposal(runtimeKey: string) {
       }
     })();
   }, RUNTIME_IDLE_TIMEOUT_MS);
+}
+
+export async function reloadRuntimeSettingsIfSafe(
+  sessionPath: string,
+  options: { useMutationLock?: boolean } = {},
+): Promise<boolean> {
+  return settingsRefreshController.reloadIfSafe(sessionPath, options);
+}
+
+export async function markRuntimeSettingsStale(sessionPath: string | null | undefined) {
+  const runtimeKey = getPersistedSessionPath(sessionPath ?? null);
+  if (!runtimeKey) {
+    return;
+  }
+
+  settingsRefreshController.markStale(runtimeKey);
+}
+
+export async function markRuntimeSettingsStaleForProject(projectPath?: string | null) {
+  settingsRefreshController.markStaleForProject(projectPath);
 }
 
 async function createRuntime(options: {
@@ -117,8 +149,24 @@ async function createRuntime(options: {
     if (event.type === "agent_end") {
       void publishThreadUpdate(runtime, "end");
 
+      if (runtimeKey && settingsRefreshController.isStale(runtimeKey)) {
+        void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {
+          // Keep the stale mark; the next safe point will retry silently.
+        });
+      }
+
       if (runtimeKey) {
         scheduleRuntimeDisposal(runtimeKey);
+      }
+
+      return;
+    }
+
+    if (event.type === "compaction_end") {
+      if (runtimeKey && settingsRefreshController.isStale(runtimeKey)) {
+        void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {
+          // Keep the stale mark; the next safe point will retry silently.
+        });
       }
 
       return;
@@ -190,7 +238,11 @@ export async function getOrCreateRuntimeForSessionPath(
       suspendRuntimeDisposal(persistedSessionPath);
     }
 
-    return existingRuntime.runtimePromise;
+    const runtime = await existingRuntime.runtimePromise;
+    if (!isRuntimeBusy(runtime)) {
+      await reloadRuntimeSettingsIfSafe(persistedSessionPath, { useMutationLock: false });
+    }
+    return runtime;
   }
 
   const { SessionManager } = await getPiModule();

--- a/desktop/runtime/settings-refresh.ts
+++ b/desktop/runtime/settings-refresh.ts
@@ -1,0 +1,157 @@
+import path from "node:path";
+import { getPersistedSessionPath } from "../../shared/session-paths";
+import type { ComposerState } from "../../shared/desktop-contracts";
+import type { PiRuntime } from "./types.cts";
+
+export type RuntimeRecordSnapshot = {
+  runtimeKey: string;
+  runtimePromise: Promise<PiRuntime>;
+};
+
+type RuntimeSettingsRefreshControllerOptions = {
+  getCachedRuntimeForSessionPath: (sessionPath: string) => Promise<PiRuntime> | null;
+  getRuntimeRecords: () => RuntimeRecordSnapshot[];
+  withRuntimeMutationLock: <T>(runtimeKey: string, task: () => Promise<T>) => Promise<T>;
+  buildComposerState: (runtime: PiRuntime) => Promise<ComposerState>;
+  publishComposerUpdate: (
+    composer: ComposerState,
+    selection: { projectId: string | null; sessionPath: string | null },
+  ) => void;
+};
+
+export function isRuntimeBusy(runtime: PiRuntime) {
+  return runtime.session.isStreaming || runtime.session.isCompacting;
+}
+
+export function createRuntimeSettingsRefreshController({
+  getCachedRuntimeForSessionPath,
+  getRuntimeRecords,
+  withRuntimeMutationLock,
+  buildComposerState,
+  publishComposerUpdate,
+}: RuntimeSettingsRefreshControllerOptions) {
+  const staleGenerations = new Map<string, number>();
+  const activeReloads = new Map<string, Promise<void>>();
+
+  async function reloadRuntimeSettings(runtimeKey: string, runtime: PiRuntime) {
+    if (isRuntimeBusy(runtime)) {
+      return false;
+    }
+
+    const existingReload = activeReloads.get(runtimeKey);
+    if (existingReload) {
+      await existingReload;
+      return false;
+    }
+
+    const reload = runtime.session.reload().finally(() => {
+      if (activeReloads.get(runtimeKey) === reload) {
+        activeReloads.delete(runtimeKey);
+      }
+    });
+
+    activeReloads.set(runtimeKey, reload);
+    await reload;
+    return true;
+  }
+
+  async function reloadIfSafe(
+    sessionPath: string,
+    options: { useMutationLock?: boolean } = {},
+  ): Promise<boolean> {
+    const runtimeKey = getPersistedSessionPath(sessionPath);
+    if (!runtimeKey || !staleGenerations.has(runtimeKey)) {
+      return false;
+    }
+
+    if (options.useMutationLock ?? true) {
+      return await withRuntimeMutationLock(runtimeKey, () =>
+        reloadIfSafe(runtimeKey, { useMutationLock: false }),
+      );
+    }
+
+    const runtimePromise = getCachedRuntimeForSessionPath(runtimeKey);
+    if (!runtimePromise) {
+      staleGenerations.delete(runtimeKey);
+      return false;
+    }
+
+    const runtime = await runtimePromise;
+    try {
+      let reloaded = false;
+      let reloadedGeneration: number | null = null;
+      while (!isRuntimeBusy(runtime)) {
+        const generation = staleGenerations.get(runtimeKey);
+        if (generation === undefined) {
+          break;
+        }
+
+        const didReload = await reloadRuntimeSettings(runtimeKey, runtime);
+        if (!didReload) {
+          break;
+        }
+
+        reloaded = true;
+        reloadedGeneration = generation;
+        if (staleGenerations.get(runtimeKey) === generation) {
+          break;
+        }
+      }
+
+      if (reloaded) {
+        const composer = await buildComposerState(runtime);
+        publishComposerUpdate(composer, {
+          projectId: runtime.cwd,
+          sessionPath: runtime.session.sessionFile ?? null,
+        });
+        if (
+          reloadedGeneration !== null &&
+          staleGenerations.get(runtimeKey) === reloadedGeneration
+        ) {
+          staleGenerations.delete(runtimeKey);
+        }
+      }
+      return reloaded;
+    } catch {
+      // Keep the stale mark; the next safe point retries silently.
+      return false;
+    }
+  }
+
+  function markStale(sessionPath: string | null | undefined) {
+    const runtimeKey = getPersistedSessionPath(sessionPath ?? null);
+    if (!runtimeKey) {
+      return;
+    }
+
+    staleGenerations.set(runtimeKey, (staleGenerations.get(runtimeKey) ?? 0) + 1);
+    void reloadIfSafe(runtimeKey).catch(() => undefined);
+  }
+
+  function markStaleForProject(projectPath?: string | null) {
+    if (projectPath !== null && projectPath !== undefined && projectPath.trim().length === 0) {
+      return;
+    }
+
+    const normalizedProjectPath = projectPath ? path.resolve(projectPath) : "";
+    for (const { runtimeKey, runtimePromise } of getRuntimeRecords()) {
+      void runtimePromise
+        .then((runtime) => {
+          if (normalizedProjectPath && path.resolve(runtime.cwd) !== normalizedProjectPath) {
+            return;
+          }
+
+          staleGenerations.set(runtimeKey, (staleGenerations.get(runtimeKey) ?? 0) + 1);
+          void reloadIfSafe(runtimeKey).catch(() => undefined);
+        })
+        .catch(() => undefined);
+    }
+  }
+
+  function isStale(sessionPath: string | null | undefined) {
+    const runtimeKey = getPersistedSessionPath(sessionPath ?? null);
+    return Boolean(runtimeKey && staleGenerations.has(runtimeKey));
+  }
+
+  return { isStale, markStale, markStaleForProject, reloadIfSafe };
+}

--- a/desktop/runtime/slash-commands.cts
+++ b/desktop/runtime/slash-commands.cts
@@ -1,0 +1,86 @@
+import type { ComposerSlashCommand, ComposerStateRequest } from "../../shared/desktop-contracts.ts";
+import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
+import { appSettingsSlashCommand } from "../../shared/composer-slash-commands.ts";
+import { getPersistedSessionPath } from "../../shared/session-paths.ts";
+import { createComposerSnapshotSession } from "./composer-state.cts";
+import {
+  getCachedRuntimeForSessionPath,
+  reloadRuntimeSettingsIfSafe,
+  scheduleRuntimeDisposalForRuntime,
+} from "./runtime-registry.cts";
+import type { PiRuntime } from "./types.cts";
+
+function mapSessionCommands(session: PiRuntime["session"]): ComposerSlashCommand[] {
+  const commands: ComposerSlashCommand[] = [appSettingsSlashCommand];
+  const extensionCommandNames = new Set<string>();
+
+  for (const command of session.extensionRunner.getRegisteredCommands()) {
+    extensionCommandNames.add(command.invocationName);
+    commands.push({
+      name: command.invocationName,
+      description: command.description,
+      source: "extension",
+      sourceInfo: command.sourceInfo,
+    });
+  }
+
+  for (const template of session.promptTemplates) {
+    if (extensionCommandNames.has(template.name)) {
+      continue;
+    }
+
+    commands.push({
+      name: template.name,
+      description: template.description,
+      source: "prompt",
+      sourceInfo: template.sourceInfo,
+    });
+  }
+
+  if (session.settingsManager.getEnableSkillCommands()) {
+    for (const skill of session.resourceLoader.getSkills().skills) {
+      const skillCommandName = `skill:${skill.name}`;
+      if (extensionCommandNames.has(skillCommandName)) {
+        continue;
+      }
+
+      commands.push({
+        name: skillCommandName,
+        description: skill.description,
+        source: "skill",
+        sourceInfo: skill.sourceInfo,
+      });
+    }
+  }
+
+  return commands;
+}
+
+export async function getComposerSlashCommands(
+  request: ComposerStateRequest = {},
+): Promise<ComposerSlashCommand[]> {
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  const cachedRuntimePromise = persistedSessionPath
+    ? getCachedRuntimeForSessionPath(persistedSessionPath)
+    : null;
+
+  if (cachedRuntimePromise && persistedSessionPath) {
+    const runtime = await cachedRuntimePromise;
+    if (!runtime.session.isStreaming) {
+      await reloadRuntimeSettingsIfSafe(persistedSessionPath);
+    }
+    scheduleRuntimeDisposalForRuntime(runtime);
+    return mapSessionCommands(runtime.session);
+  }
+
+  const snapshot = await createComposerSnapshotSession({
+    projectId: request.projectId ?? getDesktopWorkingDirectory(),
+    sessionPath: persistedSessionPath,
+  });
+
+  try {
+    return mapSessionCommands(snapshot.session);
+  } finally {
+    snapshot.session.dispose();
+  }
+}

--- a/desktop/skills/mutations.cts
+++ b/desktop/skills/mutations.cts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { PiSkillMutationResult } from "../../shared/desktop-contracts.ts";
+import { markRuntimeSettingsStaleForProject } from "../runtime/runtime-registry.cts";
 import { type SkillDownloadApiFile, downloadSkillApi } from "./api.cts";
 import { listConfiguredPiSkills } from "./configured-skills.cts";
 import {
@@ -108,6 +109,8 @@ export async function installPiSkill(request: {
     throw error;
   }
 
+  await markRuntimeSettingsStaleForProject(request.local ? request.projectPath : null);
+
   return {
     source: request.source,
     normalizedSource: parsedSource.normalizedSource,
@@ -125,14 +128,19 @@ export async function removePiSkill(request: {
   const globalRootPaths = getGlobalSkillsDirs();
   const projectRootPaths = getProjectSkillsDirs(request.projectPath);
 
-  if (
-    !globalRootPaths.some((rootPath) => isPathWithinRootDescendant(installedPath, rootPath)) &&
-    !projectRootPaths.some((rootPath) => isPathWithinRootDescendant(installedPath, rootPath))
-  ) {
+  const isGlobalSkill = globalRootPaths.some((rootPath) =>
+    isPathWithinRootDescendant(installedPath, rootPath),
+  );
+  const isProjectSkill = projectRootPaths.some((rootPath) =>
+    isPathWithinRootDescendant(installedPath, rootPath),
+  );
+
+  if (!isGlobalSkill && !isProjectSkill) {
     throw new Error("That skill cannot be removed from here.");
   }
 
   await rm(installedPath, { recursive: true, force: true });
+  await markRuntimeSettingsStaleForProject(isGlobalSkill ? null : request.projectPath);
 
   return {
     source: installedPath,

--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -87,6 +87,7 @@ const handlers: DesktopRequestHandlerMap = {
   },
   listComposerAttachmentEntries: (request) => listComposerAttachmentEntries(request),
   getComposerState: (request) => piThreads.loadComposerState(request),
+  getComposerSlashCommands: (request) => piThreads.loadComposerSlashCommands(request),
   getDictationState: () => piThreads.getDictationState(),
   listDictationModels: () => piThreads.listDictationModels(),
   installDictationModel: (request) => piThreads.installDictationModel(request),

--- a/shared/composer-slash-commands.ts
+++ b/shared/composer-slash-commands.ts
@@ -1,0 +1,9 @@
+import type { ComposerSlashCommand } from "./desktop-contracts";
+
+export const appSettingsSlashCommand: ComposerSlashCommand = {
+  name: "settings",
+  description: "Open howcode app settings",
+  source: "app",
+};
+
+export const fallbackAppSlashCommands: ComposerSlashCommand[] = [appSettingsSlashCommand];

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -136,6 +136,7 @@ export type DesktopActionPayloadMap = {
     queueSnapshotKey: string;
     queueMode: Exclude<ComposerStreamingBehavior, "stop">;
   };
+  "composer.reload-settings": { projectId?: string | null; sessionPath?: string | null };
   "inbox.mark-read": { sessionPath: string; projectId?: string | null };
   "inbox.dismiss": { sessionPath: string; projectId?: string | null };
   "composer.host": EmptyActionPayload;

--- a/shared/desktop-action-coverage.ts
+++ b/shared/desktop-action-coverage.ts
@@ -25,6 +25,7 @@ export const implementedDesktopActions = [
   "composer.model",
   "composer.thinking",
   "composer.send",
+  "composer.reload-settings",
   "inbox.mark-read",
   "inbox.dismiss",
   "workspace.commit",

--- a/shared/desktop-actions.ts
+++ b/shared/desktop-actions.ts
@@ -39,6 +39,7 @@ export const desktopActions = [
   "composer.send",
   "composer.stop",
   "composer.dequeue",
+  "composer.reload-settings",
   "composer.host",
   "inbox.mark-read",
   "inbox.dismiss",

--- a/shared/desktop-composer-contracts.ts
+++ b/shared/desktop-composer-contracts.ts
@@ -50,3 +50,12 @@ export type ComposerStateRequest = {
   projectId?: string | null;
   sessionPath?: string | null;
 };
+
+export type ComposerSlashCommandSource = "app" | "extension" | "prompt" | "skill";
+
+export type ComposerSlashCommand = {
+  name: string;
+  description?: string;
+  source: ComposerSlashCommandSource;
+  sourceInfo?: unknown;
+};

--- a/shared/desktop-ipc.ts
+++ b/shared/desktop-ipc.ts
@@ -6,6 +6,7 @@ import type {
   DesktopClipboardFilePaths,
   DesktopClipboardSnapshot,
   ComposerFilePickerState,
+  ComposerSlashCommand,
   ComposerState,
   ComposerStateRequest,
   DesktopActionResult,
@@ -127,6 +128,7 @@ export type DesktopRequestMap = {
     response: ComposerFilePickerState;
   };
   getComposerState: { params: ComposerStateRequest; response: ComposerState };
+  getComposerSlashCommands: { params: ComposerStateRequest; response: ComposerSlashCommand[] };
   getDictationState: { params: Record<string, never>; response: DictationState };
   listDictationModels: { params: Record<string, never>; response: DictationModelSummary[] };
   installDictationModel: {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -252,7 +252,7 @@ export function useAppShellController() {
     setTakeoverOverrideForSelectedSession(true);
   };
 
-  const closeTakeover = ({
+  const closeTakeover = async ({
     preserveSessionOverride = false,
     refreshThread = true,
   }: {
@@ -267,6 +267,13 @@ export function useAppShellController() {
 
     if (refreshThread) {
       setThreadRefreshKey((current) => current + 1);
+    }
+
+    if (state.selectedSessionPath) {
+      await handleAction("composer.reload-settings", {
+        projectId: composerProjectId,
+        sessionPath: state.selectedSessionPath,
+      });
     }
   };
 

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -14,6 +14,11 @@ import {
   hasFilePayloadInClipboardData,
 } from "./composer-paste-attachments";
 import { useComposerController } from "./useComposerController";
+import {
+  getComposerSlashCommandOptionId,
+  slashCommandSourceLabels,
+  useComposerSlashCommands,
+} from "./useComposerSlashCommands";
 
 type ComposerPromptSurfaceProps = ComposerProps & {
   composerPanelRef: RefObject<HTMLDivElement | null>;
@@ -108,6 +113,14 @@ export function ComposerPromptSurface({
     onListAttachmentEntries,
   });
   const dictationTranscribing = dictationInterimText.length > 0;
+  const slashCommands = useComposerSlashCommands({
+    draft,
+    projectId,
+    sessionPath,
+    setDraft,
+    send,
+    onOpenSettingsView,
+  });
 
   useEffect(() => {
     if (!pickerOpen && !dictationActive && !dictationTranscribing) {
@@ -238,6 +251,62 @@ export function ComposerPromptSurface({
               </div>
 
               <div className="min-w-0 flex-1">
+                {slashCommands.open ? (
+                  <div
+                    id={slashCommands.listboxId}
+                    // biome-ignore lint/a11y/useSemanticElements: This is a textarea-owned combobox popup, not a native select.
+                    role="listbox"
+                    tabIndex={-1}
+                    aria-label="Composer slash commands"
+                    className="absolute right-3 bottom-[calc(100%-0.25rem)] left-12 z-20 max-h-64 overflow-auto rounded-xl border border-[rgba(169,178,215,0.12)] bg-[#202332] p-1.5 shadow-[0_16px_48px_rgba(0,0,0,0.38)]"
+                  >
+                    {slashCommands.commands.length > 0 ? (
+                      slashCommands.commands.map((command, index) => {
+                        const selected = index === slashCommands.selectedIndex;
+                        const previous = slashCommands.commands[index - 1];
+                        const showGroup = previous?.source !== command.source;
+                        return (
+                          <div key={`${command.source}:${command.name}`}>
+                            {showGroup ? (
+                              <div className="px-2 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--muted-2)]">
+                                {slashCommandSourceLabels[command.source]}
+                              </div>
+                            ) : null}
+                            <button
+                              id={getComposerSlashCommandOptionId(index)}
+                              type="button"
+                              // biome-ignore lint/a11y/useSemanticElements: Command options remain clickable buttons inside the textarea-owned listbox.
+                              role="option"
+                              aria-selected={selected}
+                              className={cn(
+                                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left",
+                                selected
+                                  ? "bg-[rgba(169,178,215,0.14)] text-[color:var(--text)]"
+                                  : "text-[color:var(--muted)] hover:bg-[rgba(169,178,215,0.08)] hover:text-[color:var(--text)]",
+                              )}
+                              onPointerEnter={() => slashCommands.setSelectedIndex(index)}
+                              onMouseDown={(event) => event.preventDefault()}
+                              onClick={() => slashCommands.selectCommand(command)}
+                            >
+                              <span className="shrink-0 font-mono text-[12px] text-[color:var(--text)]">
+                                /{command.name}
+                              </span>
+                              {command.description ? (
+                                <span className="min-w-0 truncate text-[12px]">
+                                  {command.description}
+                                </span>
+                              ) : null}
+                            </button>
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <div className="px-2 py-2 text-[12px] text-[color:var(--muted)]">
+                        {slashCommands.loading ? "Loading commands…" : "No matching commands"}
+                      </div>
+                    )}
+                  </div>
+                ) : null}
                 <ComposerTextField
                   value={draft}
                   onChange={setDraft}
@@ -247,6 +316,10 @@ export function ComposerPromptSurface({
                     }
                   }}
                   onKeyDown={(event) => {
+                    if (slashCommands.handleKeyDown(event)) {
+                      return;
+                    }
+
                     if (event.key === "Escape" && (dictationActive || dictationTranscribing)) {
                       event.preventDefault();
                       void cancelDictation();
@@ -255,7 +328,7 @@ export function ComposerPromptSurface({
 
                     if (event.key === "Enter" && !event.shiftKey) {
                       event.preventDefault();
-                      void send();
+                      slashCommands.submit();
                     }
                   }}
                   onPaste={(event: ClipboardEvent<HTMLTextAreaElement>) => {
@@ -281,6 +354,9 @@ export function ComposerPromptSurface({
                     });
                   }}
                   ariaLabel="Prompt composer"
+                  ariaActiveDescendant={slashCommands.activeDescendantId}
+                  ariaControls={slashCommands.open ? slashCommands.listboxId : undefined}
+                  ariaExpanded={slashCommands.open}
                   placeholder={placeholderText}
                   reservedLineCount={1}
                   onHeightChange={onLayoutChange}
@@ -318,7 +394,7 @@ export function ComposerPromptSurface({
                   compactIconButtonClass,
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
-                onClick={() => void send()}
+                onClick={slashCommands.submit}
                 disabled={!canSend}
                 aria-label="Send"
                 title="Send"

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -4,6 +4,9 @@ type ComposerTextFieldProps = {
   value: string;
   placeholder: string;
   ariaLabel: string;
+  ariaActiveDescendant?: string;
+  ariaControls?: string;
+  ariaExpanded?: boolean;
   reservedLineCount?: number;
   onHeightChange?: (height: number) => void;
   onChange: (value: string) => void;
@@ -19,6 +22,9 @@ export function ComposerTextField({
   value,
   placeholder,
   ariaLabel,
+  ariaActiveDescendant,
+  ariaControls,
+  ariaExpanded,
   reservedLineCount = 4,
   onHeightChange,
   onChange,
@@ -106,6 +112,10 @@ export function ComposerTextField({
         onFocus={onFocus}
         onBlur={onBlur}
         aria-label={ariaLabel}
+        aria-activedescendant={ariaActiveDescendant}
+        aria-autocomplete={ariaControls ? "list" : undefined}
+        aria-controls={ariaControls}
+        aria-expanded={ariaExpanded}
         placeholder={placeholder}
       />
     </div>

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -1,0 +1,214 @@
+import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
+import { appSettingsSlashCommand } from "../../../../../shared/composer-slash-commands";
+import type { ComposerSlashCommand } from "../../../desktop/types";
+import { getComposerSlashCommandsQuery } from "../../../query/desktop-query";
+
+export const slashCommandSourceLabels: Record<ComposerSlashCommand["source"], string> = {
+  app: "App",
+  extension: "Extensions",
+  prompt: "Prompts",
+  skill: "Skills",
+};
+
+export const composerSlashCommandListboxId = "composer-slash-command-listbox";
+
+export function getComposerSlashCommandOptionId(index: number) {
+  return `composer-slash-command-${index}`;
+}
+
+function getSlashCommandFilter(draft: string) {
+  if (!draft.startsWith("/")) {
+    return null;
+  }
+
+  const query = draft.slice(1);
+  if (/\s/.test(query)) {
+    return null;
+  }
+
+  return query.toLowerCase();
+}
+
+type UseComposerSlashCommandsOptions = {
+  draft: string;
+  projectId: string;
+  sessionPath: string | null;
+  setDraft: (draft: string) => void;
+  send: () => void;
+  onOpenSettingsView: () => void;
+};
+
+export function useComposerSlashCommands({
+  draft,
+  projectId,
+  sessionPath,
+  setDraft,
+  send,
+  onOpenSettingsView,
+}: UseComposerSlashCommandsOptions) {
+  const [commands, setCommands] = useState<ComposerSlashCommand[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dismissedDraft, setDismissedDraft] = useState<string | null>(null);
+  const candidateFilter = getSlashCommandFilter(draft);
+  const filter = draft === dismissedDraft ? null : candidateFilter;
+  const open = filter !== null;
+  const filteredCommands = useMemo(() => {
+    if (filter === null) {
+      return [];
+    }
+
+    return commands.filter((command) => {
+      const haystack = `${command.name} ${command.description ?? ""}`.toLowerCase();
+      return haystack.includes(filter);
+    });
+  }, [commands, filter]);
+
+  const selectCommand = (command: ComposerSlashCommand) => {
+    if (command.source === "app" && command.name === "settings") {
+      setDraft("");
+      onOpenSettingsView();
+      return;
+    }
+
+    setDraft(`/${command.name} `);
+  };
+
+  const submit = () => {
+    if (open) {
+      const selectedCommand = filteredCommands[selectedIndex];
+      if (selectedCommand) {
+        selectCommand(selectedCommand);
+        return;
+      }
+
+      if (loading && draft.trim() !== "/settings") {
+        return;
+      }
+    }
+
+    // Keep this exact-match only: selected Pi commands named "settings" intentionally insert
+    // "/settings " so they can still be sent through AgentSession.prompt().
+    if (draft === "/settings") {
+      selectCommand(appSettingsSlashCommand);
+      return;
+    }
+
+    send();
+  };
+
+  const dismiss = () => {
+    setDismissedDraft(draft);
+    setCommands([]);
+    setLoading(false);
+    setSelectedIndex(0);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!open) {
+      return false;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      dismiss();
+      return true;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedIndex((current) =>
+        Math.min(current + 1, Math.max(0, filteredCommands.length - 1)),
+      );
+      return true;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedIndex((current) => Math.max(0, current - 1));
+      return true;
+    }
+
+    if (event.key === "Enter" && !event.shiftKey && filteredCommands[selectedIndex]) {
+      event.preventDefault();
+      selectCommand(filteredCommands[selectedIndex]);
+      return true;
+    }
+
+    if (event.key === "Enter" && !event.shiftKey && draft === "/settings") {
+      event.preventDefault();
+      submit();
+      return true;
+    }
+
+    if (event.key === "Enter" && !event.shiftKey && loading) {
+      event.preventDefault();
+      return true;
+    }
+
+    return false;
+  };
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedIndex(0);
+      setCommands([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setCommands([]);
+    setSelectedIndex(0);
+    setLoading(true);
+    void getComposerSlashCommandsQuery({ projectId, sessionPath })
+      .then((nextCommands) => {
+        if (!cancelled) {
+          setCommands(nextCommands);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCommands([appSettingsSlashCommand]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, projectId, sessionPath]);
+
+  useEffect(() => {
+    if (selectedIndex >= filteredCommands.length) {
+      setSelectedIndex(Math.max(0, filteredCommands.length - 1));
+    }
+  }, [filteredCommands.length, selectedIndex]);
+
+  useEffect(() => {
+    if (dismissedDraft !== null && draft !== dismissedDraft) {
+      setDismissedDraft(null);
+    }
+  }, [dismissedDraft, draft]);
+
+  return {
+    activeDescendantId: open
+      ? filteredCommands[selectedIndex]
+        ? getComposerSlashCommandOptionId(selectedIndex)
+        : undefined
+      : undefined,
+    commands: filteredCommands,
+    handleKeyDown,
+    listboxId: composerSlashCommandListboxId,
+    loading,
+    open,
+    selectCommand,
+    selectedIndex,
+    setSelectedIndex,
+    submit,
+  };
+}

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -9,6 +9,8 @@ export type {
   ComposerFilePickerState,
   ComposerModel,
   ComposerQueuedPrompt,
+  ComposerSlashCommand,
+  ComposerSlashCommandSource,
   ComposerStreamingBehavior,
   ComposerState,
   ComposerStateRequest,

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -144,6 +144,7 @@ export function installDevWebDesktopBridge() {
     listComposerAttachmentEntries: (request = {}) =>
       invokeRequest("listComposerAttachmentEntries", request),
     getComposerState: (request = {}) => invokeRequest("getComposerState", request),
+    getComposerSlashCommands: (request = {}) => invokeRequest("getComposerSlashCommands", request),
     getDictationState: () => invokeRequest("getDictationState", {}),
     listDictationModels: () => invokeRequest("listDictationModels", {}),
     installDictationModel: (modelId: "tiny.en" | "base.en" | "small.en") =>

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -1,8 +1,10 @@
 import { getPersistedSessionPath } from "../../../shared/session-paths";
+import { fallbackAppSlashCommands } from "../../../shared/composer-slash-commands";
 import type {
   ArchivedThread,
   ComposerAttachment,
   ComposerFilePickerState,
+  ComposerSlashCommand,
   ComposerState,
   ComposerStateRequest,
   DesktopClipboardFilePaths,
@@ -79,6 +81,12 @@ export async function getComposerStateQuery(
   request: ComposerStateRequest = {},
 ): Promise<ComposerState | null> {
   return (await window.piDesktop?.getComposerState?.(request)) ?? null;
+}
+
+export async function getComposerSlashCommandsQuery(
+  request: ComposerStateRequest = {},
+): Promise<ComposerSlashCommand[]> {
+  return (await window.piDesktop?.getComposerSlashCommands?.(request)) ?? fallbackAppSlashCommands;
 }
 
 export async function getProjectGitStateQuery(projectId: string): Promise<ProjectGitState | null> {

--- a/src/electron/main/ipc/request-handlers/pi-threads.ts
+++ b/src/electron/main/ipc/request-handlers/pi-threads.ts
@@ -11,6 +11,7 @@ type PiThreadsRequestHandlers = Pick<
   | "captureProjectDiffBaseline"
   | "listProjectCommits"
   | "getComposerState"
+  | "getComposerSlashCommands"
   | "getDictationState"
   | "listDictationModels"
   | "installDictationModel"
@@ -36,6 +37,7 @@ export function createPiThreadsHandlers(piThreads: PiThreadsModule): PiThreadsRe
     listProjectCommits: ({ projectId, limit }) =>
       piThreads.listProjectCommits(projectId, limit ?? null),
     getComposerState: (request) => piThreads.loadComposerState(request),
+    getComposerSlashCommands: (request) => piThreads.loadComposerSlashCommands(request),
     getDictationState: () => piThreads.getDictationState(),
     listDictationModels: () => piThreads.listDictationModels(),
     installDictationModel: (request) => piThreads.installDictationModel(request),

--- a/src/electron/main/runtime/desktop-runtime-contracts.ts
+++ b/src/electron/main/runtime/desktop-runtime-contracts.ts
@@ -4,6 +4,7 @@ import type {
   ArchivedThread,
   ComposerState,
   ComposerStateRequest,
+  ComposerSlashCommand,
   DesktopActionResultData,
   DesktopEvent,
   DictationModelInstallResult,
@@ -44,6 +45,7 @@ export type PiThreadsModule = {
   loadArchivedThreadList: () => Promise<ArchivedThread[]>;
   loadInboxThreadList: () => Promise<InboxThread[]>;
   loadComposerState: (request: ComposerStateRequest) => Promise<ComposerState>;
+  loadComposerSlashCommands: (request: ComposerStateRequest) => Promise<ComposerSlashCommand[]>;
   getDictationState: () => Promise<DictationState>;
   listDictationModels: () => Promise<DictationModelSummary[]>;
   installDictationModel: (request: {

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -99,6 +99,7 @@ export function createDesktopApi() {
     listComposerAttachmentEntries: (request = {}) =>
       invokeRequest("listComposerAttachmentEntries", request),
     getComposerState: (request = {}) => invokeRequest("getComposerState", request),
+    getComposerSlashCommands: (request = {}) => invokeRequest("getComposerSlashCommands", request),
     getDictationState: () => invokeRequest("getDictationState", {}),
     listDictationModels: () => invokeRequest("listDictationModels", {}),
     installDictationModel: (modelId: "tiny.en" | "base.en" | "small.en") =>

--- a/src/test/runtime-settings-refresh.test.ts
+++ b/src/test/runtime-settings-refresh.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRuntimeSettingsRefreshController } from "../../desktop/runtime/settings-refresh";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function createRuntime(reload: () => Promise<void> = async () => undefined) {
+  return {
+    cwd: "/repo",
+    session: {
+      isStreaming: false,
+      isCompacting: false,
+      sessionFile: "/repo/.pi/session.jsonl",
+      reload,
+    },
+  } as never;
+}
+
+describe("runtime settings refresh", () => {
+  it("publishes composer state after a safe stale reload", async () => {
+    const runtime = createRuntime();
+    const publishComposerUpdate = vi.fn();
+    const controller = createRuntimeSettingsRefreshController({
+      getCachedRuntimeForSessionPath: () => Promise.resolve(runtime),
+      getRuntimeRecords: () => [],
+      withRuntimeMutationLock: async <T>(_runtimeKey: string, task: () => Promise<T>) => task(),
+      buildComposerState: async () => ({
+        currentModel: null,
+        availableModels: [],
+        currentThinkingLevel: "medium",
+        availableThinkingLevels: ["medium"],
+        queuedPrompts: [],
+      }),
+      publishComposerUpdate,
+    });
+
+    controller.markStale("/repo/.pi/session.jsonl");
+    await vi.waitFor(() => expect(publishComposerUpdate).toHaveBeenCalledTimes(1));
+    expect(controller.isStale("/repo/.pi/session.jsonl")).toBe(false);
+  });
+
+  it("runs another reload when a newer stale generation arrives during reload", async () => {
+    const firstReload = deferred();
+    const reload = vi
+      .fn<() => Promise<void>>()
+      .mockReturnValueOnce(firstReload.promise)
+      .mockResolvedValueOnce(undefined);
+    const runtime = createRuntime(reload);
+    const controller = createRuntimeSettingsRefreshController({
+      getCachedRuntimeForSessionPath: () => Promise.resolve(runtime),
+      getRuntimeRecords: () => [],
+      withRuntimeMutationLock: async <T>(_runtimeKey: string, task: () => Promise<T>) => task(),
+      buildComposerState: async () => ({
+        currentModel: null,
+        availableModels: [],
+        currentThinkingLevel: "medium",
+        availableThinkingLevels: ["medium"],
+        queuedPrompts: [],
+      }),
+      publishComposerUpdate: vi.fn(),
+    });
+
+    controller.markStale("/repo/.pi/session.jsonl");
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    controller.markStale("/repo/.pi/session.jsonl");
+    firstReload.resolve();
+
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(2));
+    expect(controller.isStale("/repo/.pi/session.jsonl")).toBe(false);
+  });
+});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ import type {
   DesktopClipboardFilePaths,
   DesktopClipboardSnapshot,
   ComposerFilePickerState,
+  ComposerSlashCommand,
   ComposerState,
   ComposerStateRequest,
   DesktopActionResult,
@@ -119,6 +120,9 @@ declare global {
         rootPath?: string | null;
       }) => Promise<ComposerFilePickerState>;
       getComposerState?: (request?: ComposerStateRequest) => Promise<ComposerState>;
+      getComposerSlashCommands?: (
+        request?: ComposerStateRequest,
+      ) => Promise<ComposerSlashCommand[]>;
       getDictationState?: () => Promise<DictationState>;
       listDictationModels?: () => Promise<DictationModelSummary[]>;
       installDictationModel?: (


### PR DESCRIPTION
## Summary
- add a Pi-backed slash command discovery bridge for composer commands
- add a composer `/` picker with app, extension, prompt, and skill command groups
- make `/settings` open howcode Settings instead of sending a Pi prompt
- add a silent safe Pi settings reload path for returning from TUI takeover to desktop

## Details
- Pi commands are read lazily when the slash picker opens from the current live runtime or a lightweight snapshot session.
- Extension, prompt-template, and skill commands are inserted into the composer and still execute through the existing `composer.send` / `session.prompt` path.
- Runtime settings reloads are stale-marked and only applied when idle, or after `agent_end` if a run is active.
- No settings file watchers or polling were added.

## Validation
- `bun run typecheck:web && bun run typecheck:desktop && bun run typecheck:electron && bun run typecheck:scripts`
- pre-commit full `vitest run` passed

Closes #62
Closes #102
Refs #70
