### PR TITLE
Fix terminal drawer layout and bottom stickiness

### DIFF
--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -194,12 +194,12 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
 
             {terminalDrawerPresent ? (
               <div
-                className="pointer-events-none absolute inset-y-0 right-0 z-20"
+                className="pointer-events-none absolute top-0 right-0 bottom-0 z-20 max-w-full overflow-hidden"
                 style={{ width: TERMINAL_DRAWER_WIDTH }}
               >
                 <div
                   data-open={terminalDrawerVisible ? "true" : "false"}
-                  className={`motion-terminal-drawer h-full ${terminalDrawerVisible ? "pointer-events-auto" : "pointer-events-none"}`}
+                  className={`motion-terminal-drawer absolute inset-0 min-h-0 min-w-0 ${terminalDrawerVisible ? "pointer-events-auto" : "pointer-events-none"}`}
                 >
                   <TerminalPanel
                     projectId={composerProjectId}

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -117,7 +117,7 @@ export function TerminalPanel({
   return (
     <section
       aria-label="Terminal drawer"
-      className="flex h-full min-h-0 flex-col overflow-hidden border-l border-[rgba(169,178,215,0.08)] bg-[color:var(--workspace)]"
+      className="absolute inset-0 flex min-h-0 flex-col overflow-hidden border-l border-[rgba(169,178,215,0.08)] bg-[color:var(--workspace)]"
       {...getFeatureStatusDataAttributes(statusId)}
     >
       <div className="flex h-11 items-center justify-between gap-3 border-b border-[rgba(169,178,215,0.08)] px-3">
@@ -135,14 +135,14 @@ export function TerminalPanel({
           <PanelRightClose size={14} />
         </button>
       </div>
-      <div className="flex min-h-0 min-w-0 flex-1 bg-[color:var(--sidebar)]">
+      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-[color:var(--sidebar)]">
         <TerminalViewport
           projectId={projectId}
           sessionPath={sessionPath}
           launchMode="shell"
           preserveSessionOnUnmount
           backgroundCssVar="--sidebar"
-          className="terminal-viewport--flush h-full rounded-none bg-[color:var(--sidebar)]"
+          className="terminal-viewport--flush terminal-viewport--bottom-reserve absolute inset-0 h-auto min-h-0 rounded-none bg-[color:var(--sidebar)]"
         />
       </div>
     </section>

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -47,6 +47,7 @@ const MIN_INITIAL_TERMINAL_COLS = 20;
 const MIN_INITIAL_TERMINAL_ROWS = 5;
 const MIN_USABLE_TERMINAL_COLS = 2;
 const MIN_USABLE_TERMINAL_ROWS = 2;
+const TERMINAL_STICKY_BOTTOM_THRESHOLD_PX = 24;
 const DEFAULT_MAX_KEEP_ALIVE_MS_ON_UNMOUNT = 12 * 60 * 60 * 1_000;
 const MAX_TERMINAL_STATUS_FAILURES_BEFORE_CLOSE = 2;
 type SessionFileStat = { mtimeMs: number; size: number };
@@ -450,6 +451,13 @@ function terminalStyleVars(backgroundCssVar: TerminalBackgroundCssVar): CSSPrope
   } as CSSProperties;
 }
 
+function isTerminalElementNearBottom(element: HTMLElement) {
+  return (
+    element.scrollHeight - element.clientHeight - element.scrollTop <=
+    TERMINAL_STICKY_BOTTOM_THRESHOLD_PX
+  );
+}
+
 export function TerminalViewport({
   projectId,
   sessionPath,
@@ -463,6 +471,7 @@ export function TerminalViewport({
 }: TerminalViewportProps) {
   const terminalHandleRef = useRef<TerminalHandle | null>(null);
   const terminalInstanceRef = useRef<WTerm | null>(null);
+  const pendingScrollFrameRef = useRef<number | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const attachFailedRef = useRef(false);
   const pendingEventsRef = useRef<TerminalEvent[]>([]);
@@ -480,9 +489,51 @@ export function TerminalViewport({
   const viewportStyle = useMemo(() => terminalWrapperStyle(backgroundCssVar), [backgroundCssVar]);
   const terminalStyle = useMemo(() => terminalStyleVars(backgroundCssVar), [backgroundCssVar]);
 
-  const writeToTerminal = useCallback((data: string | Uint8Array) => {
-    terminalHandleRef.current?.write(data);
+  const scrollTerminalToBottom = useCallback(() => {
+    const terminalElement = terminalInstanceRef.current?.element;
+    if (!terminalElement) {
+      return;
+    }
+
+    terminalElement.scrollTop = terminalElement.scrollHeight;
   }, []);
+
+  const scheduleTerminalScrollToBottom = useCallback(() => {
+    if (pendingScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingScrollFrameRef.current);
+    }
+
+    pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
+      scrollTerminalToBottom();
+      pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
+        scrollTerminalToBottom();
+        pendingScrollFrameRef.current = null;
+      });
+    });
+  }, [scrollTerminalToBottom]);
+
+  const writeToTerminal = useCallback(
+    (data: string | Uint8Array) => {
+      const terminalElement = terminalInstanceRef.current?.element;
+      const shouldStickToBottom = !terminalElement || isTerminalElementNearBottom(terminalElement);
+
+      terminalHandleRef.current?.write(data);
+
+      if (shouldStickToBottom) {
+        scheduleTerminalScrollToBottom();
+      }
+    },
+    [scheduleTerminalScrollToBottom],
+  );
+
+  useEffect(
+    () => () => {
+      if (pendingScrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(pendingScrollFrameRef.current);
+      }
+    },
+    [],
+  );
 
   const resetTerminal = useCallback(
     (history = "") => {

--- a/src/app/components/workspace/thread/ThreadTimeline.tsx
+++ b/src/app/components/workspace/thread/ThreadTimeline.tsx
@@ -28,7 +28,9 @@ export function ThreadTimeline({
   const [collapsedRowIds, setCollapsedRowIds] = useState<Record<string, boolean>>({});
   const [expandedToolGroupIds, setExpandedToolGroupIds] = useState<Record<string, boolean>>({});
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const bottomSentinelRef = useRef<HTMLDivElement>(null);
+  const programmaticScrollFrameRef = useRef<number | null>(null);
   const shouldStickToBottomRef = useRef(true);
   const pendingHistoryPrependRef = useRef<{ scrollTop: number; scrollHeight: number } | null>(null);
 
@@ -94,13 +96,45 @@ export function ThreadTimeline({
       return;
     }
 
-    const bottomSentinel = bottomSentinelRef.current;
-    if (bottomSentinel) {
-      bottomSentinel.scrollIntoView({ block: "end" });
-    } else {
-      container.scrollTop = container.scrollHeight;
+    if (programmaticScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(programmaticScrollFrameRef.current);
     }
+
+    container.scrollTop = container.scrollHeight;
+    programmaticScrollFrameRef.current = window.requestAnimationFrame(() => {
+      programmaticScrollFrameRef.current = null;
+    });
   }, []);
+
+  useEffect(
+    () => () => {
+      if (programmaticScrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(programmaticScrollFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      if (shouldStickToBottomRef.current) {
+        scrollToBottom();
+      }
+    });
+
+    observer.observe(container);
+    observer.observe(content);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [scrollToBottom]);
 
   useLayoutEffect(() => {
     void bottomAnchorKey;
@@ -132,6 +166,10 @@ export function ThreadTimeline({
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
     if (!container) {
+      return;
+    }
+
+    if (programmaticScrollFrameRef.current !== null) {
       return;
     }
 
@@ -224,6 +262,7 @@ export function ThreadTimeline({
     <div className={`${chatViewportClass} relative`}>
       <div ref={containerRef} className={chatScrollableAreaClass} onScroll={handleScroll}>
         <div
+          ref={contentRef}
           className={`mx-auto w-full min-w-0 ${CHAT_TEXT_MAX_WIDTH_CLASS} overflow-x-hidden px-4 pt-4 pb-4`}
         >
           <div className="grid min-w-0 gap-4">{rows.map(renderRow)}</div>

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -27,7 +27,6 @@ type CodeWorkspaceViewProps = {
 };
 
 const TERMINAL_DRAWER_OFFSET = "min(28rem, calc(100% - 2.5rem))";
-const TERMINAL_DRAWER_FOOTER_OFFSET = `calc(${TERMINAL_DRAWER_OFFSET} + 1.25rem)`;
 
 export function CodeWorkspaceView({
   controller,
@@ -100,21 +99,15 @@ export function CodeWorkspaceView({
     terminalSessionPath,
   });
 
-  const terminalDrawerPaddingStyle = showDesktopTerminalDrawer
-    ? { paddingRight: TERMINAL_DRAWER_OFFSET }
-    : undefined;
-  const terminalDrawerFooterPaddingStyle = showDesktopTerminalDrawer
-    ? { paddingRight: TERMINAL_DRAWER_FOOTER_OFFSET }
+  const terminalDrawerInsetStyle = showDesktopTerminalDrawer
+    ? { right: TERMINAL_DRAWER_OFFSET }
     : undefined;
 
   return (
-    <div
-      className="motion-terminal-drawer-offset relative min-h-0 flex-1 overflow-hidden"
-      style={terminalDrawerPaddingStyle}
-    >
+    <div className="relative min-h-0 flex-1 overflow-hidden">
       <div
-        className="absolute inset-x-0 top-0 overflow-hidden px-5"
-        style={{ bottom: `${footerInset}px` }}
+        className="motion-terminal-drawer-offset absolute inset-x-0 top-0 overflow-hidden px-5"
+        style={{ ...terminalDrawerInsetStyle, bottom: `${footerInset}px` }}
       >
         <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)] gap-3 overflow-hidden">
           <main
@@ -193,7 +186,7 @@ export function CodeWorkspaceView({
         <footer
           ref={footerRef}
           className="motion-terminal-drawer-offset pointer-events-none absolute inset-x-0 bottom-0 z-10 px-5 pb-4"
-          style={terminalDrawerFooterPaddingStyle}
+          style={terminalDrawerInsetStyle}
         >
           <div className="pointer-events-auto grid gap-2.5">
             <div className={workspaceContentClass}>

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -91,7 +91,8 @@
 }
 
 .motion-terminal-drawer-offset {
-  transition: padding-right 180ms var(--motion-ease-standard);
+  transition: padding-right 180ms var(--motion-ease-standard), right 180ms
+    var(--motion-ease-standard);
 }
 
 .motion-terminal-drawer {

--- a/src/styles/vendor/wterm.css
+++ b/src/styles/vendor/wterm.css
@@ -20,6 +20,10 @@
   padding: 0 0 0 14px;
 }
 
+.terminal-viewport--bottom-reserve .wterm {
+  padding-bottom: var(--term-row-height, 17px);
+}
+
 .terminal-viewport .wterm .term-grid {
   min-height: 100%;
 }


### PR DESCRIPTION
## Summary
- Keep the chat timeline and composer aligned when the terminal drawer opens by applying the same drawer inset to both absolute content regions.
- Make chat bottom-stickiness resilient to layout/content reflows and programmatic scroll events.
- Fix drawer terminal bottom behavior by reserving an invisible input-row gutter and keeping terminal output stuck to the true bottom while new output arrives.

## Details
- Replaces the previous parent padding approach with matching right insets for main content and footer.
- Adds resize-aware bottom sticking to the thread timeline.
- Adds a drawer-only terminal bottom reserve and schedules terminal scroll-to-bottom after writes so long commands leave the input row fully visible.

## Validation
- Pre-commit hook passed: biome, full typecheck, vitest.
- Push hook passed: lint and full typecheck.
