### PR TITLE
Enable native compact slash command

### DIFF
--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -1,5 +1,9 @@
 import type { DesktopAction } from "../../shared/desktop-actions.ts";
-import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts";
+import type {
+  AnyDesktopActionPayload,
+  ComposerAttachment,
+} from "../../shared/desktop-contracts.ts";
+import { isCompactSlashCommand } from "../../shared/composer-slash-commands.ts";
 import {
   getComposerAttachments,
   getComposerModelSelection,
@@ -46,14 +50,18 @@ export async function handleComposerDesktopAction(
 
     case "composer.send": {
       const text = getComposerText(payload);
-      const rawAttachments = getComposerAttachments(payload);
-      const normalizedAttachmentPayload = await normalizeComposerSendAttachments(rawAttachments);
-      const attachments = normalizedAttachmentPayload.attachments;
-      if (normalizedAttachmentPayload.rejected) {
-        return handledAction({
-          error:
-            "Could not send prompt because one or more attached files are no longer available.",
-        });
+      let attachments: ComposerAttachment[] = [];
+
+      if (!isCompactSlashCommand(text)) {
+        const rawAttachments = getComposerAttachments(payload);
+        const normalizedAttachmentPayload = await normalizeComposerSendAttachments(rawAttachments);
+        attachments = normalizedAttachmentPayload.attachments;
+        if (normalizedAttachmentPayload.rejected) {
+          return handledAction({
+            error:
+              "Could not send prompt because one or more attached files are no longer available.",
+          });
+        }
       }
 
       if (!text && attachments.length === 0) {

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -6,6 +6,7 @@ import type {
   ComposerThinkingLevel,
 } from "../../shared/desktop-contracts.ts";
 import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
+import { parseCompactSlashCommand } from "../../shared/composer-slash-commands.ts";
 import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { loadAppSettings } from "../app-settings.cts";
 import { getPiModule } from "../pi-module.cts";
@@ -165,8 +166,35 @@ export async function sendComposerPrompt(
   },
 ): Promise<"sent" | "stopped"> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
+  const compactInstructions = parseCompactSlashCommand(request.text);
 
   const runSend = async (runtime: Awaited<ReturnType<typeof getOrCreateRuntimeForSessionPath>>) => {
+    if (compactInstructions !== null) {
+      try {
+        if (runtime.session.isStreaming) {
+          throw new Error("Wait for the current response to finish before compacting.");
+        }
+
+        if (runtime.session.isCompacting) {
+          throw new Error("Wait for the current compaction to finish before compacting again.");
+        }
+
+        const entries = runtime.session.sessionManager.getBranch();
+        const messageCount = entries.filter((entry) => entry.type === "message").length;
+        if (messageCount < 2) {
+          throw new Error("Nothing to compact (no messages yet)");
+        }
+
+        await runtime.session.compact(
+          compactInstructions.length > 0 ? compactInstructions : undefined,
+        );
+        await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+        return "sent";
+      } finally {
+        scheduleRuntimeDisposalForRuntime(runtime);
+      }
+    }
+
     const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
     const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;
     const streamingBehavior =

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -163,6 +163,10 @@ async function createRuntime(options: {
     }
 
     if (event.type === "compaction_end") {
+      if (event.reason === "manual" && event.result) {
+        void publishThreadUpdate(runtime, "compaction");
+      }
+
       if (runtimeKey && settingsRefreshController.isStale(runtimeKey)) {
         void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {
           // Keep the stale mark; the next safe point will retry silently.

--- a/desktop/runtime/slash-commands.cts
+++ b/desktop/runtime/slash-commands.cts
@@ -1,6 +1,9 @@
 import type { ComposerSlashCommand, ComposerStateRequest } from "../../shared/desktop-contracts.ts";
 import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
-import { appSettingsSlashCommand } from "../../shared/composer-slash-commands.ts";
+import {
+  appSettingsSlashCommand,
+  compactSlashCommand,
+} from "../../shared/composer-slash-commands.ts";
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { createComposerSnapshotSession } from "./composer-state.cts";
 import {
@@ -10,11 +13,17 @@ import {
 } from "./runtime-registry.cts";
 import type { PiRuntime } from "./types.cts";
 
+const builtinCommandNames = new Set([compactSlashCommand.name]);
+
 function mapSessionCommands(session: PiRuntime["session"]): ComposerSlashCommand[] {
-  const commands: ComposerSlashCommand[] = [appSettingsSlashCommand];
+  const commands: ComposerSlashCommand[] = [appSettingsSlashCommand, compactSlashCommand];
   const extensionCommandNames = new Set<string>();
 
   for (const command of session.extensionRunner.getRegisteredCommands()) {
+    if (builtinCommandNames.has(command.invocationName)) {
+      continue;
+    }
+
     extensionCommandNames.add(command.invocationName);
     commands.push({
       name: command.invocationName,
@@ -25,7 +34,7 @@ function mapSessionCommands(session: PiRuntime["session"]): ComposerSlashCommand
   }
 
   for (const template of session.promptTemplates) {
-    if (extensionCommandNames.has(template.name)) {
+    if (builtinCommandNames.has(template.name) || extensionCommandNames.has(template.name)) {
       continue;
     }
 
@@ -40,7 +49,10 @@ function mapSessionCommands(session: PiRuntime["session"]): ComposerSlashCommand
   if (session.settingsManager.getEnableSkillCommands()) {
     for (const skill of session.resourceLoader.getSkills().skills) {
       const skillCommandName = `skill:${skill.name}`;
-      if (extensionCommandNames.has(skillCommandName)) {
+      if (
+        builtinCommandNames.has(skillCommandName) ||
+        extensionCommandNames.has(skillCommandName)
+      ) {
         continue;
       }
 

--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -80,7 +80,7 @@ export function normalizeThreadDataForReason(
   thread: ThreadData,
   reason: RuntimeThreadReason | "external",
 ): ThreadData {
-  if (reason !== "end" && reason !== "external") {
+  if (reason !== "end" && reason !== "external" && reason !== "compaction") {
     return thread;
   }
 

--- a/shared/composer-slash-commands.ts
+++ b/shared/composer-slash-commands.ts
@@ -1,9 +1,33 @@
 import type { ComposerSlashCommand } from "./desktop-contracts";
 
+const compactCommandPattern = /^\/compact(?:\s+([\s\S]*))?$/;
+
+export function parseCompactSlashCommand(text: string) {
+  const match = compactCommandPattern.exec(text.trim());
+  if (!match) {
+    return null;
+  }
+
+  return match[1]?.trim() ?? "";
+}
+
+export function isCompactSlashCommand(text: string) {
+  return parseCompactSlashCommand(text) !== null;
+}
+
 export const appSettingsSlashCommand: ComposerSlashCommand = {
   name: "settings",
   description: "Open howcode app settings",
   source: "app",
 };
 
-export const fallbackAppSlashCommands: ComposerSlashCommand[] = [appSettingsSlashCommand];
+export const compactSlashCommand: ComposerSlashCommand = {
+  name: "compact",
+  description: "Manually compact the session context",
+  source: "builtin",
+};
+
+export const fallbackAppSlashCommands: ComposerSlashCommand[] = [
+  appSettingsSlashCommand,
+  compactSlashCommand,
+];

--- a/shared/desktop-composer-contracts.ts
+++ b/shared/desktop-composer-contracts.ts
@@ -51,7 +51,7 @@ export type ComposerStateRequest = {
   sessionPath?: string | null;
 };
 
-export type ComposerSlashCommandSource = "app" | "extension" | "prompt" | "skill";
+export type ComposerSlashCommandSource = "app" | "builtin" | "extension" | "prompt" | "skill";
 
 export type ComposerSlashCommand = {
   name: string;

--- a/shared/desktop-event-contracts.ts
+++ b/shared/desktop-event-contracts.ts
@@ -16,7 +16,7 @@ export type DesktopEvent =
     }
   | {
       type: "thread-update";
-      reason: "start" | "update" | "end" | "external";
+      reason: "start" | "update" | "end" | "external" | "compaction";
       projectId: string;
       threadId: string;
       sessionPath: string;

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -356,7 +356,12 @@ export function useAppShellEffects({
         setComposerState(event.composer);
       }
 
-      if (event.reason === "start" || event.reason === "end" || event.reason === "external") {
+      if (
+        event.reason === "start" ||
+        event.reason === "end" ||
+        event.reason === "external" ||
+        event.reason === "compaction"
+      ) {
         void loadProjectThreads(event.projectId);
         void queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() });
         scheduleShellStateRefresh();

--- a/src/app/components/workspace/composer/submitComposerDraft.ts
+++ b/src/app/components/workspace/composer/submitComposerDraft.ts
@@ -4,6 +4,7 @@ import type {
   DesktopActionInvoker,
 } from "../../../desktop/types";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
+import { isCompactSlashCommand } from "../../../../../shared/composer-slash-commands";
 
 type SubmitComposerDraftResult =
   | { status: "skipped" }
@@ -40,9 +41,10 @@ export async function submitComposerDraft({
   }
 
   try {
+    const sendAttachments = isCompactSlashCommand(text) ? [] : attachments;
     const actionResult = await onAction("composer.send", {
       text,
-      attachments,
+      attachments: sendAttachments,
       projectId,
       sessionPath,
       streamingBehavior: streamingBehaviorPreference,
@@ -61,7 +63,7 @@ export async function submitComposerDraft({
       return { status: "stopped", text };
     }
 
-    if (draftThreadId) {
+    if (draftThreadId && !isCompactSlashCommand(text)) {
       clearStoredDraft(draftThreadId);
     }
 

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -1,10 +1,14 @@
 import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
-import { appSettingsSlashCommand } from "../../../../../shared/composer-slash-commands";
+import {
+  appSettingsSlashCommand,
+  fallbackAppSlashCommands,
+} from "../../../../../shared/composer-slash-commands";
 import type { ComposerSlashCommand } from "../../../desktop/types";
 import { getComposerSlashCommandsQuery } from "../../../query/desktop-query";
 
 export const slashCommandSourceLabels: Record<ComposerSlashCommand["source"], string> = {
   app: "App",
+  builtin: "Pi",
   extension: "Extensions",
   prompt: "Prompts",
   skill: "Skills",
@@ -169,7 +173,7 @@ export function useComposerSlashCommands({
       })
       .catch(() => {
         if (!cancelled) {
-          setCommands([appSettingsSlashCommand]);
+          setCommands(fallbackAppSlashCommands);
         }
       })
       .finally(() => {

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../desktop/types";
 import { composerDraftStore } from "./composerDraftStore";
 import { withComposerSendLock } from "./composerSendLock";
+import { isCompactSlashCommand } from "../../../../../shared/composer-slash-commands";
 import { submitComposerDraft } from "./submitComposerDraft";
 
 type UseComposerSubmissionProps = {
@@ -81,12 +82,17 @@ export function useComposerSubmission({
         }
 
         const submittedDraft = textToSend;
+        const preserveAttachments = isCompactSlashCommand(submittedDraft);
 
         setErrorMessage(null);
         setOpenMenu(null);
-        skipNextDraftPersistenceRef.current = submittedDraftThreadId;
+        if (!preserveAttachments) {
+          skipNextDraftPersistenceRef.current = submittedDraftThreadId;
+        }
         setDraftValue("");
-        setAttachments([]);
+        if (!preserveAttachments) {
+          setAttachments([]);
+        }
 
         const result = await submitComposerDraft({
           draft: submittedDraft,

--- a/src/test/submit-composer-draft.test.ts
+++ b/src/test/submit-composer-draft.test.ts
@@ -223,6 +223,33 @@ describe("submitComposerDraft", () => {
     expect(clearStoredDraft).toHaveBeenCalledWith("session:/repo/thread.json");
   });
 
+  it("sends compact commands without attachments and keeps stored attachments available", async () => {
+    const onAction = vi.fn(async () => buildActionSuccessResult());
+    const clearStoredDraft = vi.fn();
+
+    const result = await submitComposerDraft({
+      draft: "  /compact keep repo state  ",
+      attachments: [{ path: "/repo/file.ts", name: "file.ts", kind: "text" }],
+      draftThreadId: "session:/repo/thread.json",
+      isSending: false,
+      projectId: "/repo",
+      sessionPath: "/repo/thread.json",
+      streamingBehaviorPreference: "followUp",
+      onAction,
+      clearStoredDraft,
+    });
+
+    expect(result).toEqual({ status: "sent", text: "/compact keep repo state" });
+    expect(onAction).toHaveBeenCalledWith("composer.send", {
+      text: "/compact keep repo state",
+      attachments: [],
+      projectId: "/repo",
+      sessionPath: "/repo/thread.json",
+      streamingBehavior: "followUp",
+    });
+    expect(clearStoredDraft).not.toHaveBeenCalled();
+  });
+
   it("skips sends while a request is already in flight", async () => {
     const onAction = vi.fn(async () => null);
 


### PR DESCRIPTION
## Summary
- add /compact to composer slash command discovery and fallback commands
- route raw /compact commands to Pi native session.compact() while preserving attachments for the next prompt
- publish manual compaction thread updates without inbox end-of-turn side effects

## Validation
- pre-commit passed: Biome, typechecks, Vitest (112 tests)

Refs #29
Refs #105