### PR TITLE
Fix composer stop and send while agent is working

### DIFF
--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -88,13 +88,17 @@ async function promptAndReturnAfterPreflight({
     return;
   }
 
-  promptPromise.catch((error) => {
-    console.error("Composer prompt failed after dispatch", error);
-    void emitComposerUpdate({
-      ...request,
-      sessionPath: getPersistedSessionPath(runtime.session.sessionFile),
+  promptPromise
+    .catch((error) => {
+      console.error("Composer prompt failed after dispatch", error);
+      void emitComposerUpdate({
+        ...request,
+        sessionPath: getPersistedSessionPath(runtime.session.sessionFile),
+      });
+    })
+    .finally(() => {
+      scheduleRuntimeDisposalForRuntime(runtime);
     });
-  });
 }
 
 async function setDraftComposerModel(cwd: string, provider: string, modelId: string) {

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -35,6 +35,7 @@ import {
   publishComposerUpdate,
   subscribeDesktopEvents,
 } from "./thread-publisher.cts";
+import type { PiRuntime } from "./types.cts";
 
 async function emitComposerUpdate(request: ComposerStateRequest = {}) {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
@@ -58,6 +59,42 @@ async function emitComposerUpdate(request: ComposerStateRequest = {}) {
     composer,
     runtime,
   };
+}
+
+async function promptAndReturnAfterPreflight({
+  runtime,
+  message,
+  options,
+  request,
+}: {
+  runtime: PiRuntime;
+  message: string;
+  options?: Parameters<PiRuntime["session"]["prompt"]>[1];
+  request: ComposerStateRequest;
+}) {
+  let resolvePreflight: (success: boolean) => void;
+  const preflight = new Promise<boolean>((resolve) => {
+    resolvePreflight = resolve;
+  });
+
+  const promptPromise = runtime.session.prompt(message, {
+    ...options,
+    preflightResult: (success) => resolvePreflight(success),
+  });
+
+  const accepted = await preflight;
+  if (!accepted) {
+    await promptPromise;
+    return;
+  }
+
+  promptPromise.catch((error) => {
+    console.error("Composer prompt failed after dispatch", error);
+    void emitComposerUpdate({
+      ...request,
+      sessionPath: getPersistedSessionPath(runtime.session.sessionFile),
+    });
+  });
 }
 
 async function setDraftComposerModel(cwd: string, provider: string, modelId: string) {
@@ -213,9 +250,18 @@ export async function sendComposerPrompt(
           return "stopped";
         }
 
-        await runtime.session.prompt(message, { streamingBehavior });
+        await promptAndReturnAfterPreflight({
+          runtime,
+          message,
+          options: { streamingBehavior },
+          request: { ...request, sessionPath: persistedSessionPath },
+        });
       } else {
-        await runtime.session.prompt(message);
+        await promptAndReturnAfterPreflight({
+          runtime,
+          message,
+          request: { ...request, sessionPath: persistedSessionPath },
+        });
       }
 
       return "sent";
@@ -231,6 +277,14 @@ export async function sendComposerPrompt(
     );
   }
 
+  const cachedRuntimePromise = getCachedRuntimeForSessionPath(persistedSessionPath);
+  if (cachedRuntimePromise) {
+    const cachedRuntime = await cachedRuntimePromise;
+    if (cachedRuntime.session.isStreaming) {
+      return await runSend(cachedRuntime);
+    }
+  }
+
   return await withRuntimeMutationLock(
     persistedSessionPath,
     async () =>
@@ -244,6 +298,17 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   if (!persistedSessionPath) {
     return;
+  }
+
+  const cachedRuntimePromise = getCachedRuntimeForSessionPath(persistedSessionPath);
+  if (cachedRuntimePromise) {
+    const cachedRuntime = await cachedRuntimePromise;
+    if (cachedRuntime.session.isStreaming) {
+      await cachedRuntime.session.abort();
+      scheduleRuntimeDisposalForRuntime(cachedRuntime);
+      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+      return;
+    }
   }
 
   await withRuntimeMutationLock(persistedSessionPath, async () => {


### PR DESCRIPTION
## Summary
- Make composer sends resolve after Pi accepts the prompt instead of waiting for the full agent turn.
- Let Stop and send-while-working actions reach the live streaming runtime immediately instead of waiting behind the runtime mutation lock.
- Preserve background error reporting by logging post-dispatch prompt failures and refreshing composer state.

## Validation
- `bun run typecheck:desktop`
- `bun test src/test/submit-composer-draft.test.ts src/test/composer-send-lock.test.ts`
- Commit hook: full typecheck suite and `vitest run` (`29` files / `122` tests passed)
