### PR TITLE
Fix composer slash command popover UX

### DIFF
--- a/src/app/app-shell/SmallWindowOverlay.tsx
+++ b/src/app/app-shell/SmallWindowOverlay.tsx
@@ -15,7 +15,7 @@ function getWindowSize(): AppWindowSize | null {
 
 export function SmallWindowOverlay() {
   const [windowSize, setWindowSize] = useState<AppWindowSize | null>(getWindowSize);
-  const dialogRef = useRef<HTMLDialogElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
   const overlayVisible = windowSize ? isSmallAppWindow(windowSize) : false;
   const overlayPresent = useAnimatedPresence(overlayVisible);
 
@@ -58,9 +58,10 @@ export function SmallWindowOverlay() {
       data-open={overlayVisible ? "true" : "false"}
       className={`motion-overlay-panel fixed inset-0 z-[200] flex items-center justify-center bg-[rgba(7,9,16,0.74)] px-6 py-8 backdrop-blur-md ${overlayVisible ? "pointer-events-auto" : "pointer-events-none"}`}
     >
-      <dialog
+      <div
         ref={dialogRef}
-        open={true}
+        // biome-ignore lint/a11y/useSemanticElements: Native dialog applies UA positioning that offsets this small-window overlay in the app shell.
+        role="dialog"
         aria-modal="true"
         aria-labelledby="small-window-overlay-title"
         aria-describedby="small-window-overlay-description"
@@ -109,7 +110,7 @@ export function SmallWindowOverlay() {
             </div>
           </div>
         </div>
-      </dialog>
+      </div>
     </div>
   );
 }

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -126,6 +126,9 @@ export function ComposerPromptSurface({
     send,
     onOpenSettingsView,
   });
+  const slashCommandListSignature = slashCommands.commands
+    .map((command) => `${command.source}:${command.name}`)
+    .join("|");
 
   useEffect(() => {
     if (!slashCommands.open) {
@@ -134,7 +137,11 @@ export function ComposerPromptSurface({
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node | null;
-      if (!target || slashCommandPanelRef.current?.contains(target)) {
+      if (
+        !target ||
+        slashCommandPanelRef.current?.contains(target) ||
+        composerPanelRef.current?.contains(target)
+      ) {
         return;
       }
 
@@ -145,12 +152,16 @@ export function ComposerPromptSurface({
     return () => {
       window.removeEventListener("pointerdown", handlePointerDown, true);
     };
-  }, [slashCommands]);
+  }, [composerPanelRef, slashCommands]);
 
   useEffect(() => {
     if (!slashCommands.open || !slashCommands.activeDescendantId) {
       return;
     }
+
+    // Keep the effect tied to command content changes too: the active id can remain
+    // `...-0` while filtering swaps the actual first row underneath it.
+    void slashCommandListSignature;
 
     const panel = slashCommandPanelRef.current;
     const option = panel?.querySelector<HTMLElement>(`#${slashCommands.activeDescendantId}`);
@@ -176,7 +187,12 @@ export function ComposerPromptSurface({
     } else if (optionBottom > visibleBottom) {
       panel.scrollTop = optionBottom - panel.clientHeight + paddingBottom;
     }
-  }, [slashCommands.open, slashCommands.activeDescendantId, slashCommands.selectedIndex]);
+  }, [
+    slashCommands.open,
+    slashCommands.activeDescendantId,
+    slashCommands.selectedIndex,
+    slashCommandListSignature,
+  ]);
 
   useEffect(() => {
     if (!pickerOpen && !dictationActive && !dictationTranscribing) {

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -1,5 +1,5 @@
 import { Paperclip, Send, Square, X } from "lucide-react";
-import { type ClipboardEvent, type RefObject, useEffect } from "react";
+import { type ClipboardEvent, type RefObject, useEffect, useRef } from "react";
 import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { getPathForFileQuery } from "../../../query/desktop-query";
@@ -117,6 +117,7 @@ export function ComposerPromptSurface({
     onListAttachmentEntries,
   });
   const dictationTranscribing = dictationInterimText.length > 0;
+  const slashCommandPanelRef = useRef<HTMLDivElement>(null);
   const slashCommands = useComposerSlashCommands({
     draft,
     projectId,
@@ -125,6 +126,26 @@ export function ComposerPromptSurface({
     send,
     onOpenSettingsView,
   });
+
+  useEffect(() => {
+    if (!slashCommands.open) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target || slashCommandPanelRef.current?.contains(target)) {
+        return;
+      }
+
+      slashCommands.dismiss({ clearDraft: true });
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [slashCommands]);
 
   useEffect(() => {
     if (!pickerOpen && !dictationActive && !dictationTranscribing) {
@@ -225,7 +246,12 @@ export function ComposerPromptSurface({
                   ref={pickerButtonRef}
                   type="button"
                   className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md"
-                  onClick={pickAttachments}
+                  onClick={() => {
+                    if (slashCommands.open) {
+                      slashCommands.dismiss({ clearDraft: true });
+                    }
+                    pickAttachments();
+                  }}
                   aria-label={attachmentButtonLabel}
                   title={attachmentButtonLabel}
                 >
@@ -258,12 +284,13 @@ export function ComposerPromptSurface({
               <div className="min-w-0 flex-1">
                 {slashCommands.open ? (
                   <div
+                    ref={slashCommandPanelRef}
                     id={slashCommands.listboxId}
                     // biome-ignore lint/a11y/useSemanticElements: This is a textarea-owned combobox popup, not a native select.
                     role="listbox"
                     tabIndex={-1}
                     aria-label="Composer slash commands"
-                    className="absolute right-3 bottom-[calc(100%-0.25rem)] left-12 z-20 max-h-64 overflow-auto rounded-xl border border-[rgba(169,178,215,0.12)] bg-[#202332] p-1.5 shadow-[0_16px_48px_rgba(0,0,0,0.38)]"
+                    className="absolute right-0 bottom-full left-0 z-20 max-h-64 overflow-auto rounded-xl border border-[rgba(169,178,215,0.12)] bg-[#202332] p-1.5 shadow-[0_16px_48px_rgba(0,0,0,0.38)]"
                   >
                     {slashCommands.commands.length > 0 ? (
                       slashCommands.commands.map((command, index) => {

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -16,7 +16,7 @@ import {
 import { useComposerController } from "./useComposerController";
 import {
   getComposerSlashCommandOptionId,
-  slashCommandSourceLabels,
+  getComposerSlashCommandGroupLabel,
   useComposerSlashCommands,
 } from "./useComposerSlashCommands";
 
@@ -146,6 +146,37 @@ export function ComposerPromptSurface({
       window.removeEventListener("pointerdown", handlePointerDown, true);
     };
   }, [slashCommands]);
+
+  useEffect(() => {
+    if (!slashCommands.open || !slashCommands.activeDescendantId) {
+      return;
+    }
+
+    const panel = slashCommandPanelRef.current;
+    const option = panel?.querySelector<HTMLElement>(`#${slashCommands.activeDescendantId}`);
+    if (!panel || !option) {
+      return;
+    }
+
+    if (slashCommands.selectedIndex === 0) {
+      panel.scrollTop = 0;
+      return;
+    }
+
+    const panelStyles = window.getComputedStyle(panel);
+    const paddingTop = Number.parseFloat(panelStyles.paddingTop) || 0;
+    const paddingBottom = Number.parseFloat(panelStyles.paddingBottom) || 0;
+    const visibleTop = panel.scrollTop + paddingTop;
+    const visibleBottom = panel.scrollTop + panel.clientHeight - paddingBottom;
+    const optionTop = option.offsetTop;
+    const optionBottom = optionTop + option.offsetHeight;
+
+    if (optionTop < visibleTop) {
+      panel.scrollTop = optionTop - paddingTop;
+    } else if (optionBottom > visibleBottom) {
+      panel.scrollTop = optionBottom - panel.clientHeight + paddingBottom;
+    }
+  }, [slashCommands.open, slashCommands.activeDescendantId, slashCommands.selectedIndex]);
 
   useEffect(() => {
     if (!pickerOpen && !dictationActive && !dictationTranscribing) {
@@ -290,18 +321,22 @@ export function ComposerPromptSurface({
                     role="listbox"
                     tabIndex={-1}
                     aria-label="Composer slash commands"
-                    className="absolute right-0 bottom-full left-0 z-20 max-h-64 overflow-auto rounded-xl border border-[rgba(169,178,215,0.12)] bg-[#202332] p-1.5 shadow-[0_16px_48px_rgba(0,0,0,0.38)]"
+                    className="absolute right-0 bottom-full left-0 z-20 max-h-64 scroll-py-1.5 overflow-auto rounded-xl border border-[rgba(169,178,215,0.12)] bg-[#202332] p-1.5 shadow-[0_16px_48px_rgba(0,0,0,0.38)]"
                   >
                     {slashCommands.commands.length > 0 ? (
                       slashCommands.commands.map((command, index) => {
                         const selected = index === slashCommands.selectedIndex;
                         const previous = slashCommands.commands[index - 1];
-                        const showGroup = previous?.source !== command.source;
+                        const groupLabel = getComposerSlashCommandGroupLabel(command);
+                        const previousGroupLabel = previous
+                          ? getComposerSlashCommandGroupLabel(previous)
+                          : null;
+                        const showGroup = previousGroupLabel !== groupLabel;
                         return (
                           <div key={`${command.source}:${command.name}`}>
                             {showGroup ? (
                               <div className="px-2 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--muted-2)]">
-                                {slashCommandSourceLabels[command.source]}
+                                {groupLabel}
                               </div>
                             ) : null}
                             <button

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -62,10 +62,7 @@ export function useComposerSlashCommands({
       return [];
     }
 
-    return commands.filter((command) => {
-      const haystack = `${command.name} ${command.description ?? ""}`.toLowerCase();
-      return haystack.includes(filter);
-    });
+    return commands.filter((command) => command.name.toLowerCase().includes(filter));
   }, [commands, filter]);
 
   const selectCommand = (command: ComposerSlashCommand) => {
@@ -75,6 +72,10 @@ export function useComposerSlashCommands({
       return;
     }
 
+    setDraft(`/${command.name} `);
+  };
+
+  const completeCommand = (command: ComposerSlashCommand) => {
     setDraft(`/${command.name} `);
   };
 
@@ -101,11 +102,14 @@ export function useComposerSlashCommands({
     send();
   };
 
-  const dismiss = () => {
+  const dismiss = (options?: { clearDraft?: boolean }) => {
     setDismissedDraft(draft);
     setCommands([]);
     setLoading(false);
     setSelectedIndex(0);
+    if (options?.clearDraft) {
+      setDraft("");
+    }
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -130,6 +134,12 @@ export function useComposerSlashCommands({
     if (event.key === "ArrowUp") {
       event.preventDefault();
       setSelectedIndex((current) => Math.max(0, current - 1));
+      return true;
+    }
+
+    if (event.key === "Tab" && !event.shiftKey && filteredCommands[0]) {
+      event.preventDefault();
+      completeCommand(filteredCommands[0]);
       return true;
     }
 
@@ -210,6 +220,7 @@ export function useComposerSlashCommands({
     listboxId: composerSlashCommandListboxId,
     loading,
     open,
+    dismiss,
     selectCommand,
     selectedIndex,
     setSelectedIndex,

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -6,13 +6,25 @@ import {
 import type { ComposerSlashCommand } from "../../../desktop/types";
 import { getComposerSlashCommandsQuery } from "../../../query/desktop-query";
 
-export const slashCommandSourceLabels: Record<ComposerSlashCommand["source"], string> = {
-  app: "App",
-  builtin: "Pi",
+const slashCommandSourceOrder: Record<ComposerSlashCommand["source"], number> = {
+  prompt: 0,
+  app: 1,
+  builtin: 1,
+  skill: 2,
+  extension: 3,
+};
+
+const slashCommandSourceLabels: Record<ComposerSlashCommand["source"], string> = {
+  app: "System",
+  builtin: "System",
   extension: "Extensions",
   prompt: "Prompts",
   skill: "Skills",
 };
+
+export function getComposerSlashCommandGroupLabel(command: ComposerSlashCommand) {
+  return slashCommandSourceLabels[command.source];
+}
 
 export const composerSlashCommandListboxId = "composer-slash-command-listbox";
 
@@ -62,7 +74,17 @@ export function useComposerSlashCommands({
       return [];
     }
 
-    return commands.filter((command) => command.name.toLowerCase().includes(filter));
+    return commands
+      .filter((command) => command.name.toLowerCase().includes(filter))
+      .sort((left, right) => {
+        const sourceOrder =
+          slashCommandSourceOrder[left.source] - slashCommandSourceOrder[right.source];
+        if (sourceOrder !== 0) {
+          return sourceOrder;
+        }
+
+        return left.name.localeCompare(right.name);
+      });
   }, [commands, filter]);
 
   const selectCommand = (command: ComposerSlashCommand) => {

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -159,9 +159,9 @@ export function useComposerSlashCommands({
       return true;
     }
 
-    if (event.key === "Tab" && !event.shiftKey && filteredCommands[0]) {
+    if (event.key === "Tab" && !event.shiftKey && filteredCommands[selectedIndex]) {
       event.preventDefault();
-      completeCommand(filteredCommands[0]);
+      completeCommand(filteredCommands[selectedIndex]);
       return true;
     }
 


### PR DESCRIPTION
## Summary
- Center the small-window overlay reliably in the viewport.
- Align the slash-command popover to the full composer width and dismiss/clear it when clicking away or opening attachments.
- Improve slash-command UX: name-only filtering, Tab completion, grouped ordering, and keyboard scroll tracking.

## Validation
- Pre-commit passed: Biome, typechecks, and Vitest.
- Push hook passed: lint and typecheck.
