### PR TITLE
Keep Pi TUI alive while session file changes

### DIFF
--- a/desktop/app-settings.cts
+++ b/desktop/app-settings.cts
@@ -308,7 +308,6 @@ export function loadAppSettings(): AppSettings {
       `,
     )
     .get(piTuiTakeoverKey) as PreferenceRow | undefined;
-
   const dictationModelIdRow = db
     .prepare(
       `

--- a/desktop/terminal/manager.cts
+++ b/desktop/terminal/manager.cts
@@ -1,4 +1,6 @@
 import { rmSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import type {
   TerminalCloseRequest,
   TerminalOpenRequest,
@@ -86,6 +88,33 @@ export async function resizeTerminal(sessionId: string, cols: number, rows: numb
 
 export async function listTerminals(): Promise<TerminalSessionSnapshot[]> {
   return listTerminalSessions().map((record) => record.snapshot);
+}
+
+export async function getTerminalStatus(sessionId: string) {
+  const record = getTerminalSession(sessionId);
+  return record ? { sessionId, status: record.snapshot.status } : null;
+}
+
+export async function statSessionFile(sessionId: string) {
+  const record = getTerminalSession(sessionId);
+  const persistedSessionPath = getPersistedSessionPath(record?.snapshot.sessionPath ?? null);
+  if (!persistedSessionPath) {
+    return null;
+  }
+
+  try {
+    const fileStat = await stat(persistedSessionPath);
+    if (!fileStat.isFile()) {
+      return null;
+    }
+
+    return {
+      mtimeMs: fileStat.mtimeMs,
+      size: fileStat.size,
+    };
+  } catch {
+    return null;
+  }
 }
 
 export async function closeTerminal(request: TerminalCloseRequest) {

--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -138,6 +138,8 @@ const handlers: DesktopRequestHandlerMap = {
     await terminalManager.closeTerminal(request);
     return { ok: true };
   },
+  terminalSessionFileStat: ({ sessionId }) => terminalManager.statSessionFile(sessionId),
+  terminalStatus: ({ sessionId }) => terminalManager.getTerminalStatus(sessionId),
   openExternal: async ({ url }) => {
     const safeUrl = getSafeExternalUrl(url);
     return { ok: Boolean(safeUrl && (await openPathWithSystem(safeUrl))) };

--- a/shared/desktop-ipc.ts
+++ b/shared/desktop-ipc.ts
@@ -40,7 +40,11 @@ import type {
   TerminalEvent,
   TerminalOpenRequest,
   TerminalResizeRequest,
+  TerminalSessionFileStat,
+  TerminalSessionFileStatRequest,
   TerminalSessionSnapshot,
+  TerminalStatusRequest,
+  TerminalStatusSnapshot,
   TerminalWriteRequest,
 } from "./terminal-contracts";
 
@@ -160,6 +164,11 @@ export type DesktopRequestMap = {
   terminalWrite: { params: TerminalWriteRequest; response: { ok: boolean } };
   terminalResize: { params: TerminalResizeRequest; response: { ok: boolean } };
   terminalClose: { params: TerminalCloseRequest; response: { ok: boolean } };
+  terminalSessionFileStat: {
+    params: TerminalSessionFileStatRequest;
+    response: TerminalSessionFileStat | null;
+  };
+  terminalStatus: { params: TerminalStatusRequest; response: TerminalStatusSnapshot };
   openExternal: { params: { url: string }; response: { ok: boolean } };
   openPath: { params: { path: string }; response: { ok: boolean } };
 };

--- a/shared/terminal-contracts.ts
+++ b/shared/terminal-contracts.ts
@@ -26,6 +26,24 @@ export type TerminalCloseRequest = {
   deleteHistory?: boolean;
 };
 
+export type TerminalSessionFileStatRequest = {
+  sessionId: string;
+};
+
+export type TerminalSessionFileStat = {
+  mtimeMs: number;
+  size: number;
+};
+
+export type TerminalStatusRequest = {
+  sessionId: string;
+};
+
+export type TerminalStatusSnapshot = {
+  sessionId: string;
+  status: TerminalStatus;
+} | null;
+
 export type TerminalSessionSnapshot = {
   sessionId: string;
   projectId: string;

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -14,6 +14,7 @@ import { getGitOpsEntryButtonClass } from "./composer/git-ops";
 import { TerminalViewport } from "./terminal/TerminalViewport";
 
 const PI_TUI_KEEP_ALIVE_MS = 300_000;
+const PI_TUI_SESSION_FILE_IDLE_POLL_MS = 5 * 60_000;
 
 type TerminalPanelProps = {
   projectId: string;
@@ -59,6 +60,7 @@ export function TerminalPanel({
           sessionPath={sessionPath}
           launchMode="pi-session"
           keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
+          closeWhenSessionFileIdleMs={PI_TUI_SESSION_FILE_IDLE_POLL_MS}
           backgroundCssVar="--workspace"
           className="terminal-viewport--flush min-h-0 rounded-none bg-[color:var(--workspace)]"
         />

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -4,8 +4,10 @@ import { getPersistedSessionPath } from "../../../../../shared/session-paths";
 import type { TerminalEvent } from "../../../desktop/types";
 import {
   closeDesktopTerminal,
+  getDesktopTerminalStatus,
   openDesktopTerminal,
   resizeDesktopTerminal,
+  statDesktopTerminalSessionFile,
   subscribeDesktopTerminal,
   writeDesktopTerminal,
 } from "../../../hooks/useDesktopTerminal";
@@ -19,6 +21,8 @@ type TerminalViewportProps = {
   launchMode?: "shell" | "pi-session";
   preserveSessionOnUnmount?: boolean;
   keepAliveMsOnUnmount?: number;
+  closeWhenSessionFileIdleMs?: number;
+  maxKeepAliveMsOnUnmount?: number;
   backgroundCssVar?: TerminalBackgroundCssVar;
   className?: string;
 };
@@ -30,6 +34,7 @@ type TerminalLinkMatch = {
 };
 
 const pendingTerminalCloseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const pendingTerminalCloseGenerations = new Map<string, number>();
 
 const CLEAR_TERMINAL_SEQUENCE = "\u001b[2J\u001b[3J\u001b[H";
 const MAX_PENDING_TERMINAL_EVENTS = 200;
@@ -42,26 +47,209 @@ const MIN_INITIAL_TERMINAL_COLS = 20;
 const MIN_INITIAL_TERMINAL_ROWS = 5;
 const MIN_USABLE_TERMINAL_COLS = 2;
 const MIN_USABLE_TERMINAL_ROWS = 2;
+const DEFAULT_MAX_KEEP_ALIVE_MS_ON_UNMOUNT = 12 * 60 * 60 * 1_000;
+const MAX_TERMINAL_STATUS_FAILURES_BEFORE_CLOSE = 2;
+type SessionFileStat = { mtimeMs: number; size: number };
+
+function closeScheduledTerminal(sessionId: string, generation: number) {
+  if (pendingTerminalCloseGenerations.get(sessionId) !== generation) {
+    return;
+  }
+
+  pendingTerminalCloseTimers.delete(sessionId);
+  void closeDesktopTerminal({ sessionId }).finally(() => {
+    if (pendingTerminalCloseGenerations.get(sessionId) === generation) {
+      pendingTerminalCloseGenerations.delete(sessionId);
+    }
+  });
+}
 
 function cancelScheduledTerminalClose(sessionId: string) {
   const timer = pendingTerminalCloseTimers.get(sessionId);
   if (!timer) {
+    pendingTerminalCloseGenerations.delete(sessionId);
     return;
   }
 
+  pendingTerminalCloseGenerations.set(
+    sessionId,
+    (pendingTerminalCloseGenerations.get(sessionId) ?? 0) + 1,
+  );
   clearTimeout(timer);
   pendingTerminalCloseTimers.delete(sessionId);
 }
 
 function scheduleTerminalClose(sessionId: string, delayMs: number) {
   cancelScheduledTerminalClose(sessionId);
+  const generation = (pendingTerminalCloseGenerations.get(sessionId) ?? 0) + 1;
+  pendingTerminalCloseGenerations.set(sessionId, generation);
 
   const timer = setTimeout(() => {
-    pendingTerminalCloseTimers.delete(sessionId);
-    void closeDesktopTerminal({ sessionId });
+    if (pendingTerminalCloseGenerations.get(sessionId) !== generation) {
+      return;
+    }
+
+    closeScheduledTerminal(sessionId, generation);
   }, delayMs);
 
   pendingTerminalCloseTimers.set(sessionId, timer);
+}
+
+async function pollSessionFileBeforeClosing({
+  sessionId,
+  pollMs,
+  maxKeepAliveMs,
+  previousStat,
+  statusFailureCount,
+  startedAt,
+  generation,
+}: {
+  sessionId: string;
+  pollMs: number;
+  maxKeepAliveMs: number;
+  previousStat: SessionFileStat | null;
+  statusFailureCount: number;
+  startedAt: number;
+  generation: number;
+}) {
+  if (pendingTerminalCloseGenerations.get(sessionId) !== generation) {
+    return;
+  }
+
+  if (Date.now() - startedAt >= maxKeepAliveMs) {
+    closeScheduledTerminal(sessionId, generation);
+    return;
+  }
+
+  const [currentStat, terminalStatus] = await Promise.all([
+    statDesktopTerminalSessionFile(sessionId).catch(() => null),
+    getDesktopTerminalStatus(sessionId).catch(() => undefined),
+  ]);
+
+  if (pendingTerminalCloseGenerations.get(sessionId) !== generation) {
+    return;
+  }
+
+  const terminalStillRunning =
+    terminalStatus?.status === "starting" || terminalStatus?.status === "running";
+
+  if (terminalStatus === undefined) {
+    if (statusFailureCount + 1 >= MAX_TERMINAL_STATUS_FAILURES_BEFORE_CLOSE) {
+      closeScheduledTerminal(sessionId, generation);
+      return;
+    }
+
+    scheduleTerminalCloseWhenSessionFileIdle({
+      sessionId,
+      pollMs,
+      maxKeepAliveMs,
+      previousStat,
+      statusFailureCount: statusFailureCount + 1,
+      startedAt,
+      generation,
+    });
+    return;
+  }
+
+  if (!terminalStillRunning) {
+    closeScheduledTerminal(sessionId, generation);
+    return;
+  }
+
+  if (!currentStat) {
+    if (!previousStat) {
+      closeScheduledTerminal(sessionId, generation);
+      return;
+    }
+
+    scheduleTerminalCloseWhenSessionFileIdle({
+      sessionId,
+      pollMs,
+      maxKeepAliveMs,
+      previousStat: null,
+      statusFailureCount: 0,
+      startedAt,
+      generation,
+    });
+    return;
+  }
+
+  if (
+    previousStat &&
+    currentStat.mtimeMs === previousStat.mtimeMs &&
+    currentStat.size === previousStat.size
+  ) {
+    closeScheduledTerminal(sessionId, generation);
+    return;
+  }
+
+  scheduleTerminalCloseWhenSessionFileIdle({
+    sessionId,
+    pollMs,
+    maxKeepAliveMs,
+    previousStat: currentStat,
+    statusFailureCount: 0,
+    startedAt,
+    generation,
+  });
+}
+
+function scheduleTerminalCloseWhenSessionFileIdle({
+  sessionId,
+  pollMs,
+  maxKeepAliveMs,
+  previousStat,
+  statusFailureCount,
+  startedAt,
+  generation,
+}: {
+  sessionId: string;
+  pollMs: number;
+  maxKeepAliveMs: number;
+  previousStat: SessionFileStat | null;
+  statusFailureCount: number;
+  startedAt: number;
+  generation: number;
+}) {
+  const timer = setTimeout(() => {
+    void pollSessionFileBeforeClosing({
+      sessionId,
+      pollMs,
+      maxKeepAliveMs,
+      previousStat,
+      statusFailureCount,
+      startedAt,
+      generation,
+    });
+  }, pollMs);
+
+  pendingTerminalCloseTimers.set(sessionId, timer);
+}
+
+async function scheduleTerminalCloseAfterSessionFileIdle(
+  sessionId: string,
+  pollMs: number,
+  maxKeepAliveMs: number,
+) {
+  cancelScheduledTerminalClose(sessionId);
+  const generation = (pendingTerminalCloseGenerations.get(sessionId) ?? 0) + 1;
+  pendingTerminalCloseGenerations.set(sessionId, generation);
+  const startedAt = Date.now();
+  const initialStat = await statDesktopTerminalSessionFile(sessionId).catch(() => null);
+
+  if (pendingTerminalCloseGenerations.get(sessionId) !== generation) {
+    return;
+  }
+
+  scheduleTerminalCloseWhenSessionFileIdle({
+    sessionId,
+    pollMs,
+    maxKeepAliveMs,
+    previousStat: initialStat,
+    statusFailureCount: 0,
+    startedAt,
+    generation,
+  });
 }
 
 function writeSystemMessage(write: (data: string) => void, message: string) {
@@ -268,6 +456,8 @@ export function TerminalViewport({
   launchMode = "shell",
   preserveSessionOnUnmount = false,
   keepAliveMsOnUnmount = 0,
+  closeWhenSessionFileIdleMs = 0,
+  maxKeepAliveMsOnUnmount = DEFAULT_MAX_KEEP_ALIVE_MS_ON_UNMOUNT,
   backgroundCssVar = "--terminal-bg",
   className,
 }: TerminalViewportProps) {
@@ -597,7 +787,13 @@ export function TerminalViewport({
       unsubscribe();
 
       if (sessionId && !preserveSessionOnUnmount) {
-        if (keepAliveMsOnUnmount > 0) {
+        if (closeWhenSessionFileIdleMs > 0 && persistedSessionPath) {
+          void scheduleTerminalCloseAfterSessionFileIdle(
+            sessionId,
+            closeWhenSessionFileIdleMs,
+            maxKeepAliveMsOnUnmount,
+          );
+        } else if (keepAliveMsOnUnmount > 0) {
           scheduleTerminalClose(sessionId, keepAliveMsOnUnmount);
         } else {
           void closeDesktopTerminal({ sessionId });
@@ -607,9 +803,12 @@ export function TerminalViewport({
   }, [
     effectiveLaunchMode,
     appendTerminalHistory,
+    closeWhenSessionFileIdleMs,
     handleTerminalResize,
     keepAliveMsOnUnmount,
+    maxKeepAliveMsOnUnmount,
     preserveSessionOnUnmount,
+    persistedSessionPath,
     projectId,
     resetTerminal,
     terminalReadyRevision,

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -61,7 +61,11 @@ export type {
   TerminalEvent,
   TerminalOpenRequest,
   TerminalResizeRequest,
+  TerminalSessionFileStat,
+  TerminalSessionFileStatRequest,
   TerminalSessionSnapshot,
   TerminalStatus,
+  TerminalStatusRequest,
+  TerminalStatusSnapshot,
   TerminalWriteRequest,
 } from "../../../shared/terminal-contracts.js";

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -173,6 +173,9 @@ export function installDevWebDesktopBridge() {
     closeTerminal: async (request) => {
       await invokeRequest("terminalClose", request);
     },
+    statTerminalSessionFile: (sessionId: string) =>
+      invokeRequest("terminalSessionFileStat", { sessionId }),
+    getTerminalStatus: (sessionId: string) => invokeRequest("terminalStatus", { sessionId }),
     openExternal: (url: string) => invokeRequest("openExternal", { url }).then(({ ok }) => ok),
     openPath: (path: string) => invokeRequest("openPath", { path }).then(({ ok }) => ok),
     subscribe: (listener: (event: DesktopEvent) => void) =>

--- a/src/app/hooks/useDesktopTerminal.ts
+++ b/src/app/hooks/useDesktopTerminal.ts
@@ -3,6 +3,7 @@ import type {
   TerminalEvent,
   TerminalOpenRequest,
   TerminalResizeRequest,
+  TerminalSessionFileStat,
   TerminalSessionSnapshot,
 } from "../desktop/types";
 
@@ -28,6 +29,15 @@ export async function resizeDesktopTerminal(request: TerminalResizeRequest) {
 
 export async function closeDesktopTerminal(request: TerminalCloseRequest) {
   await window.piDesktop?.closeTerminal?.(request);
+}
+
+export async function statDesktopTerminalSessionFile(sessionId: string) {
+  return ((await window.piDesktop?.statTerminalSessionFile?.(sessionId)) ??
+    null) as TerminalSessionFileStat | null;
+}
+
+export async function getDesktopTerminalStatus(sessionId: string) {
+  return (await window.piDesktop?.getTerminalStatus?.(sessionId)) ?? null;
 }
 
 export function subscribeDesktopTerminal(listener: (event: TerminalEvent) => void) {

--- a/src/electron/main/ipc/request-handlers/terminal.ts
+++ b/src/electron/main/ipc/request-handlers/terminal.ts
@@ -3,7 +3,13 @@ import type { TerminalManagerModule } from "../../runtime/desktop-runtime-contra
 
 type TerminalRequestHandlers = Pick<
   DesktopRequestHandlerMap,
-  "listTerminals" | "terminalOpen" | "terminalWrite" | "terminalResize" | "terminalClose"
+  | "listTerminals"
+  | "terminalOpen"
+  | "terminalWrite"
+  | "terminalResize"
+  | "terminalClose"
+  | "terminalSessionFileStat"
+  | "terminalStatus"
 >;
 
 export function createTerminalHandlers(
@@ -24,5 +30,7 @@ export function createTerminalHandlers(
       await terminalManager.closeTerminal(request);
       return { ok: true };
     },
+    terminalSessionFileStat: ({ sessionId }) => terminalManager.statSessionFile(sessionId),
+    terminalStatus: ({ sessionId }) => terminalManager.getTerminalStatus(sessionId),
   };
 }

--- a/src/electron/main/runtime/desktop-runtime-contracts.ts
+++ b/src/electron/main/runtime/desktop-runtime-contracts.ts
@@ -35,6 +35,7 @@ import type {
   TerminalEvent,
   TerminalOpenRequest,
   TerminalSessionSnapshot,
+  TerminalStatusSnapshot,
 } from "../../../../shared/terminal-contracts";
 
 export type PiThreadsModule = {
@@ -99,9 +100,11 @@ export type PiThreadsModule = {
 
 export type TerminalManagerModule = {
   closeTerminal: (request: { sessionId: string; deleteHistory?: boolean }) => Promise<void>;
+  getTerminalStatus: (sessionId: string) => Promise<TerminalStatusSnapshot>;
   listTerminals: () => Promise<TerminalSessionSnapshot[]>;
   openTerminal: (request: TerminalOpenRequest) => Promise<TerminalSessionSnapshot>;
   resizeTerminal: (sessionId: string, cols: number, rows: number) => Promise<void>;
+  statSessionFile: (sessionId: string) => Promise<{ mtimeMs: number; size: number } | null>;
   subscribeTerminalEvents: (listener: (event: TerminalEvent) => void) => () => void;
   writeTerminal: (sessionId: string, data: string) => Promise<void>;
 };

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -132,6 +132,9 @@ export function createDesktopApi() {
     closeTerminal: async (request: { sessionId: string; deleteHistory?: boolean }) => {
       await invokeRequest("terminalClose", request);
     },
+    statTerminalSessionFile: (sessionId: string) =>
+      invokeRequest("terminalSessionFileStat", { sessionId }),
+    getTerminalStatus: (sessionId: string) => invokeRequest("terminalStatus", { sessionId }),
     openExternal: (url: string) => invokeRequest("openExternal", { url }).then(({ ok }) => ok),
     openPath: (path: string) => invokeRequest("openPath", { path }).then(({ ok }) => ok),
     subscribe: (listener: (event: DesktopEvent) => void) =>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,7 +36,9 @@ import type {
   TerminalEvent,
   TerminalOpenRequest,
   TerminalResizeRequest,
+  TerminalSessionFileStat,
   TerminalSessionSnapshot,
+  TerminalStatusSnapshot,
   Thread,
   ThreadData,
 } from "./app/desktop/types";
@@ -144,6 +146,8 @@ declare global {
       writeTerminal?: (sessionId: string, data: string) => Promise<void>;
       resizeTerminal?: (request: TerminalResizeRequest) => Promise<void>;
       closeTerminal?: (request: TerminalCloseRequest) => Promise<void>;
+      statTerminalSessionFile?: (sessionId: string) => Promise<TerminalSessionFileStat | null>;
+      getTerminalStatus?: (sessionId: string) => Promise<TerminalStatusSnapshot>;
       subscribeTerminal?: (listener: (event: TerminalEvent) => void) => () => void;
       openExternal?: (url: string) => Promise<boolean>;
       openPath?: (path: string) => Promise<boolean>;


### PR DESCRIPTION
## Summary
- Keep hidden Pi TUI takeover sessions alive while their persisted session file is still changing.
- Close hidden Pi TUI processes once their session file is unchanged for the poll window, with a long max hidden lifetime cap.
- Add lightweight terminal status/session-file stat IPC using terminal session IDs instead of renderer-supplied paths.

## Details
- Takeover cleanup now polls the active terminal record's persisted Pi session file every 5 minutes.
- Drawer terminals keep their original behavior: they are preserved indefinitely when hidden.
- Session-file stat is resolved from the terminal manager's active record to avoid probing arbitrary local paths from renderer code.
- Added a lightweight `terminalStatus` IPC endpoint to avoid shipping terminal histories over IPC during cleanup checks.

## Validation
- Pre-commit hook passed during amend.
- `bun run typecheck:web`
- `bun run typecheck:desktop`
- `bun run typecheck:electron`
- `bun run typecheck:scripts`
- `vitest run` — 29 files / 122 tests passed
