### PR TITLE
Polish inbox composer

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -156,6 +156,13 @@ jobs:
                 continue;
               }
 
+              if (!artifact.name.startsWith("dev-")) {
+                core.info(
+                  `Skipping unrelated artifact ${artifact.name} (${artifact.id}) from dev run ${workflowRun.id}`,
+                );
+                continue;
+              }
+
               core.info(
                 `Deleting artifact ${artifact.name} (${artifact.id}) from dev run ${workflowRun.id}`,
               );

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ artifacts/
 .DS_Store
 *.log
 coverage/
+
+.pi/semantic-grep.sqlite

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -1,5 +1,6 @@
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
+const crypto = require("node:crypto");
 const os = require("node:os");
 const path = require("node:path");
 const { spawn, spawnSync } = require("node:child_process");
@@ -126,6 +127,12 @@ async function downloadFile(url, filePath, timeoutMs = DOWNLOAD_TIMEOUT_MS) {
   }
 }
 
+async function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  await pipeline(fs.createReadStream(filePath), hash);
+  return hash.digest("hex");
+}
+
 async function resolveLatestRelease(target) {
   const updateUrl = `${RELEASE_BASE_URL}/stable-${target.os}-${target.arch}-update.json`;
   const metadata = await fetchJson(updateUrl);
@@ -152,6 +159,15 @@ async function installRelease(target, releaseInfo, paths) {
   await fsp.mkdir(tempRoot, { recursive: true });
   await fsp.mkdir(path.dirname(paths.installDir), { recursive: true });
   await downloadFile(releaseInfo.assetUrl, archivePath);
+
+  const archiveHash = await sha256File(archivePath);
+  if (archiveHash !== releaseInfo.hash) {
+    await fsp.rm(archivePath, { force: true });
+    throw new Error(
+      `Downloaded archive hash mismatch. Expected ${releaseInfo.hash}, got ${archiveHash}.`,
+    );
+  }
+
   await fsp.mkdir(tempInstallDir, { recursive: true });
 
   const extract = spawnSync("tar", ["-xzf", archivePath, "-C", tempInstallDir], {

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -162,7 +162,7 @@ async function installRelease(target, releaseInfo, paths) {
 
   const archiveHash = await sha256File(archivePath);
   if (archiveHash !== releaseInfo.hash) {
-    await fsp.rm(archivePath, { force: true });
+    await fsp.rm(tempRoot, { recursive: true, force: true });
     throw new Error(
       `Downloaded archive hash mismatch. Expected ${releaseInfo.hash}, got ${archiveHash}.`,
     );

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -104,6 +104,7 @@ export function useAppShellController() {
     projects,
     collapsedProjectIds,
     workspaceState: state,
+    selectedInboxThread,
     composerProjectId,
     shellComposerState: shellState?.composer,
     shellAppSettings: shellState?.appSettings,

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -6,6 +6,7 @@ import type {
   ArchivedThread,
   ComposerState,
   DesktopEvent,
+  InboxThread,
   ProjectGitState,
   ThreadData,
 } from "../desktop/types";
@@ -57,6 +58,7 @@ export function useAppShellEffects({
   projects,
   collapsedProjectIds,
   workspaceState,
+  selectedInboxThread,
   composerProjectId,
   shellComposerState,
   shellAppSettings,
@@ -76,6 +78,7 @@ export function useAppShellEffects({
   projects: Project[];
   collapsedProjectIds: Record<string, boolean>;
   workspaceState: WorkspaceState;
+  selectedInboxThread: InboxThread | null;
   composerProjectId: string;
   shellComposerState: ComposerState | null | undefined;
   shellAppSettings: AppSettings | null | undefined;
@@ -178,7 +181,12 @@ export function useAppShellEffects({
   ]);
 
   useEffect(() => {
-    if (!composerProjectId) {
+    const composerStateProjectId =
+      workspaceState.activeView === "inbox" && selectedInboxThread
+        ? selectedInboxThread.projectId
+        : composerProjectId;
+
+    if (!composerStateProjectId) {
       return;
     }
 
@@ -186,11 +194,13 @@ export function useAppShellEffects({
 
     const syncComposerState = async () => {
       const nextComposerState = await loadComposerState({
-        projectId: composerProjectId,
+        projectId: composerStateProjectId,
         sessionPath:
           workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
             ? workspaceState.selectedSessionPath
-            : null,
+            : workspaceState.activeView === "inbox"
+              ? workspaceState.selectedInboxSessionPath
+              : null,
       });
 
       if (!cancelled && nextComposerState) {
@@ -204,10 +214,12 @@ export function useAppShellEffects({
       cancelled = true;
     };
   }, [
-    composerProjectId,
     loadComposerState,
+    composerProjectId,
+    selectedInboxThread,
     setComposerState,
     workspaceState.activeView,
+    workspaceState.selectedInboxSessionPath,
     workspaceState.selectedSessionPath,
   ]);
 

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -181,10 +181,16 @@ export function useAppShellEffects({
   ]);
 
   useEffect(() => {
+    const inboxProjectId = selectedInboxThread?.projectId ?? null;
+    const inboxSessionPath = selectedInboxThread?.sessionPath ?? null;
     const composerStateProjectId =
-      workspaceState.activeView === "inbox" && selectedInboxThread
-        ? selectedInboxThread.projectId
-        : composerProjectId;
+      workspaceState.activeView === "inbox" ? inboxProjectId : composerProjectId;
+    const composerStateSessionPath =
+      workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
+        ? workspaceState.selectedSessionPath
+        : workspaceState.activeView === "inbox"
+          ? inboxSessionPath
+          : null;
 
     if (!composerStateProjectId) {
       return;
@@ -195,12 +201,7 @@ export function useAppShellEffects({
     const syncComposerState = async () => {
       const nextComposerState = await loadComposerState({
         projectId: composerStateProjectId,
-        sessionPath:
-          workspaceState.activeView === "thread" || workspaceState.activeView === "gitops"
-            ? workspaceState.selectedSessionPath
-            : workspaceState.activeView === "inbox"
-              ? workspaceState.selectedInboxSessionPath
-              : null,
+        sessionPath: composerStateSessionPath,
       });
 
       if (!cancelled && nextComposerState) {
@@ -216,10 +217,10 @@ export function useAppShellEffects({
   }, [
     loadComposerState,
     composerProjectId,
-    selectedInboxThread,
+    selectedInboxThread?.projectId,
+    selectedInboxThread?.sessionPath,
     setComposerState,
     workspaceState.activeView,
-    workspaceState.selectedInboxSessionPath,
     workspaceState.selectedSessionPath,
   ]);
 

--- a/src/app/components/sidebar/Sidebar.tsx
+++ b/src/app/components/sidebar/Sidebar.tsx
@@ -6,7 +6,6 @@ import { useDismissibleLayer } from "../../hooks/useDismissibleLayer";
 import type { Project, View } from "../../types";
 
 type SidebarNavigableView = Exclude<View, "gitops">;
-import { FeatureStatusBadge } from "../common/FeatureStatusBadge";
 import { NavButton } from "../common/NavButton";
 import { SettingsMenu } from "./SettingsMenu";
 import { SidebarInboxSection } from "./inbox/SidebarInboxSection";
@@ -113,12 +112,7 @@ export function Sidebar({
         <nav className="sidebar-mode-nav" aria-label="Primary navigation">
           <NavButton
             icon={<Inbox size={16} />}
-            label={
-              <span className="sidebar-feature-label">
-                <span>Inbox</span>
-                <FeatureStatusBadge statusId="feature:sidebar.inbox" />
-              </span>
-            }
+            label="Inbox"
             active={activeView === "inbox"}
             onClick={() => onShowView("inbox")}
           />

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -1,5 +1,7 @@
 import { ArrowUpRight, Bot, Paperclip, Send, Square, X } from "lucide-react";
 import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
+import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
+import { getErrorMessage } from "../../../desktop/error-messages";
 import type {
   AppSettings,
   ComposerAttachment,
@@ -66,7 +68,7 @@ type InboxComposerProps = {
   }) => Promise<ComposerFilePickerState | null>;
   onOpenThread: () => void;
   onOpenSettingsView: () => void;
-  onSend: () => void;
+  onSend: (input: { draft: string; attachments: ComposerAttachment[] }) => Promise<void> | void;
   onStop: () => void;
 };
 
@@ -103,7 +105,42 @@ export function InboxComposer({
   const pickerPanelRef = useRef<HTMLDivElement>(null);
   const modelButtonRef = useRef<HTMLButtonElement>(null);
   const modelMenuRef = useRef<HTMLDivElement>(null);
-  const canSend = (draft.trim().length > 0 || attachments.length > 0) && !isSending;
+  const slashCommandPanelRef = useRef<HTMLDivElement>(null);
+  const draftValueRef = useRef(draft);
+  const attachmentsRef = useRef(attachments);
+  const sendLockRef = useRef(false);
+  const [localActionPending, setLocalActionPending] = useState(false);
+  const canSend =
+    (draft.trim().length > 0 || attachments.length > 0) &&
+    !isSending &&
+    !isCompacting &&
+    !localActionPending;
+
+  useEffect(() => {
+    draftValueRef.current = draft;
+  }, [draft]);
+
+  useEffect(() => {
+    attachmentsRef.current = attachments;
+  }, [attachments]);
+
+  const setDraftValue: Dispatch<SetStateAction<string>> = (value) => {
+    const nextValue =
+      typeof value === "function"
+        ? (value as (current: string) => string)(draftValueRef.current)
+        : value;
+    draftValueRef.current = nextValue;
+    onChangeDraft(nextValue);
+  };
+
+  const setAttachmentValue: Dispatch<SetStateAction<ComposerAttachment[]>> = (value) => {
+    const nextValue =
+      typeof value === "function"
+        ? (value as (current: ComposerAttachment[]) => ComposerAttachment[])(attachmentsRef.current)
+        : value;
+    attachmentsRef.current = nextValue;
+    onChangeAttachments(nextValue);
+  };
 
   useDismissibleLayer({
     open: openMenu === "model",
@@ -166,7 +203,7 @@ export function InboxComposer({
     openMenu,
     pickerRootPath: thread.projectId,
     pickerSessionKey: thread.sessionPath,
-    setAttachments: onChangeAttachments,
+    setAttachments: setAttachmentValue,
     setErrorMessage: onChangeErrorMessage,
     setOpenMenu,
     onListAttachmentEntries,
@@ -187,37 +224,145 @@ export function InboxComposer({
     draftThreadId: thread.threadId,
     projectId: thread.projectId,
     sessionPath: thread.sessionPath,
-    setDraftValue: onChangeDraft,
+    setDraftValue,
     setErrorMessage: onChangeErrorMessage,
   });
 
   const send = async () => {
-    await stopDictationAndFlush();
-    onSend();
+    if (sendLockRef.current || isSending || isCompacting || localActionPending) {
+      return;
+    }
+
+    sendLockRef.current = true;
+    setLocalActionPending(true);
+    try {
+      await stopDictationAndFlush();
+      await onSend({ draft: draftValueRef.current, attachments: attachmentsRef.current });
+    } finally {
+      sendLockRef.current = false;
+      setLocalActionPending(false);
+    }
   };
 
   const slashCommands = useComposerSlashCommands({
     draft,
     projectId: thread.projectId,
     sessionPath: thread.sessionPath,
-    setDraft: onChangeDraft,
+    setDraft: setDraftValue,
     send: () => void send(),
     onOpenSettingsView,
   });
 
-  const compact = async () => {
-    if (isSending || isStreaming || isCompacting || !thread.sessionPath) {
+  const slashCommandListSignature = slashCommands.commands
+    .map((command) => `${command.source}:${command.name}`)
+    .join("|");
+
+  useEffect(() => {
+    if (!slashCommands.open) {
       return;
     }
 
-    await stopDictationAndFlush();
-    await onAction("composer.send", {
-      projectId: thread.projectId,
-      sessionPath: thread.sessionPath,
-      text: "/compact",
-      attachments: [],
-      streamingBehavior: appSettings.composerStreamingBehavior,
-    });
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+
+      if (!target) {
+        return;
+      }
+
+      if (
+        slashCommandPanelRef.current?.contains(target) ||
+        composerPanelRef.current?.contains(target)
+      ) {
+        return;
+      }
+
+      slashCommands.dismiss();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      slashCommands.dismiss();
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [slashCommands]);
+
+  useEffect(() => {
+    if (!slashCommands.open || !slashCommands.activeDescendantId) {
+      return;
+    }
+
+    void slashCommandListSignature;
+
+    const panel = slashCommandPanelRef.current;
+    const option = panel?.querySelector<HTMLElement>(`#${slashCommands.activeDescendantId}`);
+    if (!panel || !option) {
+      return;
+    }
+
+    if (slashCommands.selectedIndex === 0) {
+      panel.scrollTop = 0;
+      return;
+    }
+
+    const panelStyles = window.getComputedStyle(panel);
+    const paddingTop = Number.parseFloat(panelStyles.paddingTop) || 0;
+    const paddingBottom = Number.parseFloat(panelStyles.paddingBottom) || 0;
+    const visibleTop = panel.scrollTop + paddingTop;
+    const visibleBottom = panel.scrollTop + panel.clientHeight - paddingBottom;
+    const optionTop = option.offsetTop;
+    const optionBottom = optionTop + option.offsetHeight;
+
+    if (optionTop < visibleTop) {
+      panel.scrollTop = optionTop - paddingTop;
+    } else if (optionBottom > visibleBottom) {
+      panel.scrollTop = optionBottom - panel.clientHeight + paddingBottom;
+    }
+  }, [
+    slashCommands.open,
+    slashCommands.activeDescendantId,
+    slashCommands.selectedIndex,
+    slashCommandListSignature,
+  ]);
+
+  const compact = async () => {
+    if (sendLockRef.current || isSending || isStreaming || isCompacting || !thread.sessionPath) {
+      return;
+    }
+
+    sendLockRef.current = true;
+    setLocalActionPending(true);
+    onChangeErrorMessage(null);
+    try {
+      await stopDictationAndFlush();
+      const result = await onAction("composer.send", {
+        projectId: thread.projectId,
+        sessionPath: thread.sessionPath,
+        text: "/compact",
+        attachments: [],
+        streamingBehavior: appSettings.composerStreamingBehavior,
+      });
+
+      const actionErrorMessage = getDesktopActionErrorMessage(result, "Could not compact context.");
+      if (actionErrorMessage) {
+        onChangeErrorMessage(actionErrorMessage);
+      }
+    } catch (error) {
+      onChangeErrorMessage(getErrorMessage(error, "Could not compact context."));
+    } finally {
+      sendLockRef.current = false;
+      setLocalActionPending(false);
+    }
   };
 
   return (
@@ -279,6 +424,7 @@ export function InboxComposer({
               <div className="min-w-0 flex-1">
                 {slashCommands.open ? (
                   <div
+                    ref={slashCommandPanelRef}
                     id={slashCommands.listboxId}
                     // biome-ignore lint/a11y/useSemanticElements: This is a textarea-owned combobox popup, not a native select.
                     role="listbox"
@@ -338,7 +484,7 @@ export function InboxComposer({
                 ) : null}
                 <ComposerTextField
                   value={draft}
-                  onChange={onChangeDraft}
+                  onChange={setDraftValue}
                   onKeyDown={(event) => {
                     if (slashCommands.handleKeyDown(event)) {
                       return;
@@ -385,7 +531,7 @@ export function InboxComposer({
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
                 onClick={onStop}
-                disabled={!isStreaming || isSending}
+                disabled={!isStreaming || isSending || localActionPending}
                 aria-label="Stop Pi"
                 title="Stop Pi"
               >
@@ -432,7 +578,9 @@ export function InboxComposer({
           <div className="absolute top-0 right-0">
             <ComposerContextMeter
               contextUsage={contextUsage}
-              compactDisabled={isStreaming || isCompacting || !thread.sessionPath}
+              compactDisabled={
+                isStreaming || isCompacting || localActionPending || !thread.sessionPath
+              }
               isCompacting={isCompacting}
               onCompact={() => void compact()}
             />

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -1,63 +1,383 @@
-import { ArrowUpRight, Send, Square, X } from "lucide-react";
+import { ArrowUpRight, Bot, Paperclip, Send, Square, X } from "lucide-react";
+import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
+import type {
+  AppSettings,
+  ComposerAttachment,
+  ComposerContextUsage,
+  ComposerFilePickerState,
+  ComposerModel,
+  ComposerThinkingLevel,
+  DesktopActionInvoker,
+  InboxThread,
+} from "../../../desktop/types";
+import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
 import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { IconButton } from "../../common/IconButton";
-import { SurfacePanel } from "../../common/SurfacePanel";
+import { ToolbarButton } from "../../common/ToolbarButton";
 import { Tooltip } from "../../common/Tooltip";
+import { ComposerContextMeter } from "../composer/ComposerContextMeter";
+import { ComposerDictationControls } from "../composer/ComposerDictationControls";
+import { ComposerFilePicker } from "../composer/ComposerFilePicker";
+import { ComposerModelPopover } from "../composer/ComposerModelPopover";
 import { ComposerTextField } from "../composer/ComposerTextField";
+import {
+  getComposerSlashCommandGroupLabel,
+  getComposerSlashCommandOptionId,
+  useComposerSlashCommands,
+} from "../composer/useComposerSlashCommands";
+import { useComposerAttachmentPicker } from "../composer/useComposerAttachmentPicker";
+import { useComposerDictation } from "../composer/useComposerDictation";
+
+const thinkingLevelLabels: Record<ComposerThinkingLevel, string> = {
+  off: "Off",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "X-High",
+};
 
 type InboxComposerProps = {
+  appSettings: AppSettings;
+  attachments: ComposerAttachment[];
+  availableModels: ComposerModel[];
+  availableThinkingLevels: ComposerThinkingLevel[];
+  contextUsage: ComposerContextUsage | null;
+  currentModel: ComposerModel | null;
+  currentThinkingLevel: ComposerThinkingLevel;
   draft: string;
   errorMessage: string | null;
+  favoriteFolders: string[];
+  isCompacting: boolean;
   isStreaming: boolean;
   isSending: boolean;
-  onChangeDraft: (value: string) => void;
+  showDictationButton: boolean;
+  thread: InboxThread;
+  onAction: DesktopActionInvoker;
+  onChangeAttachments: Dispatch<SetStateAction<ComposerAttachment[]>>;
+  onChangeDraft: Dispatch<SetStateAction<string>>;
+  onChangeErrorMessage: Dispatch<SetStateAction<string | null>>;
   onDismiss: () => void;
+  onListAttachmentEntries: (request: {
+    projectId?: string | null;
+    path?: string | null;
+    rootPath?: string | null;
+  }) => Promise<ComposerFilePickerState | null>;
   onOpenThread: () => void;
+  onOpenSettingsView: () => void;
   onSend: () => void;
   onStop: () => void;
 };
 
 export function InboxComposer({
+  appSettings,
+  attachments,
+  availableModels,
+  availableThinkingLevels,
+  contextUsage,
+  currentModel,
+  currentThinkingLevel,
   draft,
   errorMessage,
+  favoriteFolders,
+  isCompacting,
   isStreaming,
   isSending,
+  showDictationButton,
+  thread,
+  onAction,
+  onChangeAttachments,
   onChangeDraft,
+  onChangeErrorMessage,
   onDismiss,
+  onListAttachmentEntries,
   onOpenThread,
+  onOpenSettingsView,
   onSend,
   onStop,
 }: InboxComposerProps) {
-  const canSend = draft.trim().length > 0 && !isSending;
+  const [openMenu, setOpenMenu] = useState<"model" | "picker" | null>(null);
+  const composerPanelRef = useRef<HTMLDivElement>(null);
+  const pickerButtonRef = useRef<HTMLButtonElement>(null);
+  const pickerPanelRef = useRef<HTMLDivElement>(null);
+  const modelButtonRef = useRef<HTMLButtonElement>(null);
+  const modelMenuRef = useRef<HTMLDivElement>(null);
+  const canSend = (draft.trim().length > 0 || attachments.length > 0) && !isSending;
+
+  useDismissibleLayer({
+    open: openMenu === "model",
+    onDismiss: () => setOpenMenu(null),
+    refs: [modelButtonRef, modelMenuRef],
+  });
+
+  useEffect(() => {
+    if (openMenu !== "picker") {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+
+      if (!target) {
+        return;
+      }
+
+      if (pickerButtonRef.current?.contains(target) || pickerPanelRef.current?.contains(target)) {
+        return;
+      }
+
+      if (composerPanelRef.current?.contains(target)) {
+        return;
+      }
+
+      setOpenMenu((current) => (current === "picker" ? null : current));
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      setOpenMenu((current) => (current === "picker" ? null : current));
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [openMenu]);
+
+  const {
+    attachPickerAttachments,
+    clearAttachments,
+    openPickerDirectory,
+    openPickerRoot,
+    pickAttachments,
+    pickerLoading,
+    pickerState,
+    removeAttachment,
+    togglePendingPickerAttachment,
+  } = useComposerAttachmentPicker({
+    openMenu,
+    pickerRootPath: thread.projectId,
+    pickerSessionKey: thread.sessionPath,
+    setAttachments: onChangeAttachments,
+    setErrorMessage: onChangeErrorMessage,
+    setOpenMenu,
+    onListAttachmentEntries,
+  });
+
+  const {
+    cancelDictation,
+    dictationActive,
+    dictationInterimText,
+    dictationMissingModel,
+    dictationSupported,
+    stopDictationAndFlush,
+    toggleDictation,
+  } = useComposerDictation({
+    activeView: "inbox",
+    dictationModelId: appSettings.dictationModelId,
+    dictationMaxDurationSeconds: appSettings.dictationMaxDurationSeconds,
+    draftThreadId: thread.threadId,
+    projectId: thread.projectId,
+    sessionPath: thread.sessionPath,
+    setDraftValue: onChangeDraft,
+    setErrorMessage: onChangeErrorMessage,
+  });
+
+  const send = async () => {
+    await stopDictationAndFlush();
+    onSend();
+  };
+
+  const slashCommands = useComposerSlashCommands({
+    draft,
+    projectId: thread.projectId,
+    sessionPath: thread.sessionPath,
+    setDraft: onChangeDraft,
+    send: () => void send(),
+    onOpenSettingsView,
+  });
+
+  const compact = async () => {
+    if (isSending || isStreaming || isCompacting || !thread.sessionPath) {
+      return;
+    }
+
+    await stopDictationAndFlush();
+    await onAction("composer.send", {
+      projectId: thread.projectId,
+      sessionPath: thread.sessionPath,
+      text: "/compact",
+      attachments: [],
+      streamingBehavior: appSettings.composerStreamingBehavior,
+    });
+  };
 
   return (
-    <SurfacePanel
-      className="grid gap-0 overflow-visible border-[rgba(169,178,215,0.06)] bg-[rgba(39,42,57,0.94)] shadow-none"
+    <div
+      ref={composerPanelRef}
+      className="grid gap-0 overflow-visible rounded-[20px] border border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
       aria-label="Inbox composer panel"
     >
-      <div className="relative min-h-[148px]">
-        <div className="grid min-h-[148px] content-end px-4 pt-[24px] pb-3">
-          <div className="flex min-h-[82px] items-end justify-between gap-2">
-            <div className="min-w-0 flex-1">
-              <ComposerTextField
-                value={draft}
-                onChange={onChangeDraft}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" && !event.shiftKey) {
-                    event.preventDefault();
-                    onSend();
-                  }
-                }}
-                ariaLabel="Inbox prompt composer"
-                placeholder={errorMessage ?? "Reply to this thread…"}
-                placeholderTone={errorMessage ? "error" : "muted"}
-                statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
-                reservedLineCount={1}
-              />
+      <div className="relative">
+        {openMenu === "picker" ? (
+          <ComposerFilePicker
+            attachments={attachments}
+            errorMessage={errorMessage}
+            favoriteFolders={favoriteFolders}
+            loading={pickerLoading}
+            picker={pickerState}
+            panelRef={pickerPanelRef}
+            projectRootPath={thread.projectId}
+            onAttachAttachments={attachPickerAttachments}
+            onOpenRoot={openPickerRoot}
+            onOpenDirectory={openPickerDirectory}
+            onRemoveAttachment={removeAttachment}
+            onToggleFile={togglePendingPickerAttachment}
+          />
+        ) : null}
+        <div className="grid content-end px-4 py-3">
+          <div className="flex items-end justify-between gap-2">
+            <div className="flex min-w-0 flex-1 items-end gap-2">
+              <div className="inline-flex h-6 shrink-0 items-center gap-1.5">
+                <button
+                  ref={pickerButtonRef}
+                  type="button"
+                  className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md"
+                  onClick={pickAttachments}
+                  aria-label={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
+                  title={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
+                >
+                  <span className={cn(compactIconButtonClass, "shrink-0")}>
+                    <Paperclip size={16} />
+                  </span>
+                  {attachments.length > 0 ? (
+                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
+                      {attachments.length}
+                    </span>
+                  ) : null}
+                </button>
+                {attachments.length > 0 ? (
+                  <button
+                    type="button"
+                    className={cn(compactIconButtonClass, "h-5 w-5 shrink-0")}
+                    onClick={clearAttachments}
+                    aria-label="Clear attachments"
+                    title="Clear attachments"
+                  >
+                    <X size={12} />
+                  </button>
+                ) : null}
+              </div>
+              <div className="min-w-0 flex-1">
+                {slashCommands.open ? (
+                  <div
+                    id={slashCommands.listboxId}
+                    // biome-ignore lint/a11y/useSemanticElements: This is a textarea-owned combobox popup, not a native select.
+                    role="listbox"
+                    tabIndex={-1}
+                    aria-label="Composer slash commands"
+                    className="absolute right-0 bottom-full left-0 z-20 max-h-64 scroll-py-1.5 overflow-auto rounded-xl border border-[rgba(169,178,215,0.12)] bg-[#202332] p-1.5 shadow-[0_16px_48px_rgba(0,0,0,0.38)]"
+                  >
+                    {slashCommands.commands.length > 0 ? (
+                      slashCommands.commands.map((command, index) => {
+                        const selected = index === slashCommands.selectedIndex;
+                        const previous = slashCommands.commands[index - 1];
+                        const groupLabel = getComposerSlashCommandGroupLabel(command);
+                        const previousGroupLabel = previous
+                          ? getComposerSlashCommandGroupLabel(previous)
+                          : null;
+                        return (
+                          <div key={`${command.source}:${command.name}`}>
+                            {previousGroupLabel !== groupLabel ? (
+                              <div className="px-2 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--muted-2)]">
+                                {groupLabel}
+                              </div>
+                            ) : null}
+                            <button
+                              id={getComposerSlashCommandOptionId(index)}
+                              type="button"
+                              // biome-ignore lint/a11y/useSemanticElements: Command options remain clickable buttons inside the textarea-owned listbox.
+                              role="option"
+                              aria-selected={selected}
+                              className={cn(
+                                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left",
+                                selected
+                                  ? "bg-[rgba(169,178,215,0.14)] text-[color:var(--text)]"
+                                  : "text-[color:var(--muted)] hover:bg-[rgba(169,178,215,0.08)] hover:text-[color:var(--text)]",
+                              )}
+                              onPointerEnter={() => slashCommands.setSelectedIndex(index)}
+                              onMouseDown={(event) => event.preventDefault()}
+                              onClick={() => slashCommands.selectCommand(command)}
+                            >
+                              <span className="shrink-0 font-mono text-[12px] text-[color:var(--text)]">
+                                /{command.name}
+                              </span>
+                              {command.description ? (
+                                <span className="min-w-0 truncate text-[12px]">
+                                  {command.description}
+                                </span>
+                              ) : null}
+                            </button>
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <div className="px-2 py-2 text-[12px] text-[color:var(--muted)]">
+                        {slashCommands.loading ? "Loading commands…" : "No matching commands"}
+                      </div>
+                    )}
+                  </div>
+                ) : null}
+                <ComposerTextField
+                  value={draft}
+                  onChange={onChangeDraft}
+                  onKeyDown={(event) => {
+                    if (slashCommands.handleKeyDown(event)) {
+                      return;
+                    }
+
+                    if (event.key === "Escape" && (dictationActive || dictationInterimText)) {
+                      event.preventDefault();
+                      void cancelDictation();
+                      return;
+                    }
+
+                    if (event.key === "Enter" && !event.shiftKey) {
+                      event.preventDefault();
+                      slashCommands.submit();
+                    }
+                  }}
+                  ariaLabel="Inbox prompt composer"
+                  ariaActiveDescendant={slashCommands.activeDescendantId}
+                  ariaControls={slashCommands.open ? slashCommands.listboxId : undefined}
+                  ariaExpanded={slashCommands.open}
+                  placeholder={errorMessage ?? "Reply to this thread…"}
+                  placeholderTone={errorMessage ? "error" : "muted"}
+                  statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
+                  reservedLineCount={1}
+                />
+              </div>
             </div>
 
             <div className="inline-flex h-8 items-center justify-end gap-2">
+              <ComposerDictationControls
+                dictationActive={dictationActive}
+                dictationMissingModel={dictationMissingModel}
+                dictationSupported={dictationSupported}
+                dictationTranscribing={dictationInterimText.length > 0 && !dictationActive}
+                onAction={onAction}
+                onOpenSettingsView={onOpenSettingsView}
+                showDictationButton={showDictationButton}
+                toggleDictation={toggleDictation}
+              />
               <button
                 type="button"
                 className={cn(
@@ -77,7 +397,7 @@ export function InboxComposer({
                   compactIconButtonClass,
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
-                onClick={onSend}
+                onClick={() => slashCommands.submit()}
                 disabled={!canSend}
                 aria-label="Send"
                 title="Send"
@@ -98,6 +418,53 @@ export function InboxComposer({
       <div className="h-px bg-[rgba(169,178,215,0.07)]" />
 
       <div className="flex items-center justify-end gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+        <div className="relative mr-auto inline-flex h-7 items-center">
+          <ToolbarButton
+            ref={modelButtonRef}
+            label="Agent"
+            icon={<Bot size={14} />}
+            className="pr-8"
+            onClick={() => setOpenMenu((current) => (current === "model" ? null : "model"))}
+            aria-haspopup="menu"
+            aria-expanded={openMenu === "model"}
+            aria-controls="composer-model-menu"
+          />
+          <div className="absolute top-0 right-0">
+            <ComposerContextMeter
+              contextUsage={contextUsage}
+              compactDisabled={isStreaming || isCompacting || !thread.sessionPath}
+              isCompacting={isCompacting}
+              onCompact={() => void compact()}
+            />
+          </div>
+          {openMenu === "model" ? (
+            <ComposerModelPopover
+              availableModels={availableModels}
+              availableThinkingLevels={availableThinkingLevels}
+              currentModel={currentModel}
+              currentThinkingLevel={currentThinkingLevel}
+              panelRef={modelMenuRef}
+              thinkingLevelLabels={thinkingLevelLabels}
+              onSelectModel={(availableModel) => {
+                void onAction("composer.model", {
+                  provider: availableModel.provider,
+                  modelId: availableModel.id,
+                  projectId: thread.projectId,
+                  sessionPath: thread.sessionPath,
+                });
+                setOpenMenu(null);
+              }}
+              onSelectThinkingLevel={(level) => {
+                void onAction("composer.thinking", {
+                  level,
+                  projectId: thread.projectId,
+                  sessionPath: thread.sessionPath,
+                });
+                setOpenMenu(null);
+              }}
+            />
+          ) : null}
+        </div>
         <Tooltip content="Dismiss">
           <IconButton label="Dismiss" icon={<X size={14} />} onClick={onDismiss} />
         </Tooltip>
@@ -109,6 +476,6 @@ export function InboxComposer({
           />
         </Tooltip>
       </div>
-    </SurfacePanel>
+    </div>
   );
 }

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -365,6 +365,29 @@ export function InboxComposer({
     }
   };
 
+  const updateComposerOption = async (
+    action: "composer.model" | "composer.thinking",
+    payload: NonNullable<Parameters<DesktopActionInvoker>[1]>,
+  ) => {
+    onChangeErrorMessage(null);
+
+    try {
+      const result = await onAction(action, payload);
+      const actionErrorMessage = getDesktopActionErrorMessage(
+        result,
+        "Could not update the composer.",
+      );
+      if (actionErrorMessage) {
+        onChangeErrorMessage(actionErrorMessage);
+        return;
+      }
+
+      setOpenMenu(null);
+    } catch (error) {
+      onChangeErrorMessage(getErrorMessage(error, "Could not update the composer."));
+    }
+  };
+
   return (
     <div
       ref={composerPanelRef}
@@ -396,7 +419,12 @@ export function InboxComposer({
                   ref={pickerButtonRef}
                   type="button"
                   className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md"
-                  onClick={pickAttachments}
+                  onClick={() => {
+                    if (slashCommands.open) {
+                      slashCommands.dismiss({ clearDraft: true });
+                    }
+                    void pickAttachments();
+                  }}
                   aria-label={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
                   title={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
                 >
@@ -485,6 +513,11 @@ export function InboxComposer({
                 <ComposerTextField
                   value={draft}
                   onChange={setDraftValue}
+                  onInput={() => {
+                    if (errorMessage) {
+                      onChangeErrorMessage(null);
+                    }
+                  }}
                   onKeyDown={(event) => {
                     if (slashCommands.handleKeyDown(event)) {
                       return;
@@ -594,21 +627,19 @@ export function InboxComposer({
               panelRef={modelMenuRef}
               thinkingLevelLabels={thinkingLevelLabels}
               onSelectModel={(availableModel) => {
-                void onAction("composer.model", {
+                void updateComposerOption("composer.model", {
                   provider: availableModel.provider,
                   modelId: availableModel.id,
                   projectId: thread.projectId,
                   sessionPath: thread.sessionPath,
                 });
-                setOpenMenu(null);
               }}
               onSelectThinkingLevel={(level) => {
-                void onAction("composer.thinking", {
+                void updateComposerOption("composer.thinking", {
                   level,
                   projectId: thread.projectId,
                   sessionPath: thread.sessionPath,
                 });
-                setOpenMenu(null);
               }}
             />
           ) : null}

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -258,6 +258,12 @@ export function InboxComposer({
     .join("|");
 
   useEffect(() => {
+    if (slashCommands.open) {
+      setOpenMenu((current) => (current === "picker" ? null : current));
+    }
+  }, [slashCommands.open]);
+
+  useEffect(() => {
     if (!slashCommands.open) {
       return;
     }

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -276,7 +276,7 @@ export function InboxComposer({
         return;
       }
 
-      slashCommands.dismiss();
+      slashCommands.dismiss({ clearDraft: true });
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -3,6 +3,8 @@ import type {
   AppSettings,
   ArchivedThread,
   ComposerModel,
+  ComposerContextUsage,
+  ComposerFilePickerState,
   ComposerThinkingLevel,
   DesktopActionInvoker,
   InboxThread,
@@ -33,7 +35,9 @@ type CodeWorkspaceMainViewProps = {
   archivedThreads: ArchivedThread[];
   availableModels: ComposerModel[];
   availableThinkingLevels: ComposerThinkingLevel[];
+  contextUsage: ComposerContextUsage | null;
   currentModel: ComposerModel | null;
+  currentThinkingLevel: ComposerThinkingLevel;
   currentProjectName: string;
   selectedInboxThread: InboxThread | null;
   projects: Project[];
@@ -43,8 +47,14 @@ type CodeWorkspaceMainViewProps = {
   composerLayoutVersion: number;
   onAction: DesktopActionInvoker;
   onDismissInboxThread: (thread: InboxThread) => void;
+  onListAttachmentEntries: (request: {
+    projectId?: string | null;
+    path?: string | null;
+    rootPath?: string | null;
+  }) => Promise<ComposerFilePickerState | null>;
   onCloseUtilityView: () => void;
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
+  onOpenSettingsView: () => void;
   onLoadEarlierMessages: () => void;
   onSetExtensionsProjectScopeActive: (active: boolean) => void;
   onSetSkillsProjectScopeActive: (active: boolean) => void;
@@ -58,7 +68,9 @@ export function CodeWorkspaceMainView({
   archivedThreads,
   availableModels,
   availableThinkingLevels,
+  contextUsage,
   currentModel,
+  currentThinkingLevel,
   currentProjectName,
   selectedInboxThread,
   projects,
@@ -68,8 +80,10 @@ export function CodeWorkspaceMainView({
   composerLayoutVersion,
   onAction,
   onDismissInboxThread,
+  onListAttachmentEntries,
   onCloseUtilityView,
   onOpenThread,
+  onOpenSettingsView,
   onLoadEarlierMessages,
   onSetExtensionsProjectScopeActive,
   onSetSkillsProjectScopeActive,
@@ -94,10 +108,20 @@ export function CodeWorkspaceMainView({
       <InboxView
         key={selectedInboxThread?.sessionPath ?? "inbox-empty"}
         appSettings={appSettings}
+        availableModels={availableModels}
+        availableThinkingLevels={availableThinkingLevels}
+        contextUsage={contextUsage}
+        currentModel={currentModel}
+        currentThinkingLevel={currentThinkingLevel}
+        favoriteFolders={appSettings.favoriteFolders}
+        isCompacting={threadData?.isCompacting ?? false}
+        showDictationButton={appSettings.showDictationButton}
         thread={selectedInboxThread}
         onAction={onAction}
         onDismissThread={onDismissInboxThread}
+        onListAttachmentEntries={onListAttachmentEntries}
         onOpenThread={onOpenThread}
+        onOpenSettingsView={onOpenSettingsView}
       />
     );
   }

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -38,6 +38,7 @@ type CodeWorkspaceMainViewProps = {
   contextUsage: ComposerContextUsage | null;
   currentModel: ComposerModel | null;
   currentThinkingLevel: ComposerThinkingLevel;
+  isCompacting: boolean;
   currentProjectName: string;
   selectedInboxThread: InboxThread | null;
   projects: Project[];
@@ -71,6 +72,7 @@ export function CodeWorkspaceMainView({
   contextUsage,
   currentModel,
   currentThinkingLevel,
+  isCompacting,
   currentProjectName,
   selectedInboxThread,
   projects,
@@ -114,7 +116,7 @@ export function CodeWorkspaceMainView({
         currentModel={currentModel}
         currentThinkingLevel={currentThinkingLevel}
         favoriteFolders={appSettings.favoriteFolders}
-        isCompacting={threadData?.isCompacting ?? false}
+        isCompacting={isCompacting}
         showDictationButton={appSettings.showDictationButton}
         thread={selectedInboxThread}
         onAction={onAction}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -162,7 +162,9 @@ export function CodeWorkspaceView({
                 archivedThreads={controller.archivedThreads}
                 availableModels={activeComposerState?.availableModels ?? []}
                 availableThinkingLevels={activeComposerState?.availableThinkingLevels ?? ["off"]}
+                contextUsage={activeComposerState?.contextUsage ?? null}
                 currentModel={activeComposerState?.currentModel ?? null}
+                currentThinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
                 currentProjectName={currentProjectName}
                 selectedInboxThread={controller.selectedInboxThread}
                 projects={controller.projects}
@@ -172,7 +174,9 @@ export function CodeWorkspaceView({
                 composerLayoutVersion={composerLayoutVersion}
                 onAction={handleAction}
                 onDismissInboxThread={controller.handleDismissInboxThread}
+                onListAttachmentEntries={listComposerAttachmentEntries}
                 onOpenThread={controller.handleThreadOpen}
+                onOpenSettingsView={() => controller.handleShowView("settings")}
                 onCloseUtilityView={controller.handleCloseUtilityView}
                 onLoadEarlierMessages={handleLoadEarlierMessages}
                 onSetExtensionsProjectScopeActive={controller.handleSetExtensionsProjectScopeActive}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -165,6 +165,7 @@ export function CodeWorkspaceView({
                 contextUsage={activeComposerState?.contextUsage ?? null}
                 currentModel={activeComposerState?.currentModel ?? null}
                 currentThinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
+                isCompacting={activeComposerState?.isCompacting ?? false}
                 currentProjectName={currentProjectName}
                 selectedInboxThread={controller.selectedInboxThread}
                 projects={controller.projects}

--- a/src/app/features/feature-status.tsx
+++ b/src/app/features/feature-status.tsx
@@ -3,7 +3,6 @@ import { cn } from "../utils/cn";
 export type FeatureStatus = "mock" | "partial";
 
 export const featureStatusById = {
-  "feature:sidebar.inbox": { status: "partial", label: "Partial" },
   "feature:sidebar.plugins": { status: "mock", label: "Mock" },
   "feature:sidebar.automations": { status: "mock", label: "Mock" },
   "feature:sidebar.debug": { status: "mock", label: "Mock" },

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -103,7 +103,12 @@ export function InboxView({
       return;
     }
 
-    if (result?.result?.composerSendOutcome !== "stopped" && !isCompactCommand) {
+    if (result?.result?.composerSendOutcome !== "stopped" && isCompactCommand) {
+      setDraft("");
+      return;
+    }
+
+    if (result?.result?.composerSendOutcome !== "stopped") {
       setDraft("");
       setAttachments([]);
       onDismissThread(thread);

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -4,30 +4,65 @@ import { getErrorMessage } from "../desktop/error-messages";
 import { EmptyStateCard } from "../components/common/EmptyStateCard";
 import { MarkdownContent } from "../components/common/MarkdownContent";
 import { InboxComposer } from "../components/workspace/inbox/InboxComposer";
-import type { AppSettings, DesktopActionInvoker, InboxThread } from "../desktop/types";
+import { isCompactSlashCommand } from "../../../shared/composer-slash-commands";
+import type {
+  AppSettings,
+  ComposerAttachment,
+  ComposerContextUsage,
+  ComposerFilePickerState,
+  ComposerModel,
+  ComposerThinkingLevel,
+  DesktopActionInvoker,
+  InboxThread,
+} from "../desktop/types";
 
 type InboxViewProps = {
   appSettings: AppSettings;
+  availableModels: ComposerModel[];
+  availableThinkingLevels: ComposerThinkingLevel[];
+  contextUsage: ComposerContextUsage | null;
+  currentModel: ComposerModel | null;
+  currentThinkingLevel: ComposerThinkingLevel;
+  favoriteFolders: string[];
+  isCompacting: boolean;
+  showDictationButton: boolean;
   thread: InboxThread | null;
   onAction: DesktopActionInvoker;
   onDismissThread: (thread: InboxThread) => void;
+  onListAttachmentEntries: (request: {
+    projectId?: string | null;
+    path?: string | null;
+    rootPath?: string | null;
+  }) => Promise<ComposerFilePickerState | null>;
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
+  onOpenSettingsView: () => void;
 };
 
 export function InboxView({
   appSettings,
+  availableModels,
+  availableThinkingLevels,
+  contextUsage,
+  currentModel,
+  currentThinkingLevel,
+  favoriteFolders,
+  isCompacting,
+  showDictationButton,
   thread,
   onAction,
   onDismissThread,
+  onListAttachmentEntries,
   onOpenThread,
+  onOpenSettingsView,
 }: InboxViewProps) {
   const [draft, setDraft] = useState("");
+  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [isSending, setIsSending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleSend = async () => {
     const nextDraft = draft.trim();
-    if (!thread || !nextDraft || isSending) {
+    if (!thread || (nextDraft.length === 0 && attachments.length === 0) || isSending) {
       return;
     }
 
@@ -41,6 +76,7 @@ export function InboxView({
         projectId: thread.projectId,
         sessionPath: thread.sessionPath,
         text: nextDraft,
+        attachments: isCompactSlashCommand(nextDraft) ? [] : attachments,
         streamingBehavior: appSettings.composerStreamingBehavior,
       });
     } catch (error) {
@@ -58,6 +94,7 @@ export function InboxView({
 
     if (result?.result?.composerSendOutcome !== "stopped") {
       setDraft("");
+      setAttachments([]);
       onDismissThread(thread);
     }
   };
@@ -89,10 +126,13 @@ export function InboxView({
 
   if (!thread) {
     return (
-      <div className="grid h-full min-h-0 px-5 pt-6 pb-4">
-        <div className="mx-auto grid h-full w-full max-w-[860px] content-start">
-          <EmptyStateCard className="grid gap-1.5 px-5 py-5 text-[14px] text-[color:var(--muted)]">
-            <div className="text-[15px] text-[color:var(--text)]">No thread selected</div>
+      <div className="grid h-full min-h-0 place-items-center px-6 py-6">
+        <div className="w-full max-w-[520px]">
+          <EmptyStateCard className="grid gap-2 rounded-[18px] px-5 py-5 text-center text-[13px] text-[color:var(--muted)]">
+            <div className="text-[15px] font-medium text-[color:var(--text)]">Inbox is waiting</div>
+            <div>
+              Select a thread on the left to skim Pi’s latest reply and either answer or clear it.
+            </div>
           </EmptyStateCard>
         </div>
       </div>
@@ -103,22 +143,33 @@ export function InboxView({
   const messageMarkdown = thread.content.join("\n\n").trim();
 
   return (
-    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] px-5 pt-5 pb-4">
-      <div className="w-full pb-4">
-        <div className="w-full max-h-[calc(1.7em*5+2rem)] overflow-y-auto rounded-2xl border border-[color:var(--border)] bg-[rgba(43,47,62,0.92)] px-4 py-4 shadow-[var(--shadow)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <p className="m-0 whitespace-pre-wrap break-words leading-[1.7] text-[color:var(--muted)]">
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] px-6 pt-6 pb-4">
+      <div className="w-full pb-5">
+        <div className="grid w-full gap-2 rounded-[18px] border border-[rgba(169,178,215,0.09)] bg-[rgba(43,47,62,0.72)] px-4 py-3 shadow-[0_18px_48px_rgba(7,8,14,0.16)]">
+          <div className="flex min-w-0 items-center gap-2 text-[11px] leading-4 text-[color:var(--muted-2)]">
+            <span className="truncate">{thread.projectName}</span>
+            <span aria-hidden="true">•</span>
+            <span className="shrink-0 tabular-nums">{thread.age}</span>
+            {thread.running ? (
+              <>
+                <span aria-hidden="true">•</span>
+                <span className="shrink-0 text-[color:var(--accent)]">working</span>
+              </>
+            ) : null}
+          </div>
+          <p className="m-0 max-h-[calc(1.55em*4)] overflow-y-auto whitespace-pre-wrap break-words text-[15px] leading-[1.55] text-[color:var(--text)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             {prompt}
           </p>
         </div>
       </div>
 
       <div className="min-h-0 overflow-y-auto">
-        <div className="grid h-full w-full content-start pb-4">
-          <div className="min-h-0">
+        <div className="grid h-full w-full content-start pb-5">
+          <div className="min-h-0 max-w-[92ch] text-pretty">
             {messageMarkdown ? (
               <MarkdownContent markdown={messageMarkdown} className="gap-3 text-[15px]" />
             ) : (
-              <div className="text-[14px] text-[color:var(--muted)]">
+              <div className="grid min-h-28 place-items-center rounded-[18px] border border-dashed border-[color:var(--border)] text-[14px] text-[color:var(--muted)]">
                 {thread.running ? "Still working…" : "No final assistant message yet."}
               </div>
             )}
@@ -126,16 +177,32 @@ export function InboxView({
         </div>
       </div>
 
-      <div className="pt-2">
+      <div className="pt-1">
         <div className="w-full">
           <InboxComposer
+            appSettings={appSettings}
+            attachments={attachments}
+            availableModels={availableModels}
+            availableThinkingLevels={availableThinkingLevels}
+            contextUsage={contextUsage}
+            currentModel={currentModel}
+            currentThinkingLevel={currentThinkingLevel}
             draft={draft}
             errorMessage={errorMessage}
+            favoriteFolders={favoriteFolders}
+            isCompacting={isCompacting}
             isStreaming={thread.running}
             isSending={isSending}
+            showDictationButton={showDictationButton}
+            thread={thread}
             onChangeDraft={setDraft}
+            onChangeAttachments={setAttachments}
+            onChangeErrorMessage={setErrorMessage}
+            onAction={onAction}
             onDismiss={() => onDismissThread(thread)}
+            onListAttachmentEntries={onListAttachmentEntries}
             onOpenThread={() => onOpenThread(thread.projectId, thread.threadId, thread.sessionPath)}
+            onOpenSettingsView={onOpenSettingsView}
             onSend={handleSend}
             onStop={handleStop}
           />

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -67,6 +67,7 @@ export function InboxView({
     const draftToSend = input?.draft ?? draft;
     const attachmentsToSend = input?.attachments ?? attachments;
     const nextDraft = draftToSend.trim();
+    const isCompactCommand = isCompactSlashCommand(nextDraft);
     if (
       !thread ||
       (nextDraft.length === 0 && attachmentsToSend.length === 0) ||
@@ -86,7 +87,7 @@ export function InboxView({
         projectId: thread.projectId,
         sessionPath: thread.sessionPath,
         text: nextDraft,
-        attachments: isCompactSlashCommand(nextDraft) ? [] : attachmentsToSend,
+        attachments: isCompactCommand ? [] : attachmentsToSend,
         streamingBehavior: appSettings.composerStreamingBehavior,
       });
     } catch (error) {
@@ -102,7 +103,7 @@ export function InboxView({
       return;
     }
 
-    if (result?.result?.composerSendOutcome !== "stopped") {
+    if (result?.result?.composerSendOutcome !== "stopped" && !isCompactCommand) {
       setDraft("");
       setAttachments([]);
       onDismissThread(thread);

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -60,9 +60,19 @@ export function InboxView({
   const [isSending, setIsSending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const handleSend = async () => {
-    const nextDraft = draft.trim();
-    if (!thread || (nextDraft.length === 0 && attachments.length === 0) || isSending) {
+  const handleSend = async (input?: {
+    draft: string;
+    attachments: ComposerAttachment[];
+  }) => {
+    const draftToSend = input?.draft ?? draft;
+    const attachmentsToSend = input?.attachments ?? attachments;
+    const nextDraft = draftToSend.trim();
+    if (
+      !thread ||
+      (nextDraft.length === 0 && attachmentsToSend.length === 0) ||
+      isSending ||
+      isCompacting
+    ) {
       return;
     }
 
@@ -76,7 +86,7 @@ export function InboxView({
         projectId: thread.projectId,
         sessionPath: thread.sessionPath,
         text: nextDraft,
-        attachments: isCompactSlashCommand(nextDraft) ? [] : attachments,
+        attachments: isCompactSlashCommand(nextDraft) ? [] : attachmentsToSend,
         streamingBehavior: appSettings.composerStreamingBehavior,
       });
     } catch (error) {
@@ -203,7 +213,7 @@ export function InboxView({
             onListAttachmentEntries={onListAttachmentEntries}
             onOpenThread={() => onOpenThread(thread.projectId, thread.threadId, thread.sessionPath)}
             onOpenSettingsView={onOpenSettingsView}
-            onSend={handleSend}
+            onSend={(sendInput) => handleSend(sendInput)}
             onStop={handleStop}
           />
         </div>

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -719,15 +719,16 @@
 
 .sidebar-inbox-row {
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) 18px;
+  grid-template-columns: 12px minmax(0, 1fr) 18px;
   align-items: start;
-  gap: 0.5rem;
-  padding: 0.5rem 0.625rem;
+  gap: 0.625rem;
+  padding: 0.625rem 0.625rem;
 }
 
 .sidebar-inbox-row[data-selected="true"] {
-  background: rgba(183, 186, 245, 0.12);
+  background: rgba(183, 186, 245, 0.105);
   color: var(--text);
+  box-shadow: inset 0 0 0 1px rgba(183, 186, 245, 0.045), 0 10px 28px rgba(6, 7, 13, 0.12);
 }
 
 .sidebar-inbox-leading {
@@ -741,7 +742,7 @@
 .sidebar-inbox-content {
   display: grid;
   min-width: 0;
-  gap: 0.25rem;
+  gap: 0.3125rem;
   text-align: left;
 }
 
@@ -752,6 +753,8 @@
   gap: 0.375rem;
   color: var(--muted-2);
   font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1rem;
 }
 
 .sidebar-inbox-terminal {
@@ -765,7 +768,7 @@
   overflow: hidden;
   color: var(--muted);
   font-size: 13px;
-  line-height: 1.25rem;
+  line-height: 1.2rem;
   text-overflow: ellipsis;
   transition: color 150ms ease-out;
   white-space: nowrap;
@@ -786,9 +789,10 @@
   overflow: hidden;
   color: var(--muted-2);
   font-size: 12px;
-  line-height: 1.125rem;
+  line-height: 1.2rem;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  text-wrap: pretty;
 }
 
 .sidebar-inbox-dismiss {


### PR DESCRIPTION
## Summary
- polish the Inbox reading view and remove the partial badge
- bring Inbox composer closer to the main composer with attachments, slash commands, dictation, Agent/model controls, and context meter
- address release review findings by verifying launcher archive SHA-256 before extraction and narrowing dev artifact cleanup to `dev-*` artifacts

## Validation
- pre-commit hooks ran Biome, typecheck, and tests during commits
- tests passed: 27 files / 114 tests
