### PR TITLE
Refine git-ops composer UX

### DIFF
--- a/src/app/app-shell/useDesktopActionHandlers.ts
+++ b/src/app/app-shell/useDesktopActionHandlers.ts
@@ -62,8 +62,6 @@ function shouldShowGlobalActionError(action: DesktopAction) {
   return !(
     action === "composer.send" ||
     action === "composer.stop" ||
-    action === "composer.dequeue" ||
-    action === "composer.reload-settings" ||
     action === "workspace.commit" ||
     action === "workspace.commit-options"
   );

--- a/src/app/app-shell/useDesktopActionHandlers.ts
+++ b/src/app/app-shell/useDesktopActionHandlers.ts
@@ -12,6 +12,7 @@ import type {
 } from "../desktop/types";
 import type { WorkspaceAction, WorkspaceState } from "../state/workspace";
 import type { View } from "../types";
+import { cleanUserErrorMessage } from "../desktop/error-messages";
 import { buildContextualActionPayload } from "./controller-action-helpers";
 import {
   applyOptimisticPinUpdate,
@@ -49,10 +50,23 @@ function getActionErrorMessage(actionResult: DesktopActionResult | null) {
   }
 
   if (actionResult.ok === false && typeof actionResult.result?.error === "string") {
-    return actionResult.result.error;
+    return cleanUserErrorMessage(actionResult.result.error);
   }
 
-  return typeof actionResult.result?.error === "string" ? actionResult.result.error : null;
+  return typeof actionResult.result?.error === "string"
+    ? cleanUserErrorMessage(actionResult.result.error)
+    : null;
+}
+
+function shouldShowGlobalActionError(action: DesktopAction) {
+  return !(
+    action === "composer.send" ||
+    action === "composer.stop" ||
+    action === "composer.dequeue" ||
+    action === "composer.reload-settings" ||
+    action === "workspace.commit" ||
+    action === "workspace.commit-options"
+  );
 }
 
 export function useDesktopActionHandlers({
@@ -110,7 +124,7 @@ export function useDesktopActionHandlers({
       });
 
       const actionErrorMessage = getActionErrorMessage(actionResult);
-      if (actionErrorMessage) {
+      if (actionErrorMessage && shouldShowGlobalActionError(action)) {
         showToast(actionErrorMessage);
       }
 

--- a/src/app/components/workspace/GitOpsComposerPanel.tsx
+++ b/src/app/components/workspace/GitOpsComposerPanel.tsx
@@ -20,6 +20,7 @@ type GitOpsComposerPanelProps = {
   diffCommentCount: number;
   diffCommentsSending: boolean;
   diffCommentError: string | null;
+  diffLoadError: string | null;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
   onSetDiffRenderMode: (mode: "stacked" | "split") => void;
   onSendDiffComments: (message?: string | null) => void;
@@ -43,6 +44,7 @@ export function GitOpsComposerPanel({
   diffCommentCount,
   diffCommentsSending,
   diffCommentError,
+  diffLoadError,
   onSetDiffBaseline,
   onSetDiffRenderMode,
   onSendDiffComments,
@@ -75,6 +77,7 @@ export function GitOpsComposerPanel({
         diffCommentCount={diffCommentCount}
         diffCommentsSending={diffCommentsSending}
         diffCommentError={diffCommentError}
+        diffLoadError={diffLoadError}
         onSetDiffBaseline={onSetDiffBaseline}
         onSetDiffRenderMode={onSetDiffRenderMode}
         onSendDiffComments={onSendDiffComments}

--- a/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
@@ -18,15 +18,18 @@ type ComposerGitOpsFooterProps = {
   hasOrigin: boolean;
   includeUnstaged: boolean;
   isGitRepo: boolean;
+  onSaveOrigin: () => void;
   onBack: () => void;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
   onSetDiffRenderMode: (mode: "stacked" | "split") => void;
+  onSetRepoUrl: (repoUrl: string) => void;
   onToggleIncludeUnstaged: () => void;
   onTogglePreview: () => void;
   onTogglePush: () => void;
   previewEnabled: boolean;
   projectGitState: ProjectGitState | null;
   pushEnabled: boolean;
+  repoUrl: string;
 };
 
 export function ComposerGitOpsFooter({
@@ -36,15 +39,18 @@ export function ComposerGitOpsFooter({
   hasOrigin,
   includeUnstaged,
   isGitRepo,
+  onSaveOrigin,
   onBack,
   onSetDiffBaseline,
   onSetDiffRenderMode,
+  onSetRepoUrl,
   onToggleIncludeUnstaged,
   onTogglePreview,
   onTogglePush,
   previewEnabled,
   projectGitState,
   pushEnabled,
+  repoUrl,
 }: ComposerGitOpsFooterProps) {
   const [optionsOpen, setOptionsOpen] = useState(false);
   const optionsRef = useRef<HTMLDivElement>(null);
@@ -107,11 +113,29 @@ export function ComposerGitOpsFooter({
               <div
                 className={cn(
                   popoverPanelClass,
-                  "absolute bottom-[calc(100%+8px)] left-0 z-20 grid min-w-52 gap-2 rounded-xl border p-3",
+                  "absolute bottom-[calc(100%+8px)] left-0 z-20 grid min-w-56 gap-2 rounded-xl border p-3",
                 )}
                 role="menu"
                 aria-label="Commit options"
               >
+                {!hasOrigin ? (
+                  <input
+                    value={repoUrl}
+                    onChange={(event) => onSetRepoUrl(event.target.value)}
+                    onBlur={() => {
+                      void onSaveOrigin();
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        void onSaveOrigin();
+                      }
+                    }}
+                    className="min-h-7 rounded-lg border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] px-2.5 text-[12px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted-2)]"
+                    placeholder="Repository URL"
+                    aria-label="Repository URL"
+                  />
+                ) : null}
                 <PlainToggle
                   label="Include unstaged"
                   checked={includeUnstaged}

--- a/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
@@ -1,18 +1,26 @@
-import { ArrowLeft } from "lucide-react";
-import type { RefObject } from "react";
+import { ArrowLeft, Columns2, Rows3, Settings } from "lucide-react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import type { ProjectDiffBaseline, ProjectGitState } from "../../../desktop/types";
-import { compactIconButtonClass } from "../../../ui/classes";
+import {
+  compactIconButtonClass,
+  diffPanelIconButtonClass,
+  diffPanelTurnChipSelectedClass,
+  popoverPanelClass,
+} from "../../../ui/classes";
+import { cn } from "../../../utils/cn";
 import { ComposerDiffBaselineSelector } from "./ComposerDiffBaselineSelector";
 import { PlainToggle } from "./PlainToggle";
 
 type ComposerGitOpsFooterProps = {
   composerPanelRef: RefObject<HTMLDivElement | null>;
   diffBaseline: ProjectDiffBaseline;
+  diffRenderMode: "stacked" | "split";
   hasOrigin: boolean;
   includeUnstaged: boolean;
   isGitRepo: boolean;
   onBack: () => void;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
+  onSetDiffRenderMode: (mode: "stacked" | "split") => void;
   onToggleIncludeUnstaged: () => void;
   onTogglePreview: () => void;
   onTogglePush: () => void;
@@ -24,11 +32,13 @@ type ComposerGitOpsFooterProps = {
 export function ComposerGitOpsFooter({
   composerPanelRef,
   diffBaseline,
+  diffRenderMode,
   hasOrigin,
   includeUnstaged,
   isGitRepo,
   onBack,
   onSetDiffBaseline,
+  onSetDiffRenderMode,
   onToggleIncludeUnstaged,
   onTogglePreview,
   onTogglePush,
@@ -36,18 +46,124 @@ export function ComposerGitOpsFooter({
   projectGitState,
   pushEnabled,
 }: ComposerGitOpsFooterProps) {
+  const [optionsOpen, setOptionsOpen] = useState(false);
+  const optionsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!optionsOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && optionsRef.current?.contains(target)) {
+        return;
+      }
+
+      setOptionsOpen(false);
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    return () => window.removeEventListener("pointerdown", handlePointerDown, true);
+  }, [optionsOpen]);
+
+  useEffect(() => {
+    if (!optionsOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      setOptionsOpen(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [optionsOpen]);
+
   return (
     <div className="flex items-center gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
-      <div className="flex items-center gap-3">
-        <PlainToggle label="Unstaged" checked={includeUnstaged} onClick={onToggleIncludeUnstaged} />
-        <PlainToggle label="Preview" checked={previewEnabled} onClick={onTogglePreview} />
-        <PlainToggle
-          label="Push"
-          checked={pushEnabled}
-          disabled={!hasOrigin}
-          onClick={onTogglePush}
-        />
-      </div>
+      {isGitRepo ? (
+        <div className="inline-flex items-center gap-1.5">
+          <div ref={optionsRef} className="relative inline-flex">
+            <button
+              type="button"
+              className={cn(compactIconButtonClass, "h-7 w-7")}
+              onClick={() => setOptionsOpen((current) => !current)}
+              aria-label="Commit options"
+              aria-haspopup="menu"
+              aria-expanded={optionsOpen}
+              title="Commit options"
+            >
+              <Settings size={14} />
+            </button>
+
+            {optionsOpen ? (
+              <div
+                className={cn(
+                  popoverPanelClass,
+                  "absolute bottom-[calc(100%+8px)] left-0 z-20 grid min-w-52 gap-2 rounded-xl border p-3",
+                )}
+                role="menu"
+                aria-label="Commit options"
+              >
+                <PlainToggle
+                  label="Include unstaged"
+                  checked={includeUnstaged}
+                  onClick={onToggleIncludeUnstaged}
+                  toggleSide="left"
+                />
+                <PlainToggle
+                  label="Draft message"
+                  checked={previewEnabled}
+                  onClick={onTogglePreview}
+                  toggleSide="left"
+                />
+                <PlainToggle
+                  label="Commit & push"
+                  checked={pushEnabled}
+                  disabled={!hasOrigin}
+                  onClick={onTogglePush}
+                  toggleSide="left"
+                />
+              </div>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            className={cn(
+              diffPanelIconButtonClass,
+              diffRenderMode === "stacked"
+                ? diffPanelTurnChipSelectedClass
+                : "border-[color:var(--border)] bg-transparent",
+            )}
+            onClick={() => onSetDiffRenderMode("stacked")}
+            aria-label="Unified diff view"
+            title="Unified diff view"
+          >
+            <Rows3 size={14} />
+          </button>
+          <button
+            type="button"
+            className={cn(
+              diffPanelIconButtonClass,
+              diffRenderMode === "split"
+                ? diffPanelTurnChipSelectedClass
+                : "border-[color:var(--border)] bg-transparent",
+            )}
+            onClick={() => onSetDiffRenderMode("split")}
+            aria-label="Split diff view"
+            title="Split diff view"
+          >
+            <Columns2 size={14} />
+          </button>
+        </div>
+      ) : null}
 
       <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
         {isGitRepo ? (
@@ -61,7 +177,7 @@ export function ComposerGitOpsFooter({
         ) : null}
         <button
           type="button"
-          className={compactIconButtonClass}
+          className={cn(compactIconButtonClass, "h-7 w-7")}
           onClick={onBack}
           aria-label="Back"
           title="Back"

--- a/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
@@ -66,12 +66,16 @@ export function ComposerGitOpsFooter({
         return;
       }
 
-      setOptionsOpen(false);
+      if (!hasOrigin && repoUrl.trim().length > 0) {
+        void onSaveOrigin();
+      }
+
+      window.setTimeout(() => setOptionsOpen(false), 0);
     };
 
     window.addEventListener("pointerdown", handlePointerDown, true);
     return () => window.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [optionsOpen]);
+  }, [hasOrigin, onSaveOrigin, optionsOpen, repoUrl]);
 
   useEffect(() => {
     if (!optionsOpen) {

--- a/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Columns2, Rows3, Settings } from "lucide-react";
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import type { ProjectDiffBaseline, ProjectGitState } from "../../../desktop/types";
 import {
   compactIconButtonClass,
@@ -54,6 +54,18 @@ export function ComposerGitOpsFooter({
 }: ComposerGitOpsFooterProps) {
   const [optionsOpen, setOptionsOpen] = useState(false);
   const optionsRef = useRef<HTMLDivElement>(null);
+  const originSaveRequestedRef = useRef(false);
+
+  const saveOriginOnce = useCallback(() => {
+    if (hasOrigin || repoUrl.trim().length === 0 || originSaveRequestedRef.current) {
+      return;
+    }
+
+    originSaveRequestedRef.current = true;
+    void Promise.resolve(onSaveOrigin()).finally(() => {
+      originSaveRequestedRef.current = false;
+    });
+  }, [hasOrigin, onSaveOrigin, repoUrl]);
 
   useEffect(() => {
     if (!optionsOpen) {
@@ -66,16 +78,14 @@ export function ComposerGitOpsFooter({
         return;
       }
 
-      if (!hasOrigin && repoUrl.trim().length > 0) {
-        void onSaveOrigin();
-      }
+      saveOriginOnce();
 
       window.setTimeout(() => setOptionsOpen(false), 0);
     };
 
     window.addEventListener("pointerdown", handlePointerDown, true);
     return () => window.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [hasOrigin, onSaveOrigin, optionsOpen, repoUrl]);
+  }, [optionsOpen, saveOriginOnce]);
 
   useEffect(() => {
     if (!optionsOpen) {
@@ -127,12 +137,12 @@ export function ComposerGitOpsFooter({
                     value={repoUrl}
                     onChange={(event) => onSetRepoUrl(event.target.value)}
                     onBlur={() => {
-                      void onSaveOrigin();
+                      saveOriginOnce();
                     }}
                     onKeyDown={(event) => {
                       if (event.key === "Enter") {
                         event.preventDefault();
-                        void onSaveOrigin();
+                        saveOriginOnce();
                       }
                     }}
                     className="min-h-7 rounded-lg border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] px-2.5 text-[12px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted-2)]"

--- a/src/app/components/workspace/composer/ComposerGitOpsMessageField.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsMessageField.tsx
@@ -1,6 +1,4 @@
 import type { KeyboardEventHandler, ReactNode } from "react";
-import { GitCompareArrows } from "lucide-react";
-import { cn } from "../../../utils/cn";
 import { ComposerTextField } from "./ComposerTextField";
 
 type ComposerGitOpsMessageFieldProps = {
@@ -16,6 +14,7 @@ type ComposerGitOpsMessageFieldProps = {
   trailingAccessory?: ReactNode;
   value: string;
   commitFocused: boolean;
+  isGitRepo: boolean;
 };
 
 export function ComposerGitOpsMessageField({
@@ -31,7 +30,23 @@ export function ComposerGitOpsMessageField({
   trailingAccessory,
   value,
   commitFocused,
+  isGitRepo,
 }: ComposerGitOpsMessageFieldProps) {
+  const errorMessage = actionErrorMessage ?? diffCommentError;
+  const placeholder = hasDiffComments
+    ? errorMessage
+      ? errorMessage
+      : commitFocused
+        ? ""
+        : "Address & fix these comments: "
+    : errorMessage
+      ? errorMessage
+      : commitFocused
+        ? ""
+        : isGitRepo
+          ? "Leave blank to autogenerate a commit message"
+          : "Not a git repository";
+
   const field = (
     <ComposerTextField
       value={value}
@@ -41,53 +56,36 @@ export function ComposerGitOpsMessageField({
       onFocus={onFocus}
       onBlur={onBlur}
       ariaLabel={hasDiffComments ? "Comment instructions" : "Commit message"}
-      placeholder={
-        hasDiffComments
-          ? commitFocused
-            ? ""
-            : "Address & fix these comments: "
-          : commitFocused
-            ? ""
-            : "Leave blank to autogenerate a commit message"
-      }
+      placeholder={placeholder}
+      placeholderTone={errorMessage ? "error" : "muted"}
+      statusMessage={errorMessage && value.length > 0 ? errorMessage : null}
       reservedLineCount={1}
       onHeightChange={onLayoutChange}
     />
   );
 
-  const errorChrome = (
-    <div
-      className={cn(
-        "inline-flex h-8 items-center justify-end rounded-full text-right text-[12px] leading-5",
-        actionErrorMessage || diffCommentError ? "text-[#f2a7a7]" : "invisible w-8",
-      )}
-      aria-live={actionErrorMessage || diffCommentError ? "polite" : undefined}
-      aria-hidden={actionErrorMessage || diffCommentError ? undefined : true}
-    >
-      {actionErrorMessage ?? diffCommentError ?? <GitCompareArrows size={16} />}
-    </div>
-  );
+  const liveError = errorMessage ? (
+    <span className="sr-only" aria-live="polite">
+      {errorMessage}
+    </span>
+  ) : null;
 
   if (hasDiffComments) {
     return (
       <div className="flex items-end justify-between gap-2 px-4 pb-3">
         <div className="min-w-0 flex-1">{field}</div>
-        <div className="inline-flex items-center gap-2">
-          {trailingAccessory}
-          {errorChrome}
-        </div>
+        <div className="inline-flex items-center gap-2">{trailingAccessory}</div>
+        {liveError}
       </div>
     );
   }
 
   return (
-    <div className="grid content-end px-4 pt-[52px] pb-3">
+    <div className="grid content-end px-4 py-3">
       <div className="flex items-end justify-between gap-2">
         <div className="min-w-0 flex-1">{field}</div>
-        <div className="inline-flex items-center gap-2">
-          {trailingAccessory}
-          {errorChrome}
-        </div>
+        <div className="inline-flex items-center gap-2">{trailingAccessory}</div>
+        {liveError}
       </div>
     </div>
   );

--- a/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
@@ -267,15 +267,18 @@ export function ComposerGitOpsSurface({
         hasOrigin={hasOrigin}
         includeUnstaged={includeUnstaged}
         isGitRepo={isGitRepo}
+        onSaveOrigin={handleSaveOrigin}
         onBack={onBack}
         onSetDiffBaseline={onSetDiffBaseline}
         onSetDiffRenderMode={onSetDiffRenderMode}
+        onSetRepoUrl={setRepoUrl}
         onToggleIncludeUnstaged={() => setIncludeUnstaged((current) => !current)}
         onTogglePreview={togglePreviewEnabled}
         onTogglePush={() => setPushEnabled((current) => !current)}
         previewEnabled={previewEnabled}
         projectGitState={projectGitState}
         pushEnabled={pushEnabled}
+        repoUrl={repoUrl}
       />
     </div>
   );

--- a/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
@@ -195,11 +195,8 @@ export function ComposerGitOpsSurface({
             hasOrigin={hasOrigin}
             isGitHubOrigin={isGitHubOrigin}
             isGitRepo={isGitRepo}
-            onSaveOrigin={handleSaveOrigin}
             onSelectDiffComment={onSelectDiffComment}
-            onSetRepoUrl={setRepoUrl}
             projectGitState={projectGitState}
-            repoUrl={repoUrl}
           />
         ) : null}
         {!hasDiffComments ? (

--- a/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
@@ -5,7 +5,7 @@ import type {
   ProjectGitState,
 } from "../../../desktop/types";
 import { getFeatureStatusDataAttributes } from "../../../features/feature-status";
-import { toolbarButtonClass } from "../../../ui/classes";
+import { composerTextActionButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import type { SavedDiffComment } from "../diff/diffCommentStore";
 import { ComposerDictationControls } from "./ComposerDictationControls";
@@ -30,6 +30,7 @@ type ComposerGitOpsSurfaceProps = {
   diffCommentCount: number;
   diffCommentsSending: boolean;
   diffCommentError: string | null;
+  diffLoadError: string | null;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
   onSetDiffRenderMode: (mode: "stacked" | "split") => void;
   onSendDiffComments: (message?: string | null) => void;
@@ -54,6 +55,7 @@ export function ComposerGitOpsSurface({
   diffCommentCount,
   diffCommentsSending,
   diffCommentError,
+  diffLoadError,
   onSetDiffBaseline,
   onSetDiffRenderMode,
   onSendDiffComments,
@@ -159,10 +161,7 @@ export function ComposerGitOpsSurface({
   const primaryActionButton = (
     <button
       type="button"
-      className={cn(
-        toolbarButtonClass,
-        "rounded-full border border-[color:var(--accent)] bg-[color:var(--accent)] px-3 text-[#1a1c26] hover:bg-[color:var(--accent)] hover:text-[#1a1c26] disabled:cursor-not-allowed disabled:opacity-45",
-      )}
+      className={composerTextActionButtonClass}
       onClick={() => {
         void handlePrimaryAction();
       }}
@@ -189,26 +188,27 @@ export function ComposerGitOpsSurface({
       <div className={contentMinHeightClass}>
         {/* Top git-ops controls are absolutely positioned inside this shared block. The prompt
             composer mirrors this pattern with its + button, prompt body, and send controls. */}
-        <ComposerGitOpsTopBar
-          commentCards={commentCards}
-          diffRenderMode={diffRenderMode}
-          hasDiffComments={hasDiffComments}
-          hasOrigin={hasOrigin}
-          isGitHubOrigin={isGitHubOrigin}
-          isGitRepo={isGitRepo}
-          onSaveOrigin={handleSaveOrigin}
-          onSelectDiffComment={onSelectDiffComment}
-          onSetDiffRenderMode={onSetDiffRenderMode}
-          onSetRepoUrl={setRepoUrl}
-          projectGitState={projectGitState}
-          repoUrl={repoUrl}
-        />
+        {hasDiffComments ? (
+          <ComposerGitOpsTopBar
+            commentCards={commentCards}
+            hasDiffComments={hasDiffComments}
+            hasOrigin={hasOrigin}
+            isGitHubOrigin={isGitHubOrigin}
+            isGitRepo={isGitRepo}
+            onSaveOrigin={handleSaveOrigin}
+            onSelectDiffComment={onSelectDiffComment}
+            onSetRepoUrl={setRepoUrl}
+            projectGitState={projectGitState}
+            repoUrl={repoUrl}
+          />
+        ) : null}
         {!hasDiffComments ? (
           <ComposerGitOpsMessageField
             actionErrorMessage={actionErrorMessage}
             commitFocused={commitFocused}
-            diffCommentError={diffCommentError}
+            diffCommentError={diffCommentError ?? diffLoadError}
             hasDiffComments={false}
+            isGitRepo={isGitRepo}
             onBlur={() => setCommitFocused(false)}
             onChange={handleCommitMessageChange}
             onFocus={() => setCommitFocused(true)}
@@ -234,8 +234,9 @@ export function ComposerGitOpsSurface({
         <ComposerGitOpsMessageField
           actionErrorMessage={actionErrorMessage}
           commitFocused={commitFocused}
-          diffCommentError={diffCommentError}
+          diffCommentError={diffCommentError ?? diffLoadError}
           hasDiffComments
+          isGitRepo={isGitRepo}
           onBlur={() => setCommitFocused(false)}
           onChange={handleCommitMessageChange}
           onFocus={() => setCommitFocused(true)}
@@ -262,11 +263,13 @@ export function ComposerGitOpsSurface({
       <ComposerGitOpsFooter
         composerPanelRef={composerPanelRef}
         diffBaseline={diffBaseline}
+        diffRenderMode={diffRenderMode}
         hasOrigin={hasOrigin}
         includeUnstaged={includeUnstaged}
         isGitRepo={isGitRepo}
         onBack={onBack}
         onSetDiffBaseline={onSetDiffBaseline}
+        onSetDiffRenderMode={onSetDiffRenderMode}
         onToggleIncludeUnstaged={() => setIncludeUnstaged((current) => !current)}
         onTogglePreview={togglePreviewEnabled}
         onTogglePush={() => setPushEnabled((current) => !current)}

--- a/src/app/components/workspace/composer/ComposerGitOpsTopBar.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsTopBar.tsx
@@ -1,23 +1,17 @@
-import { Columns2, GitBranch, Github, Rows3, TriangleAlert } from "lucide-react";
+import { GitBranch, Github } from "lucide-react";
 import type { ProjectGitState } from "../../../desktop/types";
-import {
-  compactCardClass,
-  diffPanelIconButtonClass,
-  diffPanelTurnChipSelectedClass,
-} from "../../../ui/classes";
+import { compactCardClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import type { GitOpsCommentCard } from "./composer-git-ops.helpers";
 
 type ComposerGitOpsTopBarProps = {
   commentCards: GitOpsCommentCard[];
-  diffRenderMode: "stacked" | "split";
   hasDiffComments: boolean;
   hasOrigin: boolean;
   isGitHubOrigin: boolean;
   isGitRepo: boolean;
   onSaveOrigin: () => void;
   onSelectDiffComment: (filePath: string, commentId: string) => void;
-  onSetDiffRenderMode: (mode: "stacked" | "split") => void;
   onSetRepoUrl: (repoUrl: string) => void;
   projectGitState: ProjectGitState | null;
   repoUrl: string;
@@ -25,14 +19,12 @@ type ComposerGitOpsTopBarProps = {
 
 export function ComposerGitOpsTopBar({
   commentCards,
-  diffRenderMode,
   hasDiffComments,
   hasOrigin,
   isGitHubOrigin,
   isGitRepo,
   onSaveOrigin,
   onSelectDiffComment,
-  onSetDiffRenderMode,
   onSetRepoUrl,
   projectGitState,
   repoUrl,
@@ -74,12 +66,7 @@ export function ComposerGitOpsTopBar({
               aria-label="Repository URL"
             />
           )
-        ) : (
-          <div className="flex items-center gap-2 text-[12px] text-[#ff9c9c]">
-            <TriangleAlert size={14} />
-            <span>Not a git repository</span>
-          </div>
-        )}
+        ) : null}
 
         {isGitRepo ? (
           <button
@@ -94,37 +81,6 @@ export function ComposerGitOpsTopBar({
             <span>{projectGitState?.branch ?? "Detached"}</span>
           </button>
         ) : null}
-      </div>
-
-      <div className="absolute top-4 right-4 flex items-center gap-1.5">
-        <button
-          type="button"
-          className={cn(
-            diffPanelIconButtonClass,
-            diffRenderMode === "stacked"
-              ? diffPanelTurnChipSelectedClass
-              : "border-[color:var(--border)] bg-transparent",
-          )}
-          onClick={() => onSetDiffRenderMode("stacked")}
-          aria-label="Unified diff view"
-          title="Unified diff view"
-        >
-          <Rows3 size={14} />
-        </button>
-        <button
-          type="button"
-          className={cn(
-            diffPanelIconButtonClass,
-            diffRenderMode === "split"
-              ? diffPanelTurnChipSelectedClass
-              : "border-[color:var(--border)] bg-transparent",
-          )}
-          onClick={() => onSetDiffRenderMode("split")}
-          aria-label="Split diff view"
-          title="Split diff view"
-        >
-          <Columns2 size={14} />
-        </button>
       </div>
 
       {hasDiffComments ? (

--- a/src/app/components/workspace/composer/ComposerGitOpsTopBar.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsTopBar.tsx
@@ -10,11 +10,8 @@ type ComposerGitOpsTopBarProps = {
   hasOrigin: boolean;
   isGitHubOrigin: boolean;
   isGitRepo: boolean;
-  onSaveOrigin: () => void;
   onSelectDiffComment: (filePath: string, commentId: string) => void;
-  onSetRepoUrl: (repoUrl: string) => void;
   projectGitState: ProjectGitState | null;
-  repoUrl: string;
 };
 
 export function ComposerGitOpsTopBar({
@@ -23,49 +20,24 @@ export function ComposerGitOpsTopBar({
   hasOrigin,
   isGitHubOrigin,
   isGitRepo,
-  onSaveOrigin,
   onSelectDiffComment,
-  onSetRepoUrl,
   projectGitState,
-  repoUrl,
 }: ComposerGitOpsTopBarProps) {
   return (
     <>
       <div className="absolute top-4 left-4 flex max-w-[calc(100%-18rem)] items-center gap-2">
-        {isGitRepo ? (
-          hasOrigin ? (
-            <button
-              type="button"
-              className={cn(
-                compactCardClass,
-                "inline-flex items-center gap-1.5 px-2.5 py-1 text-[12px] text-[color:var(--text)]",
-              )}
-              title={projectGitState?.originUrl ?? "origin"}
-            >
-              {isGitHubOrigin ? <Github size={12} /> : null}
-              {projectGitState?.originName ?? "origin"}
-            </button>
-          ) : (
-            <input
-              value={repoUrl}
-              onChange={(event) => onSetRepoUrl(event.target.value)}
-              onBlur={() => {
-                void onSaveOrigin();
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  void onSaveOrigin();
-                }
-              }}
-              className={cn(
-                compactCardClass,
-                "w-64 bg-transparent px-2.5 py-1 text-[12px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]",
-              )}
-              placeholder="Paste repository URL"
-              aria-label="Repository URL"
-            />
-          )
+        {isGitRepo && hasOrigin ? (
+          <button
+            type="button"
+            className={cn(
+              compactCardClass,
+              "inline-flex items-center gap-1.5 px-2.5 py-1 text-[12px] text-[color:var(--text)]",
+            )}
+            title={projectGitState?.originUrl ?? "origin"}
+          >
+            {isGitHubOrigin ? <Github size={12} /> : null}
+            {projectGitState?.originName ?? "origin"}
+          </button>
         ) : null}
 
         {isGitRepo ? (

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -188,9 +188,10 @@ export function ComposerPromptSurface({
   }, [handleDrop]);
 
   const placeholderText =
-    activeView === "thread"
+    errorMessage ??
+    (activeView === "thread"
       ? "Ask for follow-up changes"
-      : "Ask Pi anything, @ to add files, / for commands, $ for skills";
+      : "Ask Pi anything, @ to add files, / for commands, $ for skills");
   const attachmentButtonLabel = attachments.length > 0 ? "Manage attachments" : "Add attachment";
 
   return (
@@ -362,6 +363,8 @@ export function ComposerPromptSurface({
                   ariaControls={slashCommands.open ? slashCommands.listboxId : undefined}
                   ariaExpanded={slashCommands.open}
                   placeholder={placeholderText}
+                  placeholderTone={errorMessage ? "error" : "muted"}
+                  statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                   reservedLineCount={1}
                   onHeightChange={onLayoutChange}
                 />
@@ -411,7 +414,7 @@ export function ComposerPromptSurface({
       </div>
 
       {errorMessage ? (
-        <output className="px-4 pb-2 text-[12px] text-[#f2a7a7]" aria-live="polite">
+        <output className="sr-only" aria-live="polite">
           {errorMessage}
         </output>
       ) : null}

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -1,8 +1,11 @@
 import { type ClipboardEvent, type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { cn } from "../../../utils/cn";
 
 type ComposerTextFieldProps = {
   value: string;
   placeholder: string;
+  placeholderTone?: "muted" | "error";
+  statusMessage?: string | null;
   ariaLabel: string;
   ariaActiveDescendant?: string;
   ariaControls?: string;
@@ -21,6 +24,8 @@ type ComposerTextFieldProps = {
 export function ComposerTextField({
   value,
   placeholder,
+  placeholderTone = "muted",
+  statusMessage = null,
   ariaLabel,
   ariaActiveDescendant,
   ariaControls,
@@ -78,7 +83,7 @@ export function ComposerTextField({
 
   return (
     <div
-      className="flex min-w-0 items-end"
+      className="grid min-w-0 gap-1"
       style={reservedHeight ? { minHeight: `${reservedHeight}px` } : undefined}
       onPointerEnter={(event) => {
         if (event.pointerType !== "mouse") {
@@ -100,10 +105,18 @@ export function ComposerTextField({
         focusTextareaAtEnd();
       }}
     >
+      {statusMessage ? (
+        <div className="truncate text-[12px] leading-4 text-[#f2a7a7]">{statusMessage}</div>
+      ) : null}
       <textarea
         ref={textareaRef}
         rows={1}
-        className="m-0 w-full min-h-6 resize-none overflow-hidden bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted-2)]"
+        className={cn(
+          "m-0 w-full min-h-6 resize-none overflow-hidden bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none",
+          placeholderTone === "error"
+            ? "placeholder:text-[#f2a7a7]"
+            : "placeholder:text-[color:var(--muted-2)]",
+        )}
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onInput={onInput}

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -40,6 +40,7 @@ export function ComposerTextField({
   onBlur,
   onExpandedChange,
 }: ComposerTextFieldProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const lastReportedHeightRef = useRef<number | null>(null);
   const [reservedHeight, setReservedHeight] = useState<number | null>(null);
@@ -69,10 +70,13 @@ export function ComposerTextField({
     textarea.style.height = "0px";
     const nextHeight = Math.max(textarea.scrollHeight, 24);
     textarea.style.height = `${nextHeight}px`;
-    if (lastReportedHeightRef.current !== nextHeight) {
-      lastReportedHeightRef.current = nextHeight;
-      onHeightChange?.(nextHeight);
-    }
+    window.requestAnimationFrame(() => {
+      const reportedHeight = wrapperRef.current?.getBoundingClientRect().height ?? nextHeight;
+      if (lastReportedHeightRef.current !== reportedHeight) {
+        lastReportedHeightRef.current = reportedHeight;
+        onHeightChange?.(reportedHeight);
+      }
+    });
 
     onExpandedChange?.(nextHeight > reservedHeight + 1);
 
@@ -81,8 +85,19 @@ export function ComposerTextField({
     }
   }, [onExpandedChange, onHeightChange, reservedLineCount, value]);
 
+  useEffect(() => {
+    const height = wrapperRef.current?.getBoundingClientRect().height;
+    if (!height || lastReportedHeightRef.current === height) {
+      return;
+    }
+
+    lastReportedHeightRef.current = height;
+    onHeightChange?.(height);
+  });
+
   return (
     <div
+      ref={wrapperRef}
       className="grid min-w-0 gap-1"
       style={reservedHeight ? { minHeight: `${reservedHeight}px` } : undefined}
       onPointerEnter={(event) => {

--- a/src/app/components/workspace/composer/PlainToggle.tsx
+++ b/src/app/components/workspace/composer/PlainToggle.tsx
@@ -5,9 +5,32 @@ type PlainToggleProps = {
   disabled?: boolean;
   label: string;
   onClick: () => void;
+  toggleSide?: "left" | "right";
 };
 
-export function PlainToggle({ checked, disabled = false, label, onClick }: PlainToggleProps) {
+export function PlainToggle({
+  checked,
+  disabled = false,
+  label,
+  onClick,
+  toggleSide = "right",
+}: PlainToggleProps) {
+  const toggle = (
+    <span
+      className={cn(
+        "relative inline-flex h-5 w-9 items-center rounded-full transition-colors",
+        checked ? "bg-[color:var(--accent)]" : "bg-[rgba(255,255,255,0.14)]",
+      )}
+    >
+      <span
+        className={cn(
+          "inline-block h-3 w-3 rounded-full bg-[#1a1c26] transition-transform",
+          checked ? "translate-x-5" : "translate-x-1",
+        )}
+      />
+    </span>
+  );
+
   return (
     <button
       type="button"
@@ -19,20 +42,9 @@ export function PlainToggle({ checked, disabled = false, label, onClick }: Plain
       disabled={disabled}
       aria-pressed={checked}
     >
+      {toggleSide === "left" ? toggle : null}
       <span>{label}</span>
-      <span
-        className={cn(
-          "relative inline-flex h-5 w-9 items-center rounded-full transition-colors",
-          checked ? "bg-[color:var(--accent)]" : "bg-[rgba(255,255,255,0.14)]",
-        )}
-      >
-        <span
-          className={cn(
-            "inline-block h-3 w-3 rounded-full bg-[#1a1c26] transition-transform",
-            checked ? "translate-x-5" : "translate-x-1",
-          )}
-        />
-      </span>
+      {toggleSide === "right" ? toggle : null}
     </button>
   );
 }

--- a/src/app/components/workspace/composer/submitComposerDraft.ts
+++ b/src/app/components/workspace/composer/submitComposerDraft.ts
@@ -4,6 +4,7 @@ import type {
   DesktopActionInvoker,
 } from "../../../desktop/types";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
+import { getErrorMessage } from "../../../desktop/error-messages";
 import { isCompactSlashCommand } from "../../../../../shared/composer-slash-commands";
 
 type SubmitComposerDraftResult =
@@ -71,7 +72,7 @@ export async function submitComposerDraft({
   } catch (error) {
     return {
       status: "error",
-      errorMessage: error instanceof Error ? error.message : "Could not send prompt.",
+      errorMessage: getErrorMessage(error, "Could not send prompt."),
       text,
     };
   }

--- a/src/app/components/workspace/composer/useComposerAttachmentPicker.ts
+++ b/src/app/components/workspace/composer/useComposerAttachmentPicker.ts
@@ -6,6 +6,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
+import { getErrorMessage } from "../../../desktop/error-messages";
 import type { ComposerAttachment, ComposerFilePickerState } from "../../../desktop/types";
 import { mergeComposerAttachments } from "../../../../../shared/composer-attachments";
 
@@ -72,7 +73,7 @@ export function useComposerAttachmentPicker({
           return null;
         }
 
-        setErrorMessage(error instanceof Error ? error.message : "Could not load files.");
+        setErrorMessage(getErrorMessage(error, "Could not load files."));
         return null;
       } finally {
         if (requestId === pickerRequestIdRef.current) {

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -8,6 +8,7 @@ import {
   type SetStateAction,
 } from "react";
 import type { DesktopAction } from "../../../desktop/actions";
+import { getErrorMessage } from "../../../desktop/error-messages";
 import type {
   ComposerAttachment,
   ComposerFilePickerState,
@@ -250,7 +251,7 @@ export function useComposerController({
         setOpenMenu(null);
       }
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Could not update the composer.");
+      setErrorMessage(getErrorMessage(error, "Could not update the composer."));
     }
   };
 

--- a/src/app/components/workspace/composer/useComposerDictation.ts
+++ b/src/app/components/workspace/composer/useComposerDictation.ts
@@ -7,6 +7,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
+import { getErrorMessage } from "../../../desktop/error-messages";
 import type { DictationState } from "../../../desktop/types";
 import {
   appendDictatedText,
@@ -140,9 +141,7 @@ export function useComposerDictation({
           activeDictationScopeKeyRef.current === submittedScopeKey &&
           dictationSessionTokenRef.current === submittedSessionToken
         ) {
-          setErrorMessage(
-            error instanceof Error ? error.message : "Could not stop local dictation.",
-          );
+          setErrorMessage(getErrorMessage(error, "Could not stop local dictation."));
         }
       } finally {
         dictationFlushPromiseRef.current = null;
@@ -254,7 +253,7 @@ export function useComposerDictation({
       return "started" as const;
     } catch (error) {
       clearDictationSession();
-      setErrorMessage(error instanceof Error ? error.message : "Could not start local dictation.");
+      setErrorMessage(getErrorMessage(error, "Could not start local dictation."));
       return "unavailable" as const;
     }
   };

--- a/src/app/components/workspace/composer/useComposerGitOpsState.ts
+++ b/src/app/components/workspace/composer/useComposerGitOpsState.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction } from "react";
+import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
+import { getErrorMessage } from "../../../desktop/error-messages";
 import type { DesktopActionInvoker, ProjectGitState } from "../../../desktop/types";
 import type { SavedDiffComment } from "../diff/diffCommentStore";
 import {
@@ -118,13 +120,19 @@ export function useComposerGitOpsState({
     }
 
     try {
-      await onAction("workspace.commit-options", { repoUrl: nextRepoUrl });
+      const result = await onAction("workspace.commit-options", { repoUrl: nextRepoUrl });
+      const actionErrorMessage = getDesktopActionErrorMessage(
+        result,
+        "Could not update the repository remote.",
+      );
+      if (actionErrorMessage) {
+        setActionErrorMessage(actionErrorMessage);
+        return;
+      }
       setActionErrorMessage(null);
       setRepoUrl("");
     } catch (error) {
-      setActionErrorMessage(
-        error instanceof Error ? error.message : "Could not update the repository remote.",
-      );
+      setActionErrorMessage(getErrorMessage(error, "Could not update the repository remote."));
     }
   }, [isGitRepo, onAction, repoUrl]);
 
@@ -140,10 +148,18 @@ export function useComposerGitOpsState({
 
     if (!isGitRepo) {
       try {
-        await onAction("workspace.commit-options");
+        const result = await onAction("workspace.commit-options");
+        const actionErrorMessage = getDesktopActionErrorMessage(
+          result,
+          "Could not initialize git.",
+        );
+        if (actionErrorMessage) {
+          setActionErrorMessage(actionErrorMessage);
+          return;
+        }
         setActionErrorMessage(null);
       } catch (error) {
-        setActionErrorMessage(error instanceof Error ? error.message : "Could not initialize git.");
+        setActionErrorMessage(getErrorMessage(error, "Could not initialize git."));
       }
       return;
     }
@@ -188,7 +204,7 @@ export function useComposerGitOpsState({
       }
       setActionErrorMessage(getActionResultError(result));
     } catch (error) {
-      setActionErrorMessage(error instanceof Error ? error.message : "Could not commit changes.");
+      setActionErrorMessage(getErrorMessage(error, "Could not commit changes."));
     } finally {
       setRunningPrimaryAction(false);
     }

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -1,5 +1,6 @@
 import { useCallback, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
+import { getErrorMessage } from "../../../desktop/error-messages";
 import type {
   ComposerAttachment,
   ComposerStreamingBehavior,
@@ -174,7 +175,7 @@ export function useComposerSubmission({
         setErrorMessage(actionErrorMessage);
       }
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Could not stop Pi.");
+      setErrorMessage(getErrorMessage(error, "Could not stop Pi."));
     } finally {
       setIsSending(false);
     }

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -169,15 +169,18 @@ export function DiffPanelContent({
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
             {!renderablePatch ? (
               <div className="flex h-full items-center justify-center px-3 py-2 text-center text-xs text-[color:var(--muted)]">
-                <p>
-                  {isLoading
-                    ? "Loading diff..."
-                    : error
-                      ? "Diff unavailable."
-                      : hasNoNetChanges
-                        ? `No net changes ${getDiffBaselinePrefix(baseline)} ${getResolvedDiffBaselineLabel(baseline, diff?.resolvedBaseline)}.`
-                        : "No patch available for this worktree."}
-                </p>
+                <div className="grid max-w-[42rem] gap-1.5">
+                  <p>
+                    {isLoading
+                      ? "Loading diff..."
+                      : error
+                        ? "Diff unavailable."
+                        : hasNoNetChanges
+                          ? `No net changes ${getDiffBaselinePrefix(baseline)} ${getResolvedDiffBaselineLabel(baseline, diff?.resolvedBaseline)}.`
+                          : "No patch available for this worktree."}
+                  </p>
+                  {error ? <p className="text-[#f2a7a7]">{error}</p> : null}
+                </div>
               </div>
             ) : renderablePatch.kind === "files" ? (
               <div

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -167,20 +167,16 @@ export function DiffPanelContent({
       ) : (
         <>
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-            {error && !renderablePatch ? (
-              <div className="px-3 pt-3">
-                <p className="mb-2 text-[11px] text-[#f2a7a7]">{error}</p>
-              </div>
-            ) : null}
-
             {!renderablePatch ? (
               <div className="flex h-full items-center justify-center px-3 py-2 text-center text-xs text-[color:var(--muted)]">
                 <p>
                   {isLoading
                     ? "Loading diff..."
-                    : hasNoNetChanges
-                      ? `No net changes ${getDiffBaselinePrefix(baseline)} ${getResolvedDiffBaselineLabel(baseline, diff?.resolvedBaseline)}.`
-                      : "No patch available for this worktree."}
+                    : error
+                      ? "Diff unavailable."
+                      : hasNoNetChanges
+                        ? `No net changes ${getDiffBaselinePrefix(baseline)} ${getResolvedDiffBaselineLabel(baseline, diff?.resolvedBaseline)}.`
+                        : "No patch available for this worktree."}
                 </p>
               </div>
             ) : renderablePatch.kind === "files" ? (

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -50,7 +50,10 @@ export function InboxComposer({
                   }
                 }}
                 ariaLabel="Inbox prompt composer"
-                placeholder="Reply to this thread…"
+                placeholder={errorMessage ?? "Reply to this thread…"}
+                placeholderTone={errorMessage ? "error" : "muted"}
+                statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
+                reservedLineCount={1}
               />
             </div>
 
@@ -87,7 +90,7 @@ export function InboxComposer({
       </div>
 
       {errorMessage ? (
-        <output className="px-4 pb-2 text-[12px] text-[#f2a7a7]" aria-live="polite">
+        <output className="sr-only" aria-live="polite">
           {errorMessage}
         </output>
       ) : null}

--- a/src/app/desktop/action-results.ts
+++ b/src/app/desktop/action-results.ts
@@ -1,20 +1,21 @@
 import type { DesktopActionResult } from "./types";
+import { cleanUserErrorMessage } from "./error-messages";
 
 export function getDesktopActionErrorMessage(
   actionResult: DesktopActionResult | null,
   fallbackMessage: string,
 ) {
   if (actionResult === null) {
-    return fallbackMessage;
+    return cleanUserErrorMessage(null, fallbackMessage);
   }
 
   if (actionResult?.ok === false && typeof actionResult.result?.error === "string") {
-    return actionResult.result.error;
+    return cleanUserErrorMessage(actionResult.result.error, fallbackMessage);
   }
 
   if (typeof actionResult?.result?.error === "string") {
-    return actionResult.result.error;
+    return cleanUserErrorMessage(actionResult.result.error, fallbackMessage);
   }
 
-  return actionResult.ok === false ? fallbackMessage : null;
+  return actionResult.ok === false ? cleanUserErrorMessage(null, fallbackMessage) : null;
 }

--- a/src/app/desktop/error-messages.ts
+++ b/src/app/desktop/error-messages.ts
@@ -1,0 +1,28 @@
+const ELECTRON_REMOTE_ERROR_PREFIX = /^Error invoking remote method '[^']+':\s*/i;
+
+function stripKnownWrappers(message: string) {
+  let next = message.trim().replace(ELECTRON_REMOTE_ERROR_PREFIX, "");
+
+  const lastErrorIndex = next.lastIndexOf("Error:");
+  if (lastErrorIndex >= 0) {
+    next = next.slice(lastErrorIndex + "Error:".length).trim();
+  }
+
+  return next;
+}
+
+export function cleanUserErrorMessage(
+  message: string | null | undefined,
+  fallback = "Something went wrong.",
+) {
+  if (!message) {
+    return fallback;
+  }
+
+  const cleaned = stripKnownWrappers(message).replace(/\s+/g, " ").trim();
+  return cleaned || fallback;
+}
+
+export function getErrorMessage(error: unknown, fallback: string) {
+  return cleanUserErrorMessage(error instanceof Error ? error.message : null, fallback);
+}

--- a/src/app/desktop/error-messages.ts
+++ b/src/app/desktop/error-messages.ts
@@ -1,14 +1,8 @@
 const ELECTRON_REMOTE_ERROR_PREFIX = /^Error invoking remote method '[^']+':\s*/i;
+const LEADING_ERROR_PREFIX = /^Error:\s*/i;
 
 function stripKnownWrappers(message: string) {
-  let next = message.trim().replace(ELECTRON_REMOTE_ERROR_PREFIX, "");
-
-  const lastErrorIndex = next.lastIndexOf("Error:");
-  if (lastErrorIndex >= 0) {
-    next = next.slice(lastErrorIndex + "Error:".length).trim();
-  }
-
-  return next;
+  return message.trim().replace(ELECTRON_REMOTE_ERROR_PREFIX, "").replace(LEADING_ERROR_PREFIX, "");
 }
 
 export function cleanUserErrorMessage(

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -5,6 +5,7 @@ import { DiffPanel } from "../../components/workspace/DiffPanel";
 import { GitOpsComposerPanel } from "../../components/workspace/GitOpsComposerPanel";
 import { QueuedPromptsCard } from "../../components/workspace/composer/QueuedPromptsCard";
 import type { ProjectDiffBaseline } from "../../desktop/types";
+import { useDesktopDiff } from "../../hooks/useDesktopDiff";
 import { mainPanelClass } from "../../ui/classes";
 import { CodeWorkspaceMainView } from "./CodeWorkspaceMainView";
 import { useDiffCommentController } from "./useDiffCommentController";
@@ -60,6 +61,11 @@ export function CodeWorkspaceView({
   const showWorkspaceFooter = state.activeView === "thread" || state.activeView === "gitops";
   const showDiffInMainView = state.activeView === "gitops";
   const showDesktopTerminalDrawer = state.activeView === "thread" && terminalDrawerVisible;
+  const { error: diffLoadError } = useDesktopDiff(
+    composerProjectId,
+    diffBaseline,
+    showDiffInMainView && (projectGitState?.isGitRepo ?? false),
+  );
   const footerHeight = useWorkspaceFooterHeight({
     footerRef,
     visible: showWorkspaceFooter,
@@ -198,6 +204,7 @@ export function CodeWorkspaceView({
                     diffCommentCount={diffCommentCount}
                     diffCommentsSending={diffCommentsSending}
                     diffCommentError={diffCommentError}
+                    diffLoadError={diffLoadError}
                     onSetDiffBaseline={onSetDiffBaseline}
                     onSetDiffRenderMode={setDiffRenderMode}
                     onSendDiffComments={(message) => {

--- a/src/app/features/feature-status.tsx
+++ b/src/app/features/feature-status.tsx
@@ -62,7 +62,7 @@ export function getFeatureStatusAccentClass(statusId: FeatureStatusId) {
 export function getFeatureStatusButtonClass(statusId: FeatureStatusId) {
   return getFeatureStatusMeta(statusId).status === "mock"
     ? "border-[rgba(255,110,110,0.22)] text-[#ff9c9c] hover:border-[rgba(255,110,110,0.36)] hover:bg-[rgba(255,94,94,0.08)] hover:text-[#ffd1d1]"
-    : "border-[rgba(255,214,102,0.22)] text-[#ffd36a] hover:border-[rgba(255,214,102,0.34)] hover:bg-[rgba(255,204,102,0.08)] hover:text-[#ffe297]";
+    : "border-[rgba(169,178,215,0.18)] text-[color:var(--muted)] hover:border-[rgba(169,178,215,0.28)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[color:var(--text)]";
 }
 
 export function getFeatureStatusBadgeClass(statusId: FeatureStatusId) {

--- a/src/app/hooks/useDesktopBridge.ts
+++ b/src/app/hooks/useDesktopBridge.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { DesktopAction } from "../desktop/actions";
+import { getErrorMessage } from "../desktop/error-messages";
 import type { DesktopActionInvoker, DesktopActionResult } from "../desktop/types";
 
 export const desktopBridgeUnavailableMessage =
@@ -87,7 +88,7 @@ export function useDesktopBridge() {
         at: new Date().toISOString(),
         payload: { action, payload },
         result: {
-          error: error instanceof Error ? error.message : "Desktop action request failed.",
+          error: getErrorMessage(error, "Desktop action request failed."),
         },
       };
     }

--- a/src/app/hooks/useDesktopDiff.ts
+++ b/src/app/hooks/useDesktopDiff.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { cleanUserErrorMessage } from "../desktop/error-messages";
 import type { ProjectDiffBaseline, ProjectDiffResult } from "../desktop/types";
 import { desktopQueryKeys, getProjectDiffQuery } from "../query/desktop-query";
 
@@ -7,6 +8,10 @@ type DiffState = {
   isLoading: boolean;
   error: string | null;
 };
+
+export function getReadableDesktopDiffError(error: string | null) {
+  return error ? cleanUserErrorMessage(error, "Could not load diff.") : null;
+}
 
 export function useDesktopDiff(
   projectId: string | null,
@@ -25,6 +30,6 @@ export function useDesktopDiff(
   return {
     diff: query.data ?? null,
     isLoading: query.isLoading || query.isFetching,
-    error: query.error?.message ?? null,
+    error: getReadableDesktopDiffError(query.error?.message ?? null),
   } satisfies DiffState;
 }

--- a/src/app/hooks/useDesktopDiff.ts
+++ b/src/app/hooks/useDesktopDiff.ts
@@ -18,18 +18,19 @@ export function useDesktopDiff(
   baseline: ProjectDiffBaseline | null = null,
   enabled = true,
 ) {
+  const queryEnabled = enabled && Boolean(projectId);
   const query = useQuery<ProjectDiffResult | null, Error>({
     queryKey: projectId
       ? desktopQueryKeys.projectDiff(projectId, baseline)
       : ["desktop", "projectDiff", null],
     queryFn: () => (projectId ? getProjectDiffQuery(projectId, baseline) : Promise.resolve(null)),
-    enabled: enabled && Boolean(projectId),
+    enabled: queryEnabled,
     refetchOnMount: "always",
   });
 
   return {
     diff: query.data ?? null,
     isLoading: query.isLoading || query.isFetching,
-    error: getReadableDesktopDiffError(query.error?.message ?? null),
+    error: queryEnabled ? getReadableDesktopDiffError(query.error?.message ?? null) : null,
   } satisfies DiffState;
 }

--- a/src/app/ui/classes.ts
+++ b/src/app/ui/classes.ts
@@ -62,7 +62,10 @@ export const ghostButtonClass =
   "rounded-[10px] border border-transparent px-2 py-1 text-[12.5px] leading-5 text-[color:var(--muted)] transition-colors duration-150 ease-out hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]";
 
 export const primaryButtonClass =
-  "min-h-8 rounded-full bg-[color:var(--accent)] px-4 text-[13px] font-medium text-[#1a1c26] transition-opacity duration-150 ease-out hover:opacity-90";
+  "min-h-8 rounded-full border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.06)] px-4 text-[13px] font-medium text-[color:var(--text)] transition-colors duration-150 ease-out hover:border-[rgba(169,178,215,0.22)] hover:bg-[rgba(255,255,255,0.1)] disabled:cursor-not-allowed disabled:border-transparent disabled:bg-[rgba(255,255,255,0.035)] disabled:text-[color:var(--muted-2)]";
+
+export const composerTextActionButtonClass =
+  "inline-flex h-7 items-center justify-center rounded-md border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.06)] px-3 text-[12.5px] font-medium leading-5 text-[color:var(--text)] transition-colors duration-150 ease-out hover:border-[rgba(169,178,215,0.22)] hover:bg-[rgba(255,255,255,0.1)] disabled:cursor-not-allowed disabled:border-transparent disabled:bg-[rgba(255,255,255,0.035)] disabled:text-[color:var(--muted-2)]";
 
 export const interactiveCardClass =
   "rounded-[20px] border border-[color:var(--border)] bg-[rgba(39,42,57,0.9)] text-left shadow-[var(--shadow)] transition-colors duration-150 ease-out hover:bg-[rgba(44,47,64,0.94)]";

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { getDesktopActionErrorMessage } from "../desktop/action-results";
+import { getErrorMessage } from "../desktop/error-messages";
 import { EmptyStateCard } from "../components/common/EmptyStateCard";
 import { MarkdownContent } from "../components/common/MarkdownContent";
 import { InboxComposer } from "../components/workspace/inbox/InboxComposer";
@@ -42,8 +43,8 @@ export function InboxView({
         text: nextDraft,
         streamingBehavior: appSettings.composerStreamingBehavior,
       });
-    } catch {
-      setErrorMessage("Could not send follow-up.");
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error, "Could not send follow-up."));
       return;
     } finally {
       setIsSending(false);
@@ -79,8 +80,8 @@ export function InboxView({
       if (actionErrorMessage) {
         setErrorMessage(actionErrorMessage);
       }
-    } catch {
-      setErrorMessage("Could not stop Pi.");
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error, "Could not stop Pi."));
     } finally {
       setIsSending(false);
     }


### PR DESCRIPTION
## Summary
- Makes the git-ops composer match the compact one-line footprint of the main composer.
- Moves commit options into a cog popover and relocates diff display controls into the footer.
- Standardizes composer/inbox/git-ops error handling through cleaned placeholder/status messages.
- Replaces pale accent-filled primary buttons with reusable neutral button styling and neutralizes partial-feature button hover color.

## Details
- Git-ops no longer reserves a top metadata band for normal commit flows; no-git state now uses the composer placeholder.
- Commit options now include `Include unstaged`, `Draft message`, and `Commit & push` behind the footer cog.
- Diff load errors are shortened and surfaced through the git-ops composer instead of as a noisy top-of-view message.
- Main composer, git-ops composer, and inbox composer display errors in placeholder space when empty and as a small red status line above typed text when non-empty.
- Adds a shared user-facing error cleanup helper for composer-scope paths.

## Validation
- Pre-commit hooks passed: Biome, web/desktop/electron/scripts typechecks, Vitest.
- Push hook passed: lint and typecheck.

Closes #71
Refs #108
