### PR TITLE
Show context usage in composer

### DIFF
--- a/desktop/pi-threads/thread-loader.cts
+++ b/desktop/pi-threads/thread-loader.cts
@@ -84,6 +84,7 @@ export async function loadThreadSnapshot(
       sourceMessages: historySlice.sourceMessages,
       previousMessageCount: historySlice.previousMessageCount,
       isStreaming: false,
+      isCompacting: false,
     }),
   };
 }
@@ -93,7 +94,10 @@ export async function loadThread(
   options?: { historyCompactions?: number },
 ): Promise<ThreadData> {
   const liveThread = getLiveThread(sessionPath);
-  if (liveThread?.isStreaming && (options?.historyCompactions ?? 0) === 0) {
+  if (
+    (liveThread?.isStreaming || liveThread?.isCompacting) &&
+    (options?.historyCompactions ?? 0) === 0
+  ) {
     return liveThread;
   }
 

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -188,6 +188,7 @@ export async function sendComposerPrompt(
         await runtime.session.compact(
           compactInstructions.length > 0 ? compactInstructions : undefined,
         );
+
         await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
         return "sent";
       } finally {
@@ -201,6 +202,10 @@ export async function sendComposerPrompt(
       request.streamingBehavior ?? loadAppSettings().composerStreamingBehavior;
 
     try {
+      if (runtime.session.isCompacting) {
+        throw new Error("Wait for the current compaction to finish before sending another prompt.");
+      }
+
       if (runtime.session.isStreaming) {
         if (streamingBehavior === "stop") {
           await runtime.session.abort();

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -2,6 +2,7 @@ import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import { supportsXhigh } from "@mariozechner/pi-ai";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type {
+  ComposerContextUsage,
   ComposerModel,
   ComposerQueuedPrompt,
   ComposerState,
@@ -17,6 +18,11 @@ import type { PiRuntime } from "./types.cts";
 export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
 
 type ComposerSourceModel = NonNullable<AgentSession["model"]>;
+type BuildComposerStateOptions = {
+  includeContextUsage?: boolean;
+};
+
+const contextUsageCache = new WeakMap<AgentSession, ComposerContextUsage | null>();
 
 function mapComposerModel(
   model: AgentSession["model"] | ComposerSourceModel | null | undefined,
@@ -43,6 +49,34 @@ function buildSessionQueuedPrompts(session: AgentSession): ComposerQueuedPrompt[
     steering: [...session.getSteeringMessages()],
     followUp: [...session.getFollowUpMessages()],
   });
+}
+
+function mapContextUsage(session: AgentSession): ComposerContextUsage | null {
+  const usage = session.getContextUsage();
+  if (!usage) {
+    contextUsageCache.set(session, null);
+    return null;
+  }
+
+  const contextUsage = {
+    tokens: usage.tokens,
+    contextWindow: usage.contextWindow,
+    percent: usage.percent,
+  };
+  contextUsageCache.set(session, contextUsage);
+  return contextUsage;
+}
+
+function getContextUsageForComposerState(
+  session: AgentSession,
+  options: BuildComposerStateOptions = {},
+) {
+  const cachedUsage = contextUsageCache.get(session);
+  if (options.includeContextUsage === false && cachedUsage !== undefined) {
+    return cachedUsage;
+  }
+
+  return mapContextUsage(session);
 }
 
 export function getAvailableThinkingLevelsForModel(
@@ -126,6 +160,7 @@ async function resolveComposerStateSnapshot(request: ComposerStateRequest = {}) 
         availableThinkingLevels,
       ),
       availableThinkingLevels,
+      contextUsage: mapContextUsage(session),
     };
   } finally {
     session.dispose();
@@ -195,10 +230,15 @@ export async function buildComposerStateSnapshot(
     currentThinkingLevel: snapshot.currentThinkingLevel,
     availableThinkingLevels: snapshot.availableThinkingLevels,
     queuedPrompts: [],
+    contextUsage: snapshot.contextUsage,
+    isCompacting: false,
   };
 }
 
-export async function buildComposerState(runtime: PiRuntime): Promise<ComposerState> {
+export async function buildComposerState(
+  runtime: PiRuntime,
+  options: BuildComposerStateOptions = {},
+): Promise<ComposerState> {
   const availableModels = (await runtime.session.modelRegistry.getAvailable()).map((model) => ({
     provider: model.provider,
     id: model.id,
@@ -213,5 +253,7 @@ export async function buildComposerState(runtime: PiRuntime): Promise<ComposerSt
     currentThinkingLevel: runtime.session.thinkingLevel as ComposerThinkingLevel,
     availableThinkingLevels: mapThinkingLevels(runtime.session.getAvailableThinkingLevels()),
     queuedPrompts: buildSessionQueuedPrompts(runtime.session),
+    contextUsage: getContextUsageForComposerState(runtime.session, options),
+    isCompacting: runtime.session.isCompacting,
   };
 }

--- a/desktop/runtime/live-thread-store.cts
+++ b/desktop/runtime/live-thread-store.cts
@@ -18,7 +18,8 @@ export function getLiveThread(sessionPath: string) {
 }
 
 export function shouldSuppressExternalThreadUpdate(sessionPath: string, now = Date.now()) {
-  if (liveThreads.get(sessionPath)?.isStreaming) {
+  const liveThread = liveThreads.get(sessionPath);
+  if (liveThread?.isStreaming || liveThread?.isCompacting) {
     return true;
   }
 

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -162,10 +162,38 @@ async function createRuntime(options: {
       return;
     }
 
+    if (event.type === "compaction_start") {
+      void publishThreadUpdate(runtime, "compaction-start");
+
+      void buildComposerState(runtime)
+        .then((composer) => {
+          publishComposerUpdate(composer, {
+            projectId: runtime.cwd,
+            sessionPath: runtime.session.sessionFile,
+          });
+        })
+        .catch(() => {
+          // Ignore transient composer snapshot errors; compaction_end will publish again.
+        });
+
+      return;
+    }
+
     if (event.type === "compaction_end") {
-      if (event.reason === "manual" && event.result) {
+      setTimeout(() => {
         void publishThreadUpdate(runtime, "compaction");
-      }
+
+        void buildComposerState(runtime)
+          .then((composer) => {
+            publishComposerUpdate(composer, {
+              projectId: runtime.cwd,
+              sessionPath: runtime.session.sessionFile,
+            });
+          })
+          .catch(() => {
+            // Ignore transient composer snapshot errors; a later runtime event will republish state.
+          });
+      }, 0);
 
       if (runtimeKey && settingsRefreshController.isStale(runtimeKey)) {
         void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {

--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -1,9 +1,13 @@
 import { stat } from "node:fs/promises";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ComposerState, ThreadData } from "../../shared/desktop-contracts.ts";
-import { getPreviousMessageCount } from "../../shared/pi-message-mapper.ts";
+import { type SessionPathEntry, buildThreadHistorySlice } from "../../shared/thread-history.ts";
 import { getLatestInboxAssistantMessage } from "../../shared/thread-inbox.ts";
-import { buildThreadData, setThreadStreamingState } from "../../shared/thread-data.ts";
+import {
+  buildThreadData,
+  setThreadCompactingState,
+  setThreadStreamingState,
+} from "../../shared/thread-data.ts";
 import {
   beginInboxThreadTurn,
   getThreadAssistantSnapshot,
@@ -30,17 +34,21 @@ function buildLiveThreadData(runtime: PiRuntime) {
   }
 
   const streamingMessage = runtime.session.state.streamingMessage;
+  const historySlice = buildThreadHistorySlice(
+    [...(runtime.session.sessionManager.getBranch() as SessionPathEntry[])],
+    0,
+  );
   const sourceMessages = [
-    ...runtime.session.messages,
+    ...historySlice.sourceMessages,
     ...(streamingMessage ? [streamingMessage] : []),
   ] as AgentMessage[];
-  const previousMessageCount = getPreviousMessageCount(runtime.session.sessionManager.getBranch());
 
   return buildThreadData({
     sessionPath,
     sourceMessages,
-    previousMessageCount,
+    previousMessageCount: historySlice.previousMessageCount,
     isStreaming: runtime.session.isStreaming,
+    isCompacting: runtime.session.isCompacting,
   });
 }
 
@@ -80,11 +88,15 @@ export function normalizeThreadDataForReason(
   thread: ThreadData,
   reason: RuntimeThreadReason | "external",
 ): ThreadData {
+  if (reason === "compaction-start") {
+    return setThreadCompactingState(thread, true);
+  }
+
   if (reason !== "end" && reason !== "external" && reason !== "compaction") {
     return thread;
   }
 
-  return setThreadStreamingState(thread, false);
+  return setThreadCompactingState(setThreadStreamingState(thread, false), false);
 }
 
 export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThreadReason) {
@@ -102,7 +114,7 @@ export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThr
 
   const thread = normalizeThreadDataForReason(liveThread, reason);
 
-  const threadId = runtime.session.sessionId;
+  let threadId = runtime.session.sessionId;
   const projectId = runtime.cwd;
   const timestamp = Date.now();
   let hasPersistedSessionFile = false;
@@ -118,7 +130,7 @@ export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThr
   rememberSessionPath(sessionPath, projectId);
 
   if (hasPersistedSessionFile) {
-    upsertThreadSummary({
+    threadId = upsertThreadSummary({
       id: threadId,
       cwd: projectId,
       sessionPath,
@@ -128,7 +140,9 @@ export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThr
 
     setThreadRunningState(
       sessionPath,
-      reason === "update" || (reason === "start" && thread.messages.length > 0),
+      reason === "update" ||
+        reason === "compaction-start" ||
+        (reason === "start" && thread.messages.length > 0),
     );
 
     if (reason === "start") {
@@ -160,7 +174,7 @@ export async function publishThreadUpdate(runtime: PiRuntime, reason: RuntimeThr
     threadId,
     sessionPath,
     thread,
-    composer: await buildComposerState(runtime),
+    composer: await buildComposerState(runtime, { includeContextUsage: reason !== "update" }),
   });
 }
 
@@ -181,7 +195,7 @@ export async function publishExternalThreadUpdate({
 
   rememberLiveThread(sessionPath, thread);
   rememberSessionPath(sessionPath, projectId);
-  upsertThreadSummary({
+  threadId = upsertThreadSummary({
     id: threadId,
     cwd: projectId,
     sessionPath,

--- a/desktop/thread-state-db/session-writes.cts
+++ b/desktop/thread-state-db/session-writes.cts
@@ -1,8 +1,43 @@
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { getThreadStateDatabase } from "./db.cts";
 import { ensureProject } from "./project-writes.cts";
 import type { SessionSummaryRecord } from "./types.cts";
 import { runInTransaction } from "./write-transaction.cts";
+
+type ThreadIdPathRow = {
+  id?: string;
+  sessionPath: string;
+};
+
+function escapeLikePattern(value: string) {
+  return value.replace(/[\\%_]/g, (character) => `\\${character}`);
+}
+
+function getDisambiguatedThreadId(session: SessionSummaryRecord) {
+  const suffix = createHash("sha1").update(session.sessionPath).digest("hex").slice(0, 8);
+  return `${session.id}:${suffix}`;
+}
+
+function getSessionThreadId(session: SessionSummaryRecord, duplicateSessionIds: Set<string>) {
+  return duplicateSessionIds.has(session.id) ? getDisambiguatedThreadId(session) : session.id;
+}
+
+function getDuplicateSessionIds(sessions: SessionSummaryRecord[]) {
+  const sessionPathsById = new Map<string, Set<string>>();
+
+  for (const session of sessions) {
+    const sessionPaths = sessionPathsById.get(session.id) ?? new Set<string>();
+    sessionPaths.add(session.sessionPath);
+    sessionPathsById.set(session.id, sessionPaths);
+  }
+
+  return new Set(
+    [...sessionPathsById.entries()]
+      .filter(([, sessionPaths]) => sessionPaths.size > 1)
+      .map(([sessionId]) => sessionId),
+  );
+}
 
 export function syncSessionSummaries(cwd: string, sessions: SessionSummaryRecord[]) {
   const db = getThreadStateDatabase();
@@ -27,13 +62,16 @@ export function syncSessionSummaries(cwd: string, sessions: SessionSummaryRecord
         updated_at = CURRENT_TIMESTAMP
     `,
   );
-
   ensureProject(cwd);
   runInTransaction(db, () => {
+    const duplicateSessionIds = getDuplicateSessionIds(sessions);
+
     for (const session of sessions) {
       insertProject.run(session.cwd, path.basename(session.cwd) || session.cwd);
+      const threadId = getSessionThreadId(session, duplicateSessionIds);
+
       insertThread.run(
-        session.id,
+        threadId,
         session.cwd,
         session.sessionPath,
         session.title,
@@ -47,6 +85,37 @@ export function upsertThreadSummary(session: SessionSummaryRecord) {
   const db = getThreadStateDatabase();
   ensureProject(session.cwd);
 
+  const storedThreadForPath = db
+    .prepare(
+      `
+        SELECT id, session_path AS sessionPath
+        FROM threads
+        WHERE session_path = ?
+      `,
+    )
+    .get(session.sessionPath) as ThreadIdPathRow | undefined;
+  const storedDuplicateIdRows = db
+    .prepare(
+      `
+        SELECT id, session_path AS sessionPath
+        FROM threads
+        WHERE (id = ? OR id LIKE ? ESCAPE '\\')
+          AND session_path != ?
+      `,
+    )
+    .all(
+      session.id,
+      `${escapeLikePattern(session.id)}:%`,
+      session.sessionPath,
+    ) as ThreadIdPathRow[];
+
+  const threadId =
+    storedThreadForPath?.id && storedThreadForPath.id !== session.id
+      ? storedThreadForPath.id
+      : storedDuplicateIdRows.length > 0
+        ? getDisambiguatedThreadId(session)
+        : session.id;
+
   db.prepare(
     `
       INSERT INTO threads (id, cwd, session_path, title, last_modified_ms)
@@ -58,5 +127,7 @@ export function upsertThreadSummary(session: SessionSummaryRecord) {
         last_modified_ms = excluded.last_modified_ms,
         updated_at = CURRENT_TIMESTAMP
     `,
-  ).run(session.id, session.cwd, session.sessionPath, session.title, session.lastModifiedMs);
+  ).run(threadId, session.cwd, session.sessionPath, session.title, session.lastModifiedMs);
+
+  return threadId;
 }

--- a/shared/desktop-composer-contracts.ts
+++ b/shared/desktop-composer-contracts.ts
@@ -18,12 +18,20 @@ export type ComposerModel = {
   input: Array<"text" | "image">;
 };
 
+export type ComposerContextUsage = {
+  tokens: number | null;
+  contextWindow: number;
+  percent: number | null;
+};
+
 export type ComposerState = {
   currentModel: ComposerModel | null;
   availableModels: ComposerModel[];
   currentThinkingLevel: ComposerThinkingLevel;
   availableThinkingLevels: ComposerThinkingLevel[];
   queuedPrompts: ComposerQueuedPrompt[];
+  contextUsage: ComposerContextUsage | null;
+  isCompacting: boolean;
 };
 
 export type ComposerAttachment = {

--- a/shared/desktop-event-contracts.ts
+++ b/shared/desktop-event-contracts.ts
@@ -16,7 +16,7 @@ export type DesktopEvent =
     }
   | {
       type: "thread-update";
-      reason: "start" | "update" | "end" | "external" | "compaction";
+      reason: "start" | "update" | "end" | "external" | "compaction-start" | "compaction";
       projectId: string;
       threadId: string;
       sessionPath: string;

--- a/shared/desktop-thread-contracts.ts
+++ b/shared/desktop-thread-contracts.ts
@@ -111,4 +111,5 @@ export type ThreadData = {
   messages: Message[];
   previousMessageCount: number;
   isStreaming: boolean;
+  isCompacting: boolean;
 };

--- a/shared/thread-data.ts
+++ b/shared/thread-data.ts
@@ -7,6 +7,7 @@ type BuildThreadDataInput = {
   sourceMessages: readonly AgentMessage[];
   previousMessageCount: number;
   isStreaming: boolean;
+  isCompacting?: boolean;
 };
 
 export function buildThreadData({
@@ -14,6 +15,7 @@ export function buildThreadData({
   sourceMessages,
   previousMessageCount,
   isStreaming,
+  isCompacting = false,
 }: BuildThreadDataInput): ThreadData {
   const messages = mapAgentMessagesToUiMessages([...sourceMessages]);
 
@@ -23,9 +25,14 @@ export function buildThreadData({
     messages,
     previousMessageCount,
     isStreaming,
+    isCompacting,
   };
 }
 
 export function setThreadStreamingState(thread: ThreadData, isStreaming: boolean): ThreadData {
   return thread.isStreaming === isStreaming ? thread : { ...thread, isStreaming };
+}
+
+export function setThreadCompactingState(thread: ThreadData, isCompacting: boolean): ThreadData {
+  return thread.isCompacting === isCompacting ? thread : { ...thread, isCompacting };
 }

--- a/shared/thread-history.ts
+++ b/shared/thread-history.ts
@@ -122,8 +122,8 @@ export function buildThreadHistorySlice(
 
   return {
     sourceMessages: buildSourceMessagesFromPathEntries([
-      selectedCompaction,
       ...pathEntries.slice(firstKeptIndex, selectedCompactionIndex),
+      selectedCompaction,
       ...pathEntries.slice(selectedCompactionIndex + 1),
     ]),
     previousMessageCount: countDisplayableEntries(pathEntries.slice(0, firstKeptIndex)),

--- a/shared/thread-running-state.ts
+++ b/shared/thread-running-state.ts
@@ -2,10 +2,10 @@ import type { InboxThread, ThreadData } from "./desktop-contracts";
 
 export function getEffectiveThreadRunningState(
   persistedRunning: boolean | number,
-  liveThread: Pick<ThreadData, "isStreaming"> | null,
+  liveThread: Pick<ThreadData, "isStreaming" | "isCompacting"> | null,
 ) {
   if (liveThread) {
-    return liveThread.isStreaming;
+    return liveThread.isStreaming || liveThread.isCompacting;
   }
 
   return Boolean(persistedRunning);

--- a/src/app/app-shell/controller-view-model.ts
+++ b/src/app/app-shell/controller-view-model.ts
@@ -33,6 +33,7 @@ function buildFallbackThreadData(
     messages: [],
     previousMessageCount: 0,
     isStreaming: false,
+    isCompacting: false,
   };
 }
 

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -1,6 +1,13 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useMemo, useReducer, useState } from "react";
-import type { ArchivedThread, ComposerState, InboxThread, ProjectGitState } from "../desktop/types";
+import { getPersistedSessionPath } from "../../../shared/session-paths";
+import type {
+  ArchivedThread,
+  ComposerState,
+  InboxThread,
+  ProjectGitState,
+  ThreadData,
+} from "../desktop/types";
 import { useDesktopBridge } from "../hooks/useDesktopBridge";
 import { useDesktopInbox } from "../hooks/useDesktopInbox";
 import { useDesktopShell } from "../hooks/useDesktopShell";
@@ -24,6 +31,7 @@ export function useAppShellController() {
   const [state, dispatch] = useReducer(workspaceReducer, [], createInitialWorkspaceState);
   const [archivedThreads, setArchivedThreads] = useState<ArchivedThread[]>([]);
   const [composerState, setComposerState] = useState<ComposerState | null>(null);
+  const [liveThreadData, setLiveThreadData] = useState<ThreadData | null>(null);
   const [projectGitState, setProjectGitState] = useState<ProjectGitState | null>(null);
   const [extensionsProjectScopeActive, setExtensionsProjectScopeActive] = useState(false);
   const [skillsProjectScopeActive, setSkillsProjectScopeActive] = useState(false);
@@ -58,6 +66,11 @@ export function useAppShellController() {
     threadRefreshKey,
     threadHistoryCompactions,
   );
+  const selectedPersistedSessionPath = getPersistedSessionPath(state.selectedSessionPath);
+  const effectiveThreadData =
+    threadHistoryCompactions === 0 && liveThreadData?.sessionPath === selectedPersistedSessionPath
+      ? liveThreadData
+      : threadData;
   const inboxQuery = useDesktopInbox();
   const inboxThreads = inboxQuery.data ?? [];
   const selectedInboxThread = useMemo(
@@ -79,12 +92,12 @@ export function useAppShellController() {
       deriveControllerViewModel({
         projects,
         workspaceState: state,
-        threadData,
+        threadData: effectiveThreadData,
         shellCwd: shellState?.cwd,
         composerState,
         shellComposerState: shellState?.composer,
       }),
-    [composerState, projects, shellState?.composer, shellState?.cwd, state, threadData],
+    [composerState, effectiveThreadData, projects, shellState?.composer, shellState?.cwd, state],
   );
 
   useAppShellEffects({
@@ -103,7 +116,9 @@ export function useAppShellController() {
     dispatch,
     setArchivedThreads,
     setComposerState,
+    setLiveThreadData,
     setProjectGitState,
+    setThreadHistoryCompactions,
   });
 
   const { handleAction, runDesktopAction } = useDesktopActionHandlers({

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -7,6 +7,7 @@ import type {
   ComposerState,
   DesktopEvent,
   ProjectGitState,
+  ThreadData,
 } from "../desktop/types";
 import { desktopQueryKeys } from "../query/desktop-query";
 import { isUtilityView } from "../state/workspace";
@@ -14,6 +15,7 @@ import type { WorkspaceAction, WorkspaceState } from "../state/workspace";
 import type { Project } from "../types";
 
 type QueryClientLike = {
+  setQueryData: (queryKey: readonly unknown[], updater: unknown) => void;
   setQueriesData: (filters: { queryKey: readonly unknown[] }, updater: unknown) => void;
   invalidateQueries: (filters: { queryKey: readonly unknown[] }) => Promise<unknown> | unknown;
 };
@@ -67,7 +69,9 @@ export function useAppShellEffects({
   dispatch,
   setArchivedThreads,
   setComposerState,
+  setLiveThreadData,
   setProjectGitState,
+  setThreadHistoryCompactions,
 }: {
   projects: Project[];
   collapsedProjectIds: Record<string, boolean>;
@@ -87,7 +91,9 @@ export function useAppShellEffects({
   dispatch: Dispatch<WorkspaceAction>;
   setArchivedThreads: Dispatch<SetStateAction<ArchivedThread[]>>;
   setComposerState: Dispatch<SetStateAction<ComposerState | null>>;
+  setLiveThreadData: Dispatch<SetStateAction<ThreadData | null>>;
   setProjectGitState: Dispatch<SetStateAction<ProjectGitState | null>>;
+  setThreadHistoryCompactions: Dispatch<SetStateAction<number>>;
 }) {
   useEffect(() => {
     if (!projects.length) {
@@ -347,10 +353,21 @@ export function useAppShellEffects({
         return;
       }
 
-      queryClient.setQueriesData(
-        { queryKey: desktopQueryKeys.thread(event.sessionPath) },
-        event.thread,
+      queryClient.setQueryData(desktopQueryKeys.thread(event.sessionPath), event.thread);
+
+      const isVisibleThreadUpdate = event.sessionPath === visibleSessionPath;
+      const isCompactionThreadUpdate =
+        event.reason === "compaction-start" || event.reason === "compaction";
+
+      setLiveThreadData((current) =>
+        isVisibleThreadUpdate || current?.sessionPath === event.sessionPath
+          ? event.thread
+          : current,
       );
+
+      if (isCompactionThreadUpdate && isVisibleThreadUpdate) {
+        setThreadHistoryCompactions(0);
+      }
 
       if (event.composer && event.sessionPath === visibleSessionPath) {
         setComposerState(event.composer);
@@ -364,7 +381,9 @@ export function useAppShellEffects({
       ) {
         void loadProjectThreads(event.projectId);
         void queryClient.invalidateQueries({ queryKey: desktopQueryKeys.inboxThreads() });
-        scheduleShellStateRefresh();
+        if (event.reason !== "compaction") {
+          scheduleShellStateRefresh();
+        }
       }
 
       if (
@@ -427,6 +446,8 @@ export function useAppShellEffects({
     queryClient,
     scheduleShellStateRefresh,
     setComposerState,
+    setLiveThreadData,
     setProjectGitState,
+    setThreadHistoryCompactions,
   ]);
 }

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -1,6 +1,7 @@
 import { useRef, type RefObject } from "react";
 import type {
   ComposerFilePickerState,
+  ComposerContextUsage,
   ComposerModel,
   ComposerStreamingBehavior,
   ComposerThinkingLevel,
@@ -16,8 +17,10 @@ export type ComposerProps = {
   activeView: View;
   hostLabel: string;
   model: ComposerModel | null;
+  contextUsage: ComposerContextUsage | null;
   availableModels: ComposerModel[];
   isStreaming: boolean;
+  isCompacting: boolean;
   thinkingLevel: ComposerThinkingLevel;
   restoredQueuedPrompt: string | null;
   streamingBehaviorPreference: ComposerStreamingBehavior;

--- a/src/app/components/workspace/composer/ComposerContextMeter.tsx
+++ b/src/app/components/workspace/composer/ComposerContextMeter.tsx
@@ -1,0 +1,161 @@
+import { useRef, useState } from "react";
+import type { ComposerContextUsage } from "../../../desktop/types";
+import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
+import { ghostButtonClass } from "../../../ui/classes";
+import { cn } from "../../../utils/cn";
+
+type ComposerContextMeterProps = {
+  contextUsage: ComposerContextUsage | null;
+  isCompacting: boolean;
+  compactDisabled: boolean;
+  onCompact: () => void;
+};
+
+const tokenFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const numberFormatter = new Intl.NumberFormat("en");
+
+function formatTokens(value: number | null | undefined, options: { compact?: boolean } = {}) {
+  if (value === null || value === undefined) {
+    return "Unknown";
+  }
+
+  return options.compact ? tokenFormatter.format(value) : numberFormatter.format(value);
+}
+
+function getMeterTone(percent: number | null | undefined) {
+  if (percent === null || percent === undefined) {
+    return "rgba(146,153,184,0.64)";
+  }
+
+  if (percent > 90) {
+    return "#ff9f9f";
+  }
+
+  if (percent > 70) {
+    return "#f2c27f";
+  }
+
+  return "#9bb7ff";
+}
+
+export function ComposerContextMeter({
+  contextUsage,
+  isCompacting,
+  compactDisabled,
+  onCompact,
+}: ComposerContextMeterProps) {
+  const [hovered, setHovered] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const percent = contextUsage?.percent ?? null;
+  const tokens = contextUsage?.tokens ?? null;
+  const contextWindow = contextUsage?.contextWindow ?? null;
+  const availableTokens =
+    tokens !== null && contextWindow !== null ? Math.max(0, contextWindow - tokens) : null;
+  const meterPercent = percent === null ? 0 : Math.max(0, Math.min(100, percent));
+  const tone = getMeterTone(percent);
+  const open = hovered || pinned;
+  const label = isCompacting
+    ? "Compacting context"
+    : percent === null || percent === undefined
+      ? "Context unknown"
+      : `${percent.toFixed(0)}% context`;
+
+  useDismissibleLayer({
+    open: pinned,
+    onDismiss: () => setPinned(false),
+    refs: [buttonRef, popoverRef],
+  });
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <button
+        ref={buttonRef}
+        type="button"
+        className="relative inline-flex h-7 w-7 items-center justify-center rounded-full text-[color:var(--muted)] transition-colors hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]"
+        onClick={() => setPinned((current) => !current)}
+        aria-label={label}
+        aria-expanded={open}
+        title={label}
+      >
+        <span
+          className={cn("absolute inset-[7px] rounded-full", isCompacting && "animate-pulse")}
+          style={{
+            background: `conic-gradient(${tone} ${meterPercent * 3.6}deg, rgba(255,255,255,0.08) 0deg)`,
+          }}
+        />
+        <span className="absolute inset-[11px] rounded-full bg-[#272a39]" />
+      </button>
+
+      {open ? (
+        <div
+          ref={popoverRef}
+          className="absolute bottom-full left-0 z-30 grid w-56 gap-2 rounded-xl border border-[rgba(169,178,215,0.18)] bg-[#2d3040] p-3 text-[12px] text-[color:var(--muted)] shadow-[0_18px_44px_rgba(0,0,0,0.4)]"
+          onMouseDown={(event) => event.preventDefault()}
+        >
+          <div className="grid gap-1">
+            <div className="flex justify-between gap-3">
+              <span>Used</span>
+              <span className="font-mono text-[color:var(--text)]">{formatTokens(tokens)}</span>
+            </div>
+            <div className="flex justify-between gap-3">
+              <span>Available</span>
+              <span className="font-mono text-[color:var(--text)]">
+                {formatTokens(availableTokens)}
+              </span>
+            </div>
+            <div className="flex justify-between gap-3">
+              <span>Window</span>
+              <span className="font-mono text-[color:var(--text)]">
+                {formatTokens(contextWindow)}
+              </span>
+            </div>
+            <div className="flex justify-between gap-3">
+              <span>Usage</span>
+              <span className="font-mono text-[color:var(--text)]">
+                {percent === null || percent === undefined ? "Unknown" : `${percent.toFixed(1)}%`}
+              </span>
+            </div>
+          </div>
+          {tokens === null ? (
+            <div className="text-[11px] text-[color:var(--muted-2)]">
+              Usage is unknown until the next response updates token stats.
+            </div>
+          ) : null}
+          {isCompacting ? (
+            <div className="rounded-lg border border-[rgba(155,183,255,0.2)] bg-[rgba(155,183,255,0.08)] px-2 py-1.5 text-[11px] text-[#cbd7ff]">
+              Compacting session context…
+            </div>
+          ) : null}
+          <button
+            type="button"
+            className={cn(
+              ghostButtonClass,
+              "mt-1 justify-center border-[color:var(--border)] text-[color:var(--text)] disabled:cursor-not-allowed disabled:opacity-45",
+            )}
+            disabled={compactDisabled}
+            onClick={() => {
+              if (compactDisabled) {
+                return;
+              }
+
+              setHovered(false);
+              setPinned(false);
+              onCompact();
+            }}
+          >
+            Compact
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/components/workspace/composer/ComposerDiffBaselineSelector.tsx
+++ b/src/app/components/workspace/composer/ComposerDiffBaselineSelector.tsx
@@ -248,36 +248,40 @@ export function ComposerDiffBaselineSelector({
         aria-expanded={open}
         aria-controls={open ? panelId : undefined}
         className={cn(
-          "group relative inline-flex min-w-[9.5rem] items-center justify-end overflow-hidden text-right text-[12px] text-[color:var(--muted)] hover:text-[color:var(--text)]",
+          "group relative inline-flex h-7 min-w-[9.5rem] items-center justify-end overflow-hidden rounded-lg px-2 text-right text-[12px] leading-none text-[color:var(--muted)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]",
           open && "text-[color:var(--text)]",
         )}
         onClick={() => setOpen((current) => !current)}
       >
         <span
           className={cn(
-            "flex items-center gap-2 transition-opacity duration-150 ease-out",
+            "flex h-full items-center gap-2 transition-opacity duration-150 ease-out",
             open ? "opacity-0" : "group-hover:opacity-0",
           )}
         >
-          <span className="text-[color:var(--muted)]">{fileCountLabel} files</span>
+          <span className="inline-flex h-full items-center text-[color:var(--muted)]">
+            {fileCountLabel} files
+          </span>
           <span
-            className={
-              counts && counts.insertions > 0 ? "text-[#7ee0bb]" : "text-[color:var(--muted)]"
-            }
+            className={cn(
+              "inline-flex h-full items-center",
+              counts && counts.insertions > 0 ? "text-[#7ee0bb]" : "text-[color:var(--muted)]",
+            )}
           >
             +{insertionCountLabel}
           </span>
           <span
-            className={
-              counts && counts.deletions > 0 ? "text-[#ff9c9c]" : "text-[color:var(--muted)]"
-            }
+            className={cn(
+              "inline-flex h-full items-center",
+              counts && counts.deletions > 0 ? "text-[#ff9c9c]" : "text-[color:var(--muted)]",
+            )}
           >
             -{deletionCountLabel}
           </span>
         </span>
         <span
           className={cn(
-            "pointer-events-none absolute inset-0 flex items-center justify-end truncate text-[12px] text-[color:var(--text)] transition-opacity duration-150 ease-out",
+            "pointer-events-none absolute inset-0 flex h-full items-center justify-end truncate px-2 text-[12px] leading-none text-[color:var(--text)] transition-opacity duration-150 ease-out",
             open ? "opacity-100" : "opacity-0 group-hover:opacity-100",
           )}
         >

--- a/src/app/components/workspace/composer/ComposerFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerFooter.tsx
@@ -1,6 +1,7 @@
 import { Bot, GitBranch, Terminal } from "lucide-react";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import type {
+  ComposerContextUsage,
   ComposerModel,
   ComposerThinkingLevel,
   ProjectDiffBaseline,
@@ -10,6 +11,7 @@ import { compactCardClass, compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { PiLogoMark } from "../../common/PiLogoMark";
 import { ToolbarButton } from "../../common/ToolbarButton";
+import { ComposerContextMeter } from "./ComposerContextMeter";
 import { ComposerDiffBaselineSelector } from "./ComposerDiffBaselineSelector";
 import { ComposerModelPopover } from "./ComposerModelPopover";
 import { getGitOpsEntryButtonClass } from "./git-ops";
@@ -20,11 +22,15 @@ type ComposerFooterProps = {
   composerPanelRef: RefObject<HTMLDivElement | null>;
   diffBaseline: ProjectDiffBaseline;
   model: ComposerModel | null;
+  contextUsage: ComposerContextUsage | null;
+  compactDisabled: boolean;
+  isCompacting: boolean;
   modelButtonRef: RefObject<HTMLButtonElement | null>;
   modelMenuOpen: boolean;
   modelMenuRef: RefObject<HTMLDivElement | null>;
   onOpenGitOps: () => void;
   onOpenTakeoverTerminal: () => void;
+  onCompact: () => void;
   onSelectBaseline: (baseline: ProjectDiffBaseline) => void;
   onSelectModel: (model: ComposerModel) => void;
   onSelectThinkingLevel: (level: ComposerThinkingLevel) => void;
@@ -43,11 +49,15 @@ export function ComposerFooter({
   composerPanelRef,
   diffBaseline,
   model,
+  contextUsage,
+  compactDisabled,
+  isCompacting,
   modelButtonRef,
   modelMenuOpen,
   modelMenuRef,
   onOpenGitOps,
   onOpenTakeoverTerminal,
+  onCompact,
   onSelectBaseline,
   onSelectModel,
   onSelectThinkingLevel,
@@ -78,16 +88,25 @@ export function ComposerFooter({
         onClick={onToggleTerminal}
         className={cn(terminalVisible && "bg-[rgba(255,255,255,0.04)] text-[color:var(--text)]")}
       />
-      <div className="relative">
+      <div className="relative inline-flex h-7 items-center">
         <ToolbarButton
           ref={modelButtonRef}
           label="Agent"
           icon={<Bot size={14} />}
+          className="pr-8"
           onClick={() => onSetOpenMenu((current) => (current === "model" ? null : "model"))}
           aria-haspopup="menu"
           aria-expanded={modelMenuOpen}
           aria-controls="composer-model-menu"
         />
+        <div className="absolute top-0 right-0">
+          <ComposerContextMeter
+            contextUsage={contextUsage}
+            compactDisabled={compactDisabled}
+            isCompacting={isCompacting}
+            onCompact={onCompact}
+          />
+        </div>
         {modelMenuOpen ? (
           <ComposerModelPopover
             availableModels={availableModels}
@@ -101,7 +120,7 @@ export function ComposerFooter({
           />
         ) : null}
       </div>
-      <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+      <div className="ml-auto flex min-h-7 items-center gap-1.5 max-md:flex-wrap">
         {projectGitState?.isGitRepo ? (
           <ComposerDiffBaselineSelector
             composerPanelRef={composerPanelRef}
@@ -115,7 +134,7 @@ export function ComposerFooter({
           <div
             className={cn(
               compactCardClass,
-              "inline-flex max-w-[12rem] px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
+              "inline-flex h-7 max-w-[12rem] items-center px-2.5 py-0 text-[12px] leading-none text-[color:var(--muted)]",
             )}
             title={projectGitState.branch ?? "Detached"}
           >
@@ -124,7 +143,11 @@ export function ComposerFooter({
         ) : null}
         <button
           type="button"
-          className={cn(compactIconButtonClass, getGitOpsEntryButtonClass(gitVisualMode))}
+          className={cn(
+            compactIconButtonClass,
+            "h-7 w-7",
+            getGitOpsEntryButtonClass(gitVisualMode),
+          )}
           onClick={onOpenGitOps}
           aria-label="Open git ops"
           title="Open git ops"

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -33,8 +33,10 @@ export function ComposerPromptSurface({
   mainViewRef,
   workspaceFooterRef,
   model,
+  contextUsage,
   availableModels,
   isStreaming,
+  isCompacting,
   thinkingLevel,
   restoredQueuedPrompt,
   streamingBehaviorPreference,
@@ -85,6 +87,7 @@ export function ComposerPromptSurface({
     openPickerRoot,
     removeAttachment,
     runComposerAction,
+    compact,
     send,
     setDraft,
     setOpenMenu,
@@ -106,6 +109,7 @@ export function ComposerPromptSurface({
     dictationModelId,
     dictationMaxDurationSeconds,
     isStreaming,
+    isCompacting,
     restoredQueuedPrompt,
     streamingBehaviorPreference,
     onAction,
@@ -420,6 +424,9 @@ export function ComposerPromptSurface({
         composerPanelRef={composerPanelRef}
         diffBaseline={diffBaseline}
         model={model}
+        contextUsage={contextUsage}
+        compactDisabled={isStreaming || isCompacting || !sessionPath}
+        isCompacting={isCompacting}
         modelButtonRef={modelButtonRef}
         modelMenuOpen={modelMenuOpen}
         modelMenuRef={modelMenuRef}
@@ -445,6 +452,7 @@ export function ComposerPromptSurface({
             sessionPath,
           });
         }}
+        onCompact={() => void compact()}
         onSetOpenMenu={setOpenMenu}
         onToggleTerminal={onToggleTerminal}
         projectGitState={projectGitState}

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -53,6 +53,7 @@ type UseComposerControllerProps = {
   dictationModelId: string | null;
   dictationMaxDurationSeconds: number;
   isStreaming: boolean;
+  isCompacting: boolean;
   restoredQueuedPrompt: string | null;
   streamingBehaviorPreference: ComposerStreamingBehavior;
   onAction: DesktopActionInvoker;
@@ -75,6 +76,7 @@ export function useComposerController({
   dictationModelId,
   dictationMaxDurationSeconds,
   isStreaming,
+  isCompacting,
   restoredQueuedPrompt,
   streamingBehaviorPreference,
   onAction,
@@ -194,7 +196,8 @@ export function useComposerController({
     };
   }, [composerPanelRef, mainViewRef, openMenu, workspaceFooterRef]);
 
-  const canSend = (draft.trim().length > 0 || attachments.length > 0) && !isSending;
+  const canSend =
+    (draft.trim().length > 0 || attachments.length > 0) && !isSending && !isCompacting;
 
   const {
     cancelDictation,
@@ -251,11 +254,12 @@ export function useComposerController({
     }
   };
 
-  const { send, stop } = useComposerSubmission({
+  const { compact, send, stop } = useComposerSubmission({
     composerScopeKey,
     draftThreadId,
     isSending,
     isStreaming,
+    isCompacting,
     onAction,
     projectId,
     sessionPath,
@@ -312,6 +316,7 @@ export function useComposerController({
     openPickerRoot,
     removeAttachment,
     runComposerAction,
+    compact,
     send,
     setDraft: setDraftValue,
     setOpenMenu,

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -15,6 +15,7 @@ type UseComposerSubmissionProps = {
   draftThreadId: string | null;
   isSending: boolean;
   isStreaming: boolean;
+  isCompacting: boolean;
   onAction: DesktopActionInvoker;
   projectId: string;
   sessionPath: string | null;
@@ -38,6 +39,7 @@ export function useComposerSubmission({
   draftThreadId,
   isSending,
   isStreaming,
+  isCompacting,
   onAction,
   projectId,
   sessionPath,
@@ -56,7 +58,7 @@ export function useComposerSubmission({
   skipNextDraftPersistenceRef,
 }: UseComposerSubmissionProps) {
   const send = useCallback(async () => {
-    if (isSending || sendLockRef.current) {
+    if (isSending || isCompacting || sendLockRef.current) {
       return;
     }
 
@@ -137,6 +139,7 @@ export function useComposerSubmission({
     composerScopeKey,
     draftThreadId,
     draftValueRef,
+    isCompacting,
     isSending,
     onAction,
     projectId,
@@ -177,7 +180,53 @@ export function useComposerSubmission({
     }
   }, [isSending, isStreaming, onAction, projectId, sessionPath, setErrorMessage, setIsSending]);
 
+  const compact = useCallback(async () => {
+    if (isSending || isStreaming || isCompacting || !sessionPath || sendLockRef.current) {
+      return;
+    }
+
+    await withComposerSendLock(sendLockRef, async () => {
+      setIsSending(true);
+      setErrorMessage(null);
+
+      try {
+        await stopDictationAndFlush();
+
+        const result = await submitComposerDraft({
+          draft: "/compact",
+          attachments: [],
+          draftThreadId: null,
+          isSending: false,
+          projectId,
+          sessionPath,
+          streamingBehaviorPreference,
+          onAction,
+          clearStoredDraft: (threadId) => composerDraftStore.clearThreadDraft(threadId),
+        });
+
+        if (result.status === "error") {
+          setErrorMessage(result.errorMessage);
+        }
+      } finally {
+        setIsSending(false);
+      }
+    });
+  }, [
+    isCompacting,
+    isSending,
+    isStreaming,
+    onAction,
+    projectId,
+    sendLockRef,
+    sessionPath,
+    setErrorMessage,
+    setIsSending,
+    stopDictationAndFlush,
+    streamingBehaviorPreference,
+  ]);
+
   return {
+    compact,
     send,
     stop,
   };

--- a/src/app/components/workspace/thread/ThreadTimeline.tsx
+++ b/src/app/components/workspace/thread/ThreadTimeline.tsx
@@ -12,6 +12,7 @@ type ThreadTimelineProps = {
   messages: Message[];
   previousMessageCount: number;
   isStreaming: boolean;
+  isCompacting: boolean;
   composerLayoutVersion: number;
   onLoadEarlierMessages: () => void;
 };
@@ -20,6 +21,7 @@ export function ThreadTimeline({
   messages,
   previousMessageCount,
   isStreaming,
+  isCompacting,
   composerLayoutVersion,
   onLoadEarlierMessages,
 }: ThreadTimelineProps) {
@@ -219,7 +221,7 @@ export function ThreadTimeline({
   );
 
   return (
-    <div className={chatViewportClass}>
+    <div className={`${chatViewportClass} relative`}>
       <div ref={containerRef} className={chatScrollableAreaClass} onScroll={handleScroll}>
         <div
           className={`mx-auto w-full min-w-0 ${CHAT_TEXT_MAX_WIDTH_CLASS} overflow-x-hidden px-4 pt-4 pb-4`}
@@ -228,6 +230,16 @@ export function ThreadTimeline({
           <div ref={bottomSentinelRef} aria-hidden="true" className="h-px w-full" />
         </div>
       </div>
+      {isCompacting ? (
+        <div className="pointer-events-none absolute right-4 bottom-4 left-4 z-20 flex justify-center">
+          <div className="rounded-full border border-[rgba(155,183,255,0.18)] bg-[#2d3040] px-3 py-2 text-[13px] text-[#cbd7ff] shadow-[0_18px_44px_rgba(0,0,0,0.36)]">
+            <div className="flex items-center gap-2">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-[#9bb7ff]" />
+              <span>Compacting session context…</span>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -3,6 +3,7 @@ export type {
   AppSettings,
   ArchivedThread,
   ComposerAttachment,
+  ComposerContextUsage,
   DesktopClipboardFilePaths,
   DesktopClipboardSnapshot,
   ComposerFilePickerEntry,

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -76,6 +76,7 @@ export function CodeWorkspaceMainView({
         messages={threadData?.messages ?? []}
         previousMessageCount={threadData?.previousMessageCount ?? 0}
         isStreaming={threadData?.isStreaming ?? false}
+        isCompacting={threadData?.isCompacting ?? false}
         composerLayoutVersion={composerLayoutVersion}
         onLoadEarlierMessages={onLoadEarlierMessages}
       />

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -227,8 +227,10 @@ export function CodeWorkspaceView({
                       activeView={state.activeView}
                       hostLabel={shellState?.availableHosts[0] ?? "Local"}
                       model={activeComposerState?.currentModel ?? null}
+                      contextUsage={activeComposerState?.contextUsage ?? null}
                       availableModels={activeComposerState?.availableModels ?? []}
                       isStreaming={activeThreadData?.isStreaming ?? false}
+                      isCompacting={activeComposerState?.isCompacting ?? false}
                       thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
                       restoredQueuedPrompt={scopedRestoredQueuedPrompt}
                       streamingBehaviorPreference={

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -57,6 +57,7 @@ export const desktopQueryKeys = {
   projectCommitsPrefix: (projectId: string) => ["desktop", "projectCommits", projectId] as const,
   projectCommits: (projectId: string, limit = 50) =>
     ["desktop", "projectCommits", projectId, limit] as const,
+  threadPrefix: (sessionPath: string) => ["desktop", "thread", sessionPath] as const,
   thread: (sessionPath: string, refreshKey = 0, historyCompactions = 0) =>
     ["desktop", "thread", sessionPath, refreshKey, historyCompactions] as const,
 };

--- a/src/app/state/workspace.test.ts
+++ b/src/app/state/workspace.test.ts
@@ -27,7 +27,37 @@ describe("workspace state", () => {
     expect(syncedState.collapsedProjectIds).toMatchObject({ alpha: false, beta: true });
   });
 
-  it("falls back to the first project when the current selection disappears", () => {
+  it("keeps an open thread visible when refreshed projects still contain it", () => {
+    const nextState = workspaceReducer(
+      {
+        ...createInitialWorkspaceState(mockProjects),
+        activeView: "thread",
+        selectedProjectId: "stale-project",
+        selectedThreadId: "thread-1",
+        selectedSessionPath: "/tmp/thread-1.jsonl",
+      },
+      {
+        type: "sync-projects",
+        projects: [
+          {
+            id: "alpha",
+            name: "alpha",
+            collapsed: false,
+            threads: [
+              { id: "thread-1", title: "Thread", age: "now", sessionPath: "/tmp/thread-1.jsonl" },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(nextState.activeView).toBe("thread");
+    expect(nextState.selectedProjectId).toBe("alpha");
+    expect(nextState.selectedThreadId).toBe("thread-1");
+    expect(nextState.selectedSessionPath).toBe("/tmp/thread-1.jsonl");
+  });
+
+  it("falls back to the first project when an open thread genuinely disappears", () => {
     const nextState = workspaceReducer(
       {
         ...createInitialWorkspaceState(mockProjects),
@@ -46,6 +76,25 @@ describe("workspace state", () => {
     expect(nextState.selectedProjectId).toBe("alpha");
     expect(nextState.selectedThreadId).toBeNull();
     expect(nextState.selectedSessionPath).toBeNull();
+  });
+
+  it("falls back to the first project when a non-thread selection disappears", () => {
+    const nextState = workspaceReducer(
+      {
+        ...createInitialWorkspaceState(mockProjects),
+        activeView: "code",
+        selectedProjectId: "missing-project",
+        selectedThreadId: null,
+        selectedSessionPath: null,
+      },
+      {
+        type: "sync-projects",
+        projects: [{ id: "alpha", name: "alpha", collapsed: false, threads: [] }],
+      },
+    );
+
+    expect(nextState.activeView).toBe("code");
+    expect(nextState.selectedProjectId).toBe("alpha");
   });
 
   it("opens threads, expands projects, and restores terminal visibility across session changes", () => {

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -173,6 +173,26 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
   };
 }
 
+function findProjectContainingThread(projects: Project[], state: WorkspaceState) {
+  if (state.selectedSessionPath) {
+    return (
+      projects.find((project) =>
+        project.threads.some((thread) => thread.sessionPath === state.selectedSessionPath),
+      ) ?? null
+    );
+  }
+
+  if (!state.selectedThreadId) {
+    return null;
+  }
+
+  return (
+    projects.find((project) =>
+      project.threads.some((thread) => thread.id === state.selectedThreadId),
+    ) ?? null
+  );
+}
+
 export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction): WorkspaceState {
   switch (action.type) {
     case "sync-projects": {
@@ -182,6 +202,10 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
       const selectedProjectId = hasSelectedProject
         ? state.selectedProjectId
         : action.projects[0]?.id || "";
+      const selectedThreadProject = findProjectContainingThread(action.projects, state);
+      const shouldPreserveSelectedThread =
+        state.activeView === "thread" && Boolean(selectedThreadProject);
+      const shouldPreserveProjectSelection = hasSelectedProject || shouldPreserveSelectedThread;
 
       const collapsedProjectIds = Object.fromEntries(
         action.projects.map((project) => [
@@ -190,8 +214,9 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         ]),
       );
 
-      const nextActiveView =
-        hasSelectedProject || !state.selectedProjectId || action.projects.length === 0
+      const nextActiveView = shouldPreserveSelectedThread
+        ? "thread"
+        : hasSelectedProject || !state.selectedProjectId || action.projects.length === 0
           ? state.activeView
           : "code";
 
@@ -199,17 +224,31 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
         ...state,
         ...getTerminalStateForNextView(state, nextActiveView),
         activeView: nextActiveView,
-        selectedProjectId,
+        selectedProjectId: selectedThreadProject
+          ? selectedThreadProject.id
+          : shouldPreserveProjectSelection
+            ? state.selectedProjectId
+            : selectedProjectId,
         selectedThreadId:
-          hasSelectedProject || !state.selectedProjectId ? state.selectedThreadId : null,
+          shouldPreserveProjectSelection || !state.selectedProjectId
+            ? state.selectedThreadId
+            : null,
         selectedSessionPath:
-          hasSelectedProject || !state.selectedProjectId ? state.selectedSessionPath : null,
+          shouldPreserveProjectSelection || !state.selectedProjectId
+            ? state.selectedSessionPath
+            : null,
         selectedDiffFilePath:
-          hasSelectedProject || !state.selectedProjectId ? state.selectedDiffFilePath : null,
+          shouldPreserveProjectSelection || !state.selectedProjectId
+            ? state.selectedDiffFilePath
+            : null,
         gitOpsReturnView:
-          hasSelectedProject || !state.selectedProjectId ? state.gitOpsReturnView : "code",
+          shouldPreserveProjectSelection || !state.selectedProjectId
+            ? state.gitOpsReturnView
+            : "code",
         utilityViewReturnState:
-          hasSelectedProject || !state.selectedProjectId ? state.utilityViewReturnState : null,
+          shouldPreserveProjectSelection || !state.selectedProjectId
+            ? state.utilityViewReturnState
+            : null,
         collapsedProjectIds,
       };
     }

--- a/src/app/views/ThreadView.tsx
+++ b/src/app/views/ThreadView.tsx
@@ -9,6 +9,7 @@ type ThreadViewProps = {
   messages: Message[];
   previousMessageCount: number;
   isStreaming: boolean;
+  isCompacting: boolean;
   composerLayoutVersion: number;
   onLoadEarlierMessages: () => void;
 };
@@ -17,6 +18,7 @@ export function ThreadView({
   messages,
   previousMessageCount,
   isStreaming,
+  isCompacting,
   composerLayoutVersion,
   onLoadEarlierMessages,
 }: ThreadViewProps) {
@@ -35,6 +37,7 @@ export function ThreadView({
       messages={messages}
       previousMessageCount={previousMessageCount}
       isStreaming={isStreaming}
+      isCompacting={isCompacting}
       composerLayoutVersion={composerLayoutVersion}
       onLoadEarlierMessages={() => {
         if (previousMessageCount === 0) {

--- a/src/test/controller-post-action-effects.test.ts
+++ b/src/test/controller-post-action-effects.test.ts
@@ -36,6 +36,8 @@ function buildShellState(): ShellState {
       currentThinkingLevel: "medium",
       availableThinkingLevels: ["off", "minimal", "low", "medium", "high", "xhigh"],
       queuedPrompts: [],
+      contextUsage: null,
+      isCompacting: false,
     },
     projects: [
       {

--- a/src/test/runtime-settings-refresh.test.ts
+++ b/src/test/runtime-settings-refresh.test.ts
@@ -35,6 +35,8 @@ describe("runtime settings refresh", () => {
         currentThinkingLevel: "medium",
         availableThinkingLevels: ["medium"],
         queuedPrompts: [],
+        contextUsage: null,
+        isCompacting: false,
       }),
       publishComposerUpdate,
     });
@@ -61,6 +63,8 @@ describe("runtime settings refresh", () => {
         currentThinkingLevel: "medium",
         availableThinkingLevels: ["medium"],
         queuedPrompts: [],
+        contextUsage: null,
+        isCompacting: false,
       }),
       publishComposerUpdate: vi.fn(),
     });

--- a/src/test/thread-history.test.ts
+++ b/src/test/thread-history.test.ts
@@ -51,9 +51,9 @@ describe("buildThreadHistorySlice", () => {
 
     expect(slice.previousMessageCount).toBe(4);
     expect(slice.sourceMessages.map((message) => `${message.timestamp}:${message.role}`)).toEqual([
-      "8:compactionSummary",
       "6:user",
       "7:assistant",
+      "8:compactionSummary",
       "9:user",
       "10:assistant",
     ]);
@@ -64,9 +64,9 @@ describe("buildThreadHistorySlice", () => {
 
     expect(slice.previousMessageCount).toBe(2);
     expect(slice.sourceMessages.map((message) => `${message.timestamp}:${message.role}`)).toEqual([
-      "5:compactionSummary",
       "3:user",
       "4:assistant",
+      "5:compactionSummary",
       "6:user",
       "7:assistant",
       "8:compactionSummary",

--- a/src/test/thread-running-state.test.ts
+++ b/src/test/thread-running-state.test.ts
@@ -7,8 +7,15 @@ import {
 
 describe("thread running state", () => {
   it("uses the live runtime state when available", () => {
-    expect(getEffectiveThreadRunningState(false, { isStreaming: true })).toBe(true);
-    expect(getEffectiveThreadRunningState(true, { isStreaming: false })).toBe(false);
+    expect(getEffectiveThreadRunningState(false, { isStreaming: true, isCompacting: false })).toBe(
+      true,
+    );
+    expect(getEffectiveThreadRunningState(false, { isStreaming: false, isCompacting: true })).toBe(
+      true,
+    );
+    expect(getEffectiveThreadRunningState(true, { isStreaming: false, isCompacting: false })).toBe(
+      false,
+    );
   });
 
   it("falls back to the persisted state when no live runtime state is known", () => {


### PR DESCRIPTION
## Summary
- Add Pi-backed context usage to composer state from `session.getContextUsage()`.
- Show a compact circular context meter in the main composer footer with an opaque stats popover.
- Route `/compact` and the meter Compact button through native Pi session compaction.
- Render native compaction summaries in the thread timeline at their chronological position.

## Details
- Reuses cached context usage during assistant streaming deltas to avoid repeated context rescans.
- Keeps `/compact` on the normal composer submission path while preserving attachment chips for the next prompt.
- Uses native Pi compaction lifecycle events as the single source for thread/composer updates.
- Suppresses external file-watch updates while a live thread is streaming or compacting to avoid stale sidebar/thread refreshes.
- Handles duplicate Pi session IDs in the local thread index without violating SQLite constraints.

## Validation
- Pre-commit ran typechecks and full vitest suite: 114 tests passed.
- Push hook passed lint and typechecks.
- Addressed `/review` findings against `dev` merge base `1381e6d1c048`.

Closes #29
