### PR TITLE
Perf: apply low-risk allocation and concurrency cleanups

### DIFF
--- a/desktop/app-settings.cts
+++ b/desktop/app-settings.cts
@@ -424,9 +424,14 @@ export function setShowDictationButton(enabled: boolean) {
 }
 
 export function setFavoriteFolders(favoriteFolders: string[]) {
-  const normalizedFavoriteFolders = [
-    ...new Set(favoriteFolders.map((folder) => folder.trim()).filter(Boolean)),
-  ];
+  const normalizedFavoriteFolderSet = new Set<string>();
+  for (const folder of favoriteFolders) {
+    const trimmedFolder = folder.trim();
+    if (trimmedFolder) {
+      normalizedFavoriteFolderSet.add(trimmedFolder);
+    }
+  }
+  const normalizedFavoriteFolders = [...normalizedFavoriteFolderSet];
 
   if (normalizedFavoriteFolders.length === 0) {
     deleteAppPreference(favoriteFoldersKey);

--- a/desktop/pi-threads/map-with-concurrency.cts
+++ b/desktop/pi-threads/map-with-concurrency.cts
@@ -1,0 +1,21 @@
+export async function mapWithConcurrency<TInput, TOutput>(
+  inputs: TInput[],
+  concurrency: number,
+  mapper: (input: TInput) => Promise<TOutput>,
+) {
+  const results = new Array<TOutput>(inputs.length);
+  let nextIndex = 0;
+
+  const workerCount = Math.min(concurrency, inputs.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < inputs.length) {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        results[currentIndex] = await mapper(inputs[currentIndex] as TInput);
+      }
+    }),
+  );
+
+  return results;
+}

--- a/desktop/pi-threads/session-index.cts
+++ b/desktop/pi-threads/session-index.cts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { normalizeThreadTitle } from "../../shared/pi-message-mapper.ts";
 import { getPiModule } from "../pi-module.cts";
+import { mapWithConcurrency } from "./map-with-concurrency.cts";
 
 export type SessionSummary = {
   id: string;
@@ -96,28 +97,6 @@ function getSessionModifiedDate(
   const headerTimestampMs =
     typeof header.timestamp === "string" ? Date.parse(header.timestamp) : Number.NaN;
   return Number.isNaN(headerTimestampMs) ? fileModified : new Date(headerTimestampMs);
-}
-
-async function mapWithConcurrency<TInput, TOutput>(
-  inputs: TInput[],
-  concurrency: number,
-  mapper: (input: TInput) => Promise<TOutput>,
-) {
-  const results = new Array<TOutput>(inputs.length);
-  let nextIndex = 0;
-
-  const workerCount = Math.min(concurrency, inputs.length);
-  await Promise.all(
-    Array.from({ length: workerCount }, async () => {
-      while (nextIndex < inputs.length) {
-        const currentIndex = nextIndex;
-        nextIndex += 1;
-        results[currentIndex] = await mapper(inputs[currentIndex] as TInput);
-      }
-    }),
-  );
-
-  return results;
 }
 
 async function readSessionSummary(filePath: string): Promise<SessionSummaryReadResult> {

--- a/desktop/pi-threads/session-index.cts
+++ b/desktop/pi-threads/session-index.cts
@@ -37,6 +37,8 @@ type SessionIndexReadResult = {
   partialFailure: boolean;
 };
 
+const SESSION_SUMMARY_READ_CONCURRENCY = 12;
+
 function isNodeErrorWithCode(error: unknown, code: string) {
   return typeof error === "object" && error !== null && "code" in error && error.code === code;
 }
@@ -94,6 +96,28 @@ function getSessionModifiedDate(
   const headerTimestampMs =
     typeof header.timestamp === "string" ? Date.parse(header.timestamp) : Number.NaN;
   return Number.isNaN(headerTimestampMs) ? fileModified : new Date(headerTimestampMs);
+}
+
+async function mapWithConcurrency<TInput, TOutput>(
+  inputs: TInput[],
+  concurrency: number,
+  mapper: (input: TInput) => Promise<TOutput>,
+) {
+  const results = new Array<TOutput>(inputs.length);
+  let nextIndex = 0;
+
+  const workerCount = Math.min(concurrency, inputs.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < inputs.length) {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        results[currentIndex] = await mapper(inputs[currentIndex] as TInput);
+      }
+    }),
+  );
+
+  return results;
 }
 
 async function readSessionSummary(filePath: string): Promise<SessionSummaryReadResult> {
@@ -227,7 +251,11 @@ export async function listAllSessionsStrict(): Promise<SessionIndexReadResult> {
     sessionFilePaths.push(...result.filePaths);
   }
 
-  const sessionResults = await Promise.all(sessionFilePaths.map(readSessionSummary));
+  const sessionResults = await mapWithConcurrency(
+    sessionFilePaths,
+    SESSION_SUMMARY_READ_CONCURRENCY,
+    readSessionSummary,
+  );
   const sessions = sessionResults
     .map((result) => result.summary)
     .filter((session): session is SessionSummary => session !== null);

--- a/desktop/pi-threads/session-index.cts
+++ b/desktop/pi-threads/session-index.cts
@@ -63,10 +63,16 @@ function getMessageText(entry: SessionFileEntry) {
   }
 
   if (Array.isArray(content)) {
-    return content
-      .filter((block) => block.type === "text" && typeof block.text === "string")
-      .map((block) => block.text)
-      .join(" ");
+    let text = "";
+    for (const block of content) {
+      if (block.type !== "text" || typeof block.text !== "string") {
+        continue;
+      }
+
+      text += text ? ` ${block.text}` : block.text;
+    }
+
+    return text;
   }
 
   return "";

--- a/desktop/pi-threads/thread-loader.cts
+++ b/desktop/pi-threads/thread-loader.cts
@@ -15,12 +15,15 @@ import {
   listProjectThreads,
   upsertInboxThreadPrompt,
 } from "../thread-state-db.cts";
+import { mapWithConcurrency } from "./map-with-concurrency.cts";
 
 export type LoadedThreadSnapshot = {
   projectId: string;
   threadId: string;
   thread: ThreadData;
 };
+
+const INBOX_PROMPT_BACKFILL_CONCURRENCY = 6;
 
 export async function loadProjectThreads(projectId: string): Promise<Thread[]> {
   ensureProject(projectId);
@@ -34,37 +37,35 @@ export async function loadArchivedThreadList(): Promise<ArchivedThread[]> {
 export async function loadInboxThreadList(): Promise<InboxThread[]> {
   const threads = listInboxThreads();
 
-  return Promise.all(
-    threads.map(async (thread) => {
-      try {
-        if (thread.prompt?.trim()) {
-          return thread;
-        }
-
-        const loadedThread = await loadThread(thread.sessionPath);
-        let prompt: string | null = null;
-
-        for (let index = loadedThread.messages.length - 1; index >= 0; index -= 1) {
-          const message = loadedThread.messages[index];
-          if (message.role === "user") {
-            const nextPrompt = message.content.join("\n\n").trim();
-            prompt = nextPrompt.length > 0 ? nextPrompt : null;
-            break;
-          }
-        }
-
-        if (!prompt) {
-          return thread;
-        }
-
-        upsertInboxThreadPrompt(thread.sessionPath, prompt);
-        return { ...thread, prompt };
-      } catch (error) {
-        console.warn(`Failed to backfill inbox prompt for ${thread.sessionPath}.`, error);
+  return mapWithConcurrency(threads, INBOX_PROMPT_BACKFILL_CONCURRENCY, async (thread) => {
+    try {
+      if (thread.prompt?.trim()) {
         return thread;
       }
-    }),
-  );
+
+      const loadedThread = await loadThread(thread.sessionPath);
+      let prompt: string | null = null;
+
+      for (let index = loadedThread.messages.length - 1; index >= 0; index -= 1) {
+        const message = loadedThread.messages[index];
+        if (message.role === "user") {
+          const nextPrompt = message.content.join("\n\n").trim();
+          prompt = nextPrompt.length > 0 ? nextPrompt : null;
+          break;
+        }
+      }
+
+      if (!prompt) {
+        return thread;
+      }
+
+      upsertInboxThreadPrompt(thread.sessionPath, prompt);
+      return { ...thread, prompt };
+    } catch (error) {
+      console.warn(`Failed to backfill inbox prompt for ${thread.sessionPath}.`, error);
+      return thread;
+    }
+  });
 }
 
 export async function loadThreadSnapshot(

--- a/desktop/pi-threads/thread-loader.cts
+++ b/desktop/pi-threads/thread-loader.cts
@@ -44,7 +44,8 @@ export async function loadInboxThreadList(): Promise<InboxThread[]> {
         const loadedThread = await loadThread(thread.sessionPath);
         let prompt: string | null = null;
 
-        for (const message of [...loadedThread.messages].reverse()) {
+        for (let index = loadedThread.messages.length - 1; index >= 0; index -= 1) {
+          const message = loadedThread.messages[index];
           if (message.role === "user") {
             const nextPrompt = message.content.join("\n\n").trim();
             prompt = nextPrompt.length > 0 ? nextPrompt : null;

--- a/desktop/project-import.cts
+++ b/desktop/project-import.cts
@@ -39,8 +39,18 @@ export async function scanKnownProjects(projectIds: string[]): Promise<ProjectIm
 
 export async function importProjects(projectIds: string[]) {
   const candidates = await scanKnownProjects(projectIds);
+  let repoProjectCount = 0;
+  let originProjectCount = 0;
 
   for (const candidate of candidates) {
+    if (candidate.isGitRepo) {
+      repoProjectCount += 1;
+    }
+
+    if (candidate.hasOrigin) {
+      originProjectCount += 1;
+    }
+
     setProjectRepoOrigin(candidate.projectId, candidate.originUrl);
   }
 
@@ -49,7 +59,7 @@ export async function importProjects(projectIds: string[]) {
   return {
     importedProjectIds: candidates.map((candidate) => candidate.projectId),
     checkedProjectCount: candidates.length,
-    repoProjectCount: candidates.filter((candidate) => candidate.isGitRepo).length,
-    originProjectCount: candidates.filter((candidate) => candidate.hasOrigin).length,
+    repoProjectCount,
+    originProjectCount,
   };
 }

--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -1,6 +1,6 @@
 import { stat } from "node:fs/promises";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { ComposerState, ThreadData } from "../../shared/desktop-contracts.ts";
+import type { ComposerState, ProseMessage, ThreadData } from "../../shared/desktop-contracts.ts";
 import { type SessionPathEntry, buildThreadHistorySlice } from "../../shared/thread-history.ts";
 import { getLatestInboxAssistantMessage } from "../../shared/thread-inbox.ts";
 import {
@@ -72,11 +72,16 @@ function hasAssistantMessageChanged(
 }
 
 function getLatestUserPrompt(thread: ThreadData) {
-  const latestUserMessage = [...thread.messages]
-    .reverse()
-    .find((message) => message.role === "user");
+  let latestUserMessage: ProseMessage | undefined;
+  for (let index = thread.messages.length - 1; index >= 0; index -= 1) {
+    const message = thread.messages[index];
+    if (message?.role === "user") {
+      latestUserMessage = message as ProseMessage;
+      break;
+    }
+  }
 
-  if (!latestUserMessage || latestUserMessage.role !== "user") {
+  if (!latestUserMessage) {
     return null;
   }
 

--- a/shared/pi-message-mapper.ts
+++ b/shared/pi-message-mapper.ts
@@ -174,13 +174,19 @@ function extractAssistantContent(message: RuntimeMessage) {
 
 function extractAssistantThinking(message: RuntimeMessage) {
   const thinkingParts = getThinkingParts(message.content);
-  const thinkingContent = thinkingParts
-    .flatMap((part) => splitParagraphs(part.thinking ?? ""))
-    .filter(Boolean);
-  const thinkingHeaders = thinkingParts
-    .flatMap((part) => splitParagraphs(part.thinking ?? ""))
-    .map(normalizeThinkingHeader)
-    .filter((value): value is string => Boolean(value));
+  const thinkingContent: string[] = [];
+  const thinkingHeaders: string[] = [];
+
+  for (const part of thinkingParts) {
+    for (const paragraph of splitParagraphs(part.thinking ?? "")) {
+      thinkingContent.push(paragraph);
+
+      const heading = normalizeThinkingHeader(paragraph);
+      if (heading) {
+        thinkingHeaders.push(heading);
+      }
+    }
+  }
 
   return {
     thinkingContent,

--- a/shared/pi-message-mapper.ts
+++ b/shared/pi-message-mapper.ts
@@ -309,14 +309,18 @@ export function getFirstUserTurnTitle(messages: Message[]) {
 }
 
 export function getPreviousMessageCount(entries: SessionBranchEntry[]) {
-  const latestCompactionIndex = [...entries]
-    .reverse()
-    .findIndex((entry) => entry.type === "compaction");
-  if (latestCompactionIndex === -1) {
+  let compactionIndex = -1;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (entries[index]?.type === "compaction") {
+      compactionIndex = index;
+      break;
+    }
+  }
+
+  if (compactionIndex === -1) {
     return 0;
   }
 
-  const compactionIndex = entries.length - latestCompactionIndex - 1;
   const compactionEntry = entries[compactionIndex];
   const firstKeptEntryId = compactionEntry?.firstKeptEntryId;
 

--- a/shared/pi-message-mapper.ts
+++ b/shared/pi-message-mapper.ts
@@ -83,9 +83,14 @@ function getTextParts(content: RuntimeMessage["content"]) {
     return [] as string[];
   }
 
-  return content
-    .filter((part) => part?.type === "text" && typeof (part as TextPart).text === "string")
-    .map((part) => (part as TextPart).text ?? "");
+  const textParts: string[] = [];
+  for (const part of content) {
+    if (part?.type === "text" && typeof (part as TextPart).text === "string") {
+      textParts.push((part as TextPart).text ?? "");
+    }
+  }
+
+  return textParts;
 }
 
 function getThinkingParts(content: RuntimeMessage["content"]) {
@@ -93,9 +98,14 @@ function getThinkingParts(content: RuntimeMessage["content"]) {
     return [] as ThinkingPart[];
   }
 
-  return content.filter(
-    (part) => part?.type === "thinking" && typeof (part as ThinkingPart).thinking === "string",
-  ) as ThinkingPart[];
+  const thinkingParts: ThinkingPart[] = [];
+  for (const part of content) {
+    if (part?.type === "thinking" && typeof (part as ThinkingPart).thinking === "string") {
+      thinkingParts.push(part as ThinkingPart);
+    }
+  }
+
+  return thinkingParts;
 }
 
 function getImageCount(content: RuntimeMessage["content"]) {
@@ -103,7 +113,14 @@ function getImageCount(content: RuntimeMessage["content"]) {
     return 0;
   }
 
-  return content.filter((part) => part?.type === "image").length;
+  let imageCount = 0;
+  for (const part of content) {
+    if (part?.type === "image") {
+      imageCount += 1;
+    }
+  }
+
+  return imageCount;
 }
 
 function getToolResultImages(content: RuntimeMessage["content"]): ToolResultImage[] {
@@ -111,14 +128,15 @@ function getToolResultImages(content: RuntimeMessage["content"]): ToolResultImag
     return [];
   }
 
-  return content.flatMap((part, index) => {
+  const images: ToolResultImage[] = [];
+  for (const [index, part] of content.entries()) {
     if (part?.type !== "image") {
-      return [];
+      continue;
     }
 
     const imagePart = part as { data?: unknown; mimeType?: unknown };
     if (typeof imagePart.data !== "string" || imagePart.data.trim().length === 0) {
-      return [];
+      continue;
     }
 
     const mimeType =
@@ -127,14 +145,14 @@ function getToolResultImages(content: RuntimeMessage["content"]): ToolResultImag
         : "image/png";
     const data = imagePart.data.trim();
 
-    return [
-      {
-        src: data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`,
-        mimeType,
-        alt: `Tool result image ${index + 1}`,
-      },
-    ];
-  });
+    images.push({
+      src: data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`,
+      mimeType,
+      alt: `Tool result image ${index + 1}`,
+    });
+  }
+
+  return images;
 }
 
 function extractUserContent(content: RuntimeMessage["content"]) {

--- a/shared/thread-history.ts
+++ b/shared/thread-history.ts
@@ -13,15 +13,22 @@ export type SessionPathEntry = {
   firstKeptEntryId?: string;
 };
 
-function countDisplayableEntries(entries: SessionPathEntry[]) {
+function isDisplayableEntry(entry: SessionPathEntry) {
+  return (
+    entry.type === "message" || entry.type === "custom_message" || entry.type === "branch_summary"
+  );
+}
+
+function countDisplayableEntriesInRange(
+  entries: SessionPathEntry[],
+  startIndex: number,
+  endIndex: number,
+) {
   let count = 0;
 
-  for (const entry of entries) {
-    if (
-      entry.type === "message" ||
-      entry.type === "custom_message" ||
-      entry.type === "branch_summary"
-    ) {
+  for (let index = startIndex; index < endIndex; index += 1) {
+    const entry = entries[index];
+    if (entry && isDisplayableEntry(entry)) {
       count += 1;
     }
   }
@@ -76,42 +83,72 @@ function appendEntryMessage(messages: AgentMessage[], entry: SessionPathEntry) {
 export function buildSourceMessagesFromPathEntries(pathEntries: SessionPathEntry[]) {
   const messages: AgentMessage[] = [];
 
-  for (const entry of pathEntries) {
-    appendEntryMessage(messages, entry);
-  }
+  appendSourceMessagesFromEntryRange(messages, pathEntries, 0, pathEntries.length);
 
   return messages;
+}
+
+function appendSourceMessagesFromEntryRange(
+  messages: AgentMessage[],
+  pathEntries: SessionPathEntry[],
+  startIndex: number,
+  endIndex: number,
+) {
+  for (let index = startIndex; index < endIndex; index += 1) {
+    const entry = pathEntries[index];
+    if (entry) {
+      appendEntryMessage(messages, entry);
+    }
+  }
+}
+
+function getSelectedCompactionIndex(pathEntries: SessionPathEntry[], revealedCompactions: number) {
+  if (revealedCompactions < 0) {
+    return -1;
+  }
+
+  let remainingCompactionsToSkip = revealedCompactions;
+
+  for (let index = pathEntries.length - 1; index >= 0; index -= 1) {
+    if (pathEntries[index]?.type !== "compaction") {
+      continue;
+    }
+
+    if (remainingCompactionsToSkip === 0) {
+      return index;
+    }
+
+    remainingCompactionsToSkip -= 1;
+  }
+
+  return -1;
+}
+
+function findEntryIndexById(pathEntries: SessionPathEntry[], entryId: string) {
+  for (let index = 0; index < pathEntries.length; index += 1) {
+    if (pathEntries[index]?.id === entryId) {
+      return index;
+    }
+  }
+
+  return -1;
 }
 
 export function buildThreadHistorySlice(
   pathEntries: SessionPathEntry[],
   revealedCompactions: number,
 ) {
-  const compactionIndexes = pathEntries.flatMap((entry, index) =>
-    entry.type === "compaction" ? [index] : [],
-  );
-
-  if (compactionIndexes.length === 0) {
+  const selectedCompactionIndex = getSelectedCompactionIndex(pathEntries, revealedCompactions);
+  if (selectedCompactionIndex === -1) {
     return {
       sourceMessages: buildSourceMessagesFromPathEntries(pathEntries),
       previousMessageCount: 0,
     };
   }
 
-  const selectedCompactionListIndex = compactionIndexes.length - 1 - revealedCompactions;
-  if (selectedCompactionListIndex < 0) {
-    return {
-      sourceMessages: buildSourceMessagesFromPathEntries(pathEntries),
-      previousMessageCount: 0,
-    };
-  }
-
-  const selectedCompactionIndex = compactionIndexes[selectedCompactionListIndex];
   const selectedCompaction = pathEntries[selectedCompactionIndex];
   const firstKeptEntryId = selectedCompaction?.firstKeptEntryId;
-  const firstKeptIndex = firstKeptEntryId
-    ? pathEntries.findIndex((entry) => entry.id === firstKeptEntryId)
-    : -1;
+  const firstKeptIndex = firstKeptEntryId ? findEntryIndexById(pathEntries, firstKeptEntryId) : -1;
 
   if (!selectedCompaction || firstKeptIndex === -1 || firstKeptIndex > selectedCompactionIndex) {
     return {
@@ -120,12 +157,16 @@ export function buildThreadHistorySlice(
     };
   }
 
+  const sourceMessages: AgentMessage[] = [];
+  appendSourceMessagesFromEntryRange(
+    sourceMessages,
+    pathEntries,
+    firstKeptIndex,
+    pathEntries.length,
+  );
+
   return {
-    sourceMessages: buildSourceMessagesFromPathEntries([
-      ...pathEntries.slice(firstKeptIndex, selectedCompactionIndex),
-      selectedCompaction,
-      ...pathEntries.slice(selectedCompactionIndex + 1),
-    ]),
-    previousMessageCount: countDisplayableEntries(pathEntries.slice(0, firstKeptIndex)),
+    sourceMessages,
+    previousMessageCount: countDisplayableEntriesInRange(pathEntries, 0, firstKeptIndex),
   };
 }

--- a/shared/thread-inbox.ts
+++ b/shared/thread-inbox.ts
@@ -3,23 +3,25 @@ import type { Message, ProseMessage } from "./desktop-contracts";
 type AssistantMessage = ProseMessage & { role: "assistant" };
 
 export function getLatestInboxAssistantMessage(messages: Message[]) {
-  const lastUserMessageIndex = [...messages]
-    .map((message, index) => ({ message, index }))
-    .reverse()
-    .find(({ message }) => message.role === "user")?.index;
+  let lastUserMessageIndex: number | undefined;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") {
+      lastUserMessageIndex = index;
+      break;
+    }
+  }
 
   const turnMessages =
     typeof lastUserMessageIndex === "number" ? messages.slice(lastUserMessageIndex + 1) : messages;
 
-  const latestAssistantMessage = [...turnMessages]
-    .reverse()
-    .find((message): message is AssistantMessage => {
-      if (message.role !== "assistant") {
-        return false;
-      }
-
-      return message.content.some((part) => part.trim().length > 0);
-    });
+  let latestAssistantMessage: AssistantMessage | undefined;
+  for (let index = turnMessages.length - 1; index >= 0; index -= 1) {
+    const message = turnMessages[index];
+    if (message?.role === "assistant" && message.content.some((part) => part.trim().length > 0)) {
+      latestAssistantMessage = message as AssistantMessage;
+      break;
+    }
+  }
 
   if (!latestAssistantMessage) {
     return null;

--- a/shared/thread-inbox.ts
+++ b/shared/thread-inbox.ts
@@ -3,22 +3,21 @@ import type { Message, ProseMessage } from "./desktop-contracts";
 type AssistantMessage = ProseMessage & { role: "assistant" };
 
 export function getLatestInboxAssistantMessage(messages: Message[]) {
-  let lastUserMessageIndex: number | undefined;
+  let turnStartIndex = 0;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     if (messages[index]?.role === "user") {
-      lastUserMessageIndex = index;
+      turnStartIndex = index + 1;
       break;
     }
   }
 
-  const turnMessages =
-    typeof lastUserMessageIndex === "number" ? messages.slice(lastUserMessageIndex + 1) : messages;
-
   let latestAssistantMessage: AssistantMessage | undefined;
-  for (let index = turnMessages.length - 1; index >= 0; index -= 1) {
-    const message = turnMessages[index];
+  let latestAssistantIndex = -1;
+  for (let index = messages.length - 1; index >= turnStartIndex; index -= 1) {
+    const message = messages[index];
     if (message?.role === "assistant" && message.content.some((part) => part.trim().length > 0)) {
       latestAssistantMessage = message as AssistantMessage;
+      latestAssistantIndex = index;
       break;
     }
   }
@@ -27,20 +26,31 @@ export function getLatestInboxAssistantMessage(messages: Message[]) {
     return null;
   }
 
-  const content = latestAssistantMessage.content.map((part) => part.trim()).filter(Boolean);
+  const content: string[] = [];
+  for (const part of latestAssistantMessage.content) {
+    const trimmedPart = part.trim();
+    if (trimmedPart) {
+      content.push(trimmedPart);
+    }
+  }
+
   if (content.length === 0) {
     return null;
   }
 
-  const latestAssistantIndex = turnMessages.lastIndexOf(latestAssistantMessage);
-  const hasLaterTurnWork = turnMessages.slice(latestAssistantIndex + 1).some((message) => {
-    return (
+  let hasLaterTurnWork = false;
+  for (let index = latestAssistantIndex + 1; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (
       message.role === "assistant" ||
       message.role === "user" ||
       message.role === "toolResult" ||
       message.role === "bashExecution"
-    );
-  });
+    ) {
+      hasLaterTurnWork = true;
+      break;
+    }
+  }
 
   if (hasLaterTurnWork) {
     return null;

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -92,7 +92,8 @@ export async function runPostDesktopActionEffects({
           ? getPayloadThreadIds(contextualPayload)
           : [];
 
-    if (archivedThreadIds.includes(workspaceState.selectedThreadId ?? "")) {
+    const selectedThreadId = workspaceState.selectedThreadId;
+    if (selectedThreadId && new Set(archivedThreadIds).has(selectedThreadId)) {
       dispatch({ type: "show-view", view: "code" });
     }
 
@@ -133,7 +134,8 @@ export async function runPostDesktopActionEffects({
             : getPayloadThreadIds(contextualPayload)
           : [];
 
-    if (deletedThreadIds.includes(workspaceState.selectedThreadId ?? "")) {
+    const selectedThreadId = workspaceState.selectedThreadId;
+    if (selectedThreadId && new Set(deletedThreadIds).has(selectedThreadId)) {
       dispatch({ type: "show-view", view: "code" });
     }
 

--- a/src/app/components/sidebar/project-tree/ProjectThreadsList.tsx
+++ b/src/app/components/sidebar/project-tree/ProjectThreadsList.tsx
@@ -30,15 +30,18 @@ function partitionProjectThreads(project: Project) {
   }
 
   const cutoffMs = Date.now() - OLD_THREAD_THRESHOLD_MS;
+  const recentThreads: Project["threads"] = [];
+  const oldThreads: Project["threads"] = [];
 
-  return {
-    recentThreads: project.threads.filter(
-      (thread) => (thread.lastModifiedMs ?? Number.MAX_SAFE_INTEGER) >= cutoffMs,
-    ),
-    oldThreads: project.threads.filter(
-      (thread) => (thread.lastModifiedMs ?? Number.MAX_SAFE_INTEGER) < cutoffMs,
-    ),
-  };
+  for (const thread of project.threads) {
+    if ((thread.lastModifiedMs ?? Number.MAX_SAFE_INTEGER) >= cutoffMs) {
+      recentThreads.push(thread);
+    } else {
+      oldThreads.push(thread);
+    }
+  }
+
+  return { recentThreads, oldThreads };
 }
 
 function ProjectThreadsGroup({

--- a/src/app/components/workspace/composer/composer-attachment-kind-lookup.ts
+++ b/src/app/components/workspace/composer/composer-attachment-kind-lookup.ts
@@ -1,0 +1,24 @@
+import type { ComposerAttachment } from "../../../desktop/types";
+
+const externalUrlPattern = /^https?:\/\//i;
+
+export function buildLocalAttachmentKindLookup(attachments: ComposerAttachment[]) {
+  const localPathSet = new Set<string>();
+  const fallbackKindsByPath: Record<string, ComposerAttachment["kind"]> = {};
+
+  for (const attachment of attachments) {
+    const trimmedPath = attachment.path.trim();
+    if (trimmedPath.length === 0 || externalUrlPattern.test(trimmedPath)) {
+      continue;
+    }
+
+    localPathSet.add(trimmedPath);
+    fallbackKindsByPath[attachment.path] = attachment.kind;
+    fallbackKindsByPath[trimmedPath] = attachment.kind;
+  }
+
+  return {
+    fallbackKindsByPath,
+    localPaths: [...localPathSet],
+  };
+}

--- a/src/app/components/workspace/composer/composer-file-picker-utils.ts
+++ b/src/app/components/workspace/composer/composer-file-picker-utils.ts
@@ -7,6 +7,7 @@ import {
   openExternalQuery,
   openPathQuery,
 } from "../../../query/desktop-query";
+import { buildLocalAttachmentKindLookup } from "./composer-attachment-kind-lookup";
 import { getComposerAttachmentsFromClipboardData } from "./composer-paste-attachments";
 
 export type ComposerFilePickerRootOption = {
@@ -111,14 +112,7 @@ export async function getDroppedComposerAttachments(dataTransfer: DataTransfer) 
   const rawAttachments = getComposerAttachmentsFromClipboardData(dataTransfer, {
     resolveFilePath: (file) => getPathForFileQuery(file as File) ?? null,
   });
-  const localPaths = [
-    ...new Set(rawAttachments.map((attachment) => attachment.path.trim())),
-  ].filter((path) => path.length > 0 && !/^https?:\/\//i.test(path));
-  const fallbackKindsByPath = Object.fromEntries(
-    rawAttachments
-      .filter((attachment) => !/^https?:\/\//i.test(attachment.path.trim()))
-      .map((attachment) => [attachment.path, attachment.kind] as const),
-  );
+  const { fallbackKindsByPath, localPaths } = buildLocalAttachmentKindLookup(rawAttachments);
   let kindsByPath: Record<string, ComposerAttachment["kind"] | null> | null = null;
 
   try {

--- a/src/app/components/workspace/composer/composerDraftStore.ts
+++ b/src/app/components/workspace/composer/composerDraftStore.ts
@@ -148,7 +148,23 @@ export function createComposerDraftStore({
       return false;
     }
 
-    return JSON.stringify(left) === JSON.stringify(right);
+    if (
+      left.prompt !== right.prompt ||
+      left.pickerOpen !== right.pickerOpen ||
+      left.attachments.length !== right.attachments.length
+    ) {
+      return false;
+    }
+
+    return left.attachments.every((leftAttachment, index) => {
+      const rightAttachment = right.attachments[index];
+      return (
+        rightAttachment !== undefined &&
+        leftAttachment.path === rightAttachment.path &&
+        leftAttachment.name === rightAttachment.name &&
+        leftAttachment.kind === rightAttachment.kind
+      );
+    });
   };
 
   const writeDraft = (threadId: string, nextDraft: ComposerDraft) => {

--- a/src/app/components/workspace/composer/composerDraftStore.ts
+++ b/src/app/components/workspace/composer/composerDraftStore.ts
@@ -124,13 +124,14 @@ export function createComposerDraftStore({
     recordKey: "draftsByThreadId",
     toEntry: toDraft,
   });
+  let draftCount = Object.keys(draftsByThreadId).length;
 
   const persistence = createStoragePersistence({
     storage,
     storageKey,
     debounceMs,
     beforeUnloadTarget,
-    hasEntries: () => Object.keys(draftsByThreadId).length > 0,
+    hasEntries: () => draftCount > 0,
     serialize: () => serializeDrafts(draftsByThreadId),
   });
 
@@ -176,17 +177,26 @@ export function createComposerDraftStore({
       nextDraft.attachments.length === 0 &&
       !nextDraft.pickerOpen
     ) {
-      delete draftsByThreadId[threadId];
+      if (threadId in draftsByThreadId) {
+        delete draftsByThreadId[threadId];
+        draftCount -= 1;
+      }
 
       if (mirroredThreadId && areDraftsEqual(draftsByThreadId[mirroredThreadId], previousDraft)) {
         delete draftsByThreadId[mirroredThreadId];
+        draftCount -= 1;
       }
     } else {
+      const addsThreadDraft = !(threadId in draftsByThreadId);
+      const addsMirroredDraft = Boolean(
+        mirroredThreadId && !(mirroredThreadId in draftsByThreadId),
+      );
       draftsByThreadId = {
         ...draftsByThreadId,
         [threadId]: cloneDraft(nextDraft),
         ...(mirroredThreadId ? { [mirroredThreadId]: cloneDraft(nextDraft) } : {}),
       };
+      draftCount += (addsThreadDraft ? 1 : 0) + (addsMirroredDraft ? 1 : 0);
     }
 
     persistence.schedulePersist();
@@ -236,17 +246,13 @@ export function createComposerDraftStore({
       const mirroredThreadId = getMirroredProjectDraftThreadId(threadId);
       const previousDraft = draftsByThreadId[threadId];
 
-      draftsByThreadId = Object.fromEntries(
-        Object.entries(draftsByThreadId).filter(
-          ([currentThreadId, currentDraft]) =>
-            currentThreadId !== threadId &&
-            !(
-              mirroredThreadId &&
-              currentThreadId === mirroredThreadId &&
-              areDraftsEqual(currentDraft, previousDraft)
-            ),
-        ),
-      );
+      delete draftsByThreadId[threadId];
+      draftCount -= 1;
+
+      if (mirroredThreadId && areDraftsEqual(draftsByThreadId[mirroredThreadId], previousDraft)) {
+        delete draftsByThreadId[mirroredThreadId];
+        draftCount -= 1;
+      }
       persistence.schedulePersist();
     },
     flush: persistence.flush,

--- a/src/app/components/workspace/composer/useComposerClipboardHandlers.ts
+++ b/src/app/components/workspace/composer/useComposerClipboardHandlers.ts
@@ -24,6 +24,7 @@ import {
   getPreferredClipboardTextFromClipboardSnapshot,
   hasAttachmentHintInClipboardData,
 } from "./composer-paste-attachments";
+import { buildLocalAttachmentKindLookup } from "./composer-attachment-kind-lookup";
 
 function applyPastedTextToTextarea(textarea: HTMLTextAreaElement, pastedText: string) {
   const selectionStart = textarea.selectionStart ?? textarea.value.length;
@@ -49,15 +50,8 @@ async function resolveDesktopAttachmentKinds(paths: string[]) {
 }
 
 async function normalizeDesktopAttachments(attachments: ComposerAttachment[]) {
-  const localPaths = [...new Set(attachments.map((attachment) => attachment.path.trim()))].filter(
-    (path) => path.length > 0 && !/^https?:\/\//i.test(path),
-  );
+  const { fallbackKindsByPath, localPaths } = buildLocalAttachmentKindLookup(attachments);
   const kindsByPath = await resolveDesktopAttachmentKinds(localPaths);
-  const fallbackKindsByPath = Object.fromEntries(
-    attachments
-      .filter((attachment) => !/^https?:\/\//i.test(attachment.path.trim()))
-      .map((attachment) => [attachment.path, attachment.kind] as const),
-  );
   const hasLookup = kindsByPath !== null;
 
   return normalizeComposerAttachments(attachments, {

--- a/src/app/components/workspace/diff/diffCommentStore.ts
+++ b/src/app/components/workspace/diff/diffCommentStore.ts
@@ -175,6 +175,7 @@ export function createDiffCommentStore({
     recordKey: "contextsById",
     toEntry: toContext,
   });
+  let contextCount = Object.keys(contextsById).length;
   const listeners = new Set<DiffCommentStoreListener>();
 
   const notifyListeners = () => {
@@ -188,18 +189,25 @@ export function createDiffCommentStore({
     storageKey,
     debounceMs,
     beforeUnloadTarget,
-    hasEntries: () => Object.keys(contextsById).length > 0,
+    hasEntries: () => contextCount > 0,
     serialize: () => serializeContexts(contextsById),
   });
 
   const writeContext = (contextId: string, context: DiffCommentContext) => {
     if (isContextEmpty(context)) {
-      delete contextsById[contextId];
+      if (contextId in contextsById) {
+        delete contextsById[contextId];
+        contextCount -= 1;
+      }
     } else {
+      const addsContext = !(contextId in contextsById);
       contextsById = {
         ...contextsById,
         [contextId]: cloneContext(context),
       };
+      if (addsContext) {
+        contextCount += 1;
+      }
     }
 
     notifyListeners();
@@ -221,6 +229,7 @@ export function createDiffCommentStore({
       }
 
       delete contextsById[contextId];
+      contextCount -= 1;
       notifyListeners();
       persistence.schedulePersist();
     },

--- a/src/app/components/workspace/thread/thread-timeline-signatures.ts
+++ b/src/app/components/workspace/thread/thread-timeline-signatures.ts
@@ -109,27 +109,37 @@ export function getRowStructureSignature(
   rows: TimelineRow[],
   collapsedRowIds: Record<string, boolean>,
 ) {
-  return rows
-    .map((row) => {
-      if (row.kind === "history-divider") {
-        return `${row.id}:${row.hiddenCount}`;
-      }
+  let signature = "";
 
-      if (row.kind === "turn") {
-        return `${row.id}:${collapsedRowIds[row.id] ? "collapsed" : "expanded"}:${row.items.length}`;
-      }
+  for (const row of rows) {
+    if (signature) {
+      signature += "||";
+    }
 
-      if (row.kind === "summary") {
-        return `${row.id}:${collapsedRowIds[row.id] ? "collapsed" : "expanded"}`;
-      }
+    if (row.kind === "history-divider") {
+      signature += `${row.id}:${row.hiddenCount}`;
+      continue;
+    }
 
-      if (row.kind === "tool-group") {
-        return `${row.id}:${row.messages.length}`;
-      }
+    if (row.kind === "turn") {
+      signature += `${row.id}:${collapsedRowIds[row.id] ? "collapsed" : "expanded"}:${row.items.length}`;
+      continue;
+    }
 
-      return `${row.id}:${row.message.id}`;
-    })
-    .join("||");
+    if (row.kind === "summary") {
+      signature += `${row.id}:${collapsedRowIds[row.id] ? "collapsed" : "expanded"}`;
+      continue;
+    }
+
+    if (row.kind === "tool-group") {
+      signature += `${row.id}:${row.messages.length}`;
+      continue;
+    }
+
+    signature += `${row.id}:${row.message.id}`;
+  }
+
+  return signature;
 }
 
 export function getFoldableRows(rows: TimelineRow[]) {

--- a/src/app/components/workspace/thread/thread-timeline-signatures.ts
+++ b/src/app/components/workspace/thread/thread-timeline-signatures.ts
@@ -31,10 +31,14 @@ export function getStreamingAssistantMessageId(messages: Message[], isStreaming:
     return null;
   }
 
-  const latestAssistantMessage = [...messages]
-    .reverse()
-    .find((message) => message.role === "assistant");
-  return latestAssistantMessage?.id ?? null;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === "assistant") {
+      return message.id;
+    }
+  }
+
+  return null;
 }
 
 export function getStreamingToolGroupId(
@@ -51,7 +55,12 @@ export function getStreamingToolGroupId(
     return null;
   }
 
-  for (const row of [...rows].reverse()) {
+  for (let rowIndex = rows.length - 1; rowIndex >= 0; rowIndex -= 1) {
+    const row = rows[rowIndex];
+    if (!row) {
+      continue;
+    }
+
     if (row.kind === "tool-group") {
       if (row.messages.some((message) => message.id === latestMessage.id)) {
         return row.id;
@@ -64,7 +73,12 @@ export function getStreamingToolGroupId(
       continue;
     }
 
-    for (const item of [...row.items].reverse()) {
+    for (let itemIndex = row.items.length - 1; itemIndex >= 0; itemIndex -= 1) {
+      const item = row.items[itemIndex];
+      if (!item) {
+        continue;
+      }
+
       if (item.kind !== "tool-group") {
         continue;
       }

--- a/src/app/components/workspace/thread/thread-timeline-signatures.ts
+++ b/src/app/components/workspace/thread/thread-timeline-signatures.ts
@@ -5,6 +5,19 @@ function isToolCallRole(message: Message | undefined) {
   return message?.role === "toolResult" || message?.role === "bashExecution";
 }
 
+function getJoinedLength(parts: string[] | undefined, separatorLength: number) {
+  if (!parts || parts.length === 0) {
+    return 0;
+  }
+
+  let length = separatorLength * (parts.length - 1);
+  for (const part of parts) {
+    length += part.length;
+  }
+
+  return length;
+}
+
 export function getMessageRenderSignature(message: Message | undefined) {
   if (!message) {
     return "empty";
@@ -16,11 +29,11 @@ export function getMessageRenderSignature(message: Message | undefined) {
     case "custom":
     case "branchSummary":
     case "compactionSummary":
-      return `${message.id}:${message.role}:${message.content.join("\n").length}`;
+      return `${message.id}:${message.role}:${getJoinedLength(message.content, 1)}`;
     case "assistant":
-      return `${message.id}:${message.role}:${message.content.join("\n").length}:${message.thinkingContent?.join("\n").length ?? 0}:${message.thinkingHeaders?.join(",").length ?? 0}`;
+      return `${message.id}:${message.role}:${getJoinedLength(message.content, 1)}:${getJoinedLength(message.thinkingContent, 1)}:${getJoinedLength(message.thinkingHeaders, 1)}`;
     case "bashExecution":
-      return `${message.id}:${message.role}:${message.command.length}:${message.output.join("\n").length}`;
+      return `${message.id}:${message.role}:${message.command.length}:${getJoinedLength(message.output, 1)}`;
     default:
       return "unknown";
   }

--- a/src/app/components/workspace/thread/thread-timeline-state.ts
+++ b/src/app/components/workspace/thread/thread-timeline-state.ts
@@ -20,7 +20,14 @@ function getExpandedStateSignature(
 }
 
 function getLatestTurnRowId(rows: TimelineRow[]) {
-  return [...rows].reverse().find((row) => row.kind === "turn")?.id ?? null;
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (row?.kind === "turn") {
+      return row.id;
+    }
+  }
+
+  return null;
 }
 
 function getStreamingTurnRowId({

--- a/src/app/views/ArchivedThreadsView.tsx
+++ b/src/app/views/ArchivedThreadsView.tsx
@@ -35,14 +35,22 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
     () => visibleThreads.map((thread) => thread.id),
     [visibleThreads],
   );
-  const selectedVisibleThreads = useMemo(
-    () => visibleThreads.filter((thread) => selectedThreadIdSet.has(thread.id)),
-    [selectedThreadIdSet, visibleThreads],
-  );
-  const selectedVisibleProjectIds = useMemo(
-    () => [...new Set(selectedVisibleThreads.map((thread) => thread.projectId))],
-    [selectedVisibleThreads],
-  );
+  const visibleProjectIds = useMemo(() => {
+    const projectIds = new Set<string>();
+    for (const thread of visibleThreads) {
+      projectIds.add(thread.projectId);
+    }
+    return [...projectIds];
+  }, [visibleThreads]);
+  const selectedVisibleProjectIds = useMemo(() => {
+    const projectIds = new Set<string>();
+    for (const thread of visibleThreads) {
+      if (selectedThreadIdSet.has(thread.id)) {
+        projectIds.add(thread.projectId);
+      }
+    }
+    return [...projectIds];
+  }, [selectedThreadIdSet, visibleThreads]);
 
   useEffect(() => {
     const threadIds = new Set(threads.map((thread) => thread.id));
@@ -166,7 +174,7 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
                   void runArchivedThreadMutation({
                     action: "thread.delete-many",
                     busyState: "delete",
-                    projectIds: [...new Set(visibleThreads.map((thread) => thread.projectId))],
+                    projectIds: visibleProjectIds,
                     threadIds: visibleThreadIds,
                   });
                 }}
@@ -203,13 +211,7 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
                   void runArchivedThreadMutation({
                     action: "thread.restore-many",
                     busyState: "restore",
-                    projectIds: [
-                      ...new Set(
-                        visibleThreads
-                          .filter((thread) => selectedThreadIdSet.has(thread.id))
-                          .map((thread) => thread.projectId),
-                      ),
-                    ],
+                    projectIds: selectedVisibleProjectIds,
                     threadIds: selectedThreadIds,
                   });
                 }}

--- a/src/app/views/ArchivedThreadsView.tsx
+++ b/src/app/views/ArchivedThreadsView.tsx
@@ -22,17 +22,22 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
   const deleteAllButtonRef = useRef<HTMLButtonElement>(null);
   const deleteSelectedButtonRef = useRef<HTMLButtonElement>(null);
 
+  const optimisticallyHiddenThreadIdSet = useMemo(
+    () => new Set(optimisticallyHiddenThreadIds),
+    [optimisticallyHiddenThreadIds],
+  );
+  const selectedThreadIdSet = useMemo(() => new Set(selectedThreadIds), [selectedThreadIds]);
   const visibleThreads = useMemo(
-    () => threads.filter((thread) => !optimisticallyHiddenThreadIds.includes(thread.id)),
-    [optimisticallyHiddenThreadIds, threads],
+    () => threads.filter((thread) => !optimisticallyHiddenThreadIdSet.has(thread.id)),
+    [optimisticallyHiddenThreadIdSet, threads],
   );
   const visibleThreadIds = useMemo(
     () => visibleThreads.map((thread) => thread.id),
     [visibleThreads],
   );
   const selectedVisibleThreads = useMemo(
-    () => visibleThreads.filter((thread) => selectedThreadIds.includes(thread.id)),
-    [selectedThreadIds, visibleThreads],
+    () => visibleThreads.filter((thread) => selectedThreadIdSet.has(thread.id)),
+    [selectedThreadIdSet, visibleThreads],
   );
   const selectedVisibleProjectIds = useMemo(
     () => [...new Set(selectedVisibleThreads.map((thread) => thread.projectId))],
@@ -83,7 +88,10 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
 
     setBusyAction(busyState);
     setOptimisticallyHiddenThreadIds((current) => [...new Set([...current, ...threadIds])]);
-    setSelectedThreadIds((current) => current.filter((threadId) => !threadIds.includes(threadId)));
+    const mutationThreadIdSet = new Set(threadIds);
+    setSelectedThreadIds((current) =>
+      current.filter((threadId) => !mutationThreadIdSet.has(threadId)),
+    );
 
     try {
       const result = await onAction(
@@ -106,20 +114,22 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
               (threadId): threadId is string => typeof threadId === "string",
             )
           : [];
+        const deletedThreadIdSet = new Set(deletedThreadIds);
         const restoredThreadIds =
           failedThreadIds.length > 0
             ? failedThreadIds
             : deletedThreadIds.length > 0
-              ? threadIds.filter((threadId) => !deletedThreadIds.includes(threadId))
+              ? threadIds.filter((threadId) => !deletedThreadIdSet.has(threadId))
               : threadIds;
+        const restoredThreadIdSet = new Set(restoredThreadIds);
 
         setOptimisticallyHiddenThreadIds((current) =>
-          current.filter((threadId) => !restoredThreadIds.includes(threadId)),
+          current.filter((threadId) => !restoredThreadIdSet.has(threadId)),
         );
       }
     } catch {
       setOptimisticallyHiddenThreadIds((current) =>
-        current.filter((threadId) => !threadIds.includes(threadId)),
+        current.filter((threadId) => !mutationThreadIdSet.has(threadId)),
       );
     }
 
@@ -196,7 +206,7 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
                     projectIds: [
                       ...new Set(
                         visibleThreads
-                          .filter((thread) => selectedThreadIds.includes(thread.id))
+                          .filter((thread) => selectedThreadIdSet.has(thread.id))
                           .map((thread) => thread.projectId),
                       ),
                     ],
@@ -249,7 +259,7 @@ export function ArchivedThreadsView({ threads, onAction }: ArchivedThreadsViewPr
               <input
                 type="checkbox"
                 className="h-4 w-4 accent-[color:var(--accent)]"
-                checked={selectedThreadIds.includes(thread.id)}
+                checked={selectedThreadIdSet.has(thread.id)}
                 onChange={() =>
                   setSelectedThreadIds((current) =>
                     current.includes(thread.id)

--- a/src/test/thread-history.test.ts
+++ b/src/test/thread-history.test.ts
@@ -18,6 +18,10 @@ function messageEntry(
   };
 }
 
+function messageSignature(slice: ReturnType<typeof buildThreadHistorySlice>) {
+  return slice.sourceMessages.map((message) => `${message.timestamp}:${message.role}`);
+}
+
 describe("buildThreadHistorySlice", () => {
   const pathEntries: SessionPathEntry[] = [
     messageEntry("u1", 1, "user", "u1"),
@@ -50,7 +54,7 @@ describe("buildThreadHistorySlice", () => {
     const slice = buildThreadHistorySlice(pathEntries, 0);
 
     expect(slice.previousMessageCount).toBe(4);
-    expect(slice.sourceMessages.map((message) => `${message.timestamp}:${message.role}`)).toEqual([
+    expect(messageSignature(slice)).toEqual([
       "6:user",
       "7:assistant",
       "8:compactionSummary",
@@ -63,7 +67,7 @@ describe("buildThreadHistorySlice", () => {
     const slice = buildThreadHistorySlice(pathEntries, 1);
 
     expect(slice.previousMessageCount).toBe(2);
-    expect(slice.sourceMessages.map((message) => `${message.timestamp}:${message.role}`)).toEqual([
+    expect(messageSignature(slice)).toEqual([
       "3:user",
       "4:assistant",
       "5:compactionSummary",
@@ -79,7 +83,7 @@ describe("buildThreadHistorySlice", () => {
     const slice = buildThreadHistorySlice(pathEntries, 2);
 
     expect(slice.previousMessageCount).toBe(0);
-    expect(slice.sourceMessages.map((message) => `${message.timestamp}:${message.role}`)).toEqual([
+    expect(messageSignature(slice)).toEqual([
       "1:user",
       "2:assistant",
       "3:user",
@@ -91,5 +95,86 @@ describe("buildThreadHistorySlice", () => {
       "9:user",
       "10:assistant",
     ]);
+  });
+
+  it("falls back to full history when compaction metadata is unusable", () => {
+    const missingFirstKeptId = buildThreadHistorySlice(
+      [
+        messageEntry("u1", 1, "user", "u1"),
+        {
+          type: "compaction",
+          id: "c1",
+          summary: "summary 1",
+          timestamp: 2,
+          tokensBefore: 100,
+        },
+        messageEntry("u2", 3, "user", "u2"),
+      ],
+      0,
+    );
+    expect(missingFirstKeptId.previousMessageCount).toBe(0);
+    expect(messageSignature(missingFirstKeptId)).toEqual([
+      "1:user",
+      "2:compactionSummary",
+      "3:user",
+    ]);
+
+    const firstKeptAfterCompaction = buildThreadHistorySlice(
+      [
+        messageEntry("u1", 1, "user", "u1"),
+        {
+          type: "compaction",
+          id: "c1",
+          summary: "summary 1",
+          firstKeptEntryId: "u2",
+          timestamp: 2,
+          tokensBefore: 100,
+        },
+        messageEntry("u2", 3, "user", "u2"),
+      ],
+      0,
+    );
+    expect(firstKeptAfterCompaction.previousMessageCount).toBe(0);
+    expect(messageSignature(firstKeptAfterCompaction)).toEqual([
+      "1:user",
+      "2:compactionSummary",
+      "3:user",
+    ]);
+  });
+
+  it("preserves current display/count behavior for non-message entries", () => {
+    const slice = buildThreadHistorySlice(
+      [
+        messageEntry("u1", 1, "user", "u1"),
+        {
+          type: "custom_message",
+          id: "hidden-custom",
+          customType: "notice",
+          content: "hidden",
+          display: false,
+          timestamp: 2,
+        },
+        {
+          type: "branch_summary",
+          id: "branch-summary",
+          summary: "branch summary",
+          timestamp: 3,
+        },
+        messageEntry("u2", 4, "user", "u2"),
+        {
+          type: "compaction",
+          id: "c1",
+          summary: "summary 1",
+          firstKeptEntryId: "u2",
+          timestamp: 5,
+          tokensBefore: 100,
+        },
+        messageEntry("a2", 6, "assistant", "a2"),
+      ],
+      0,
+    );
+
+    expect(slice.previousMessageCount).toBe(3);
+    expect(messageSignature(slice)).toEqual(["4:user", "5:compactionSummary", "6:assistant"]);
   });
 });


### PR DESCRIPTION
## Summary
- Applies a series of low-risk performance cleanups found during the repo performance sweep.
- Removes avoidable array copies, duplicate scans, temporary joined strings, and unbounded concurrency in hot-ish paths.
- Keeps behavior-preserving changes only; larger/behavior-sensitive optimizations are tracked separately.

## Notable changes
- Replaced clone-then-reverse scans with reverse loops in timeline, inbox, runtime publishing, and message mapper paths.
- Reduced allocation-heavy derivations in thread timeline signatures, archived threads, thread history slicing, and composer/diff persisted stores.
- Added bounded concurrency for session summary reads and inbox prompt backfills.
- Consolidated attachment kind lookup derivation and trimmed several map/filter/fromEntries chains into single-pass loops.

## Follow-up issues
Refs #117
Refs #118
Refs #119
Refs #120

## Validation
- Every slice was committed independently after targeted validation.
- Pre-commit/pre-push hooks ran repeatedly across the series.
- Latest push ran `bun run lint` and full `bun run typecheck` successfully.
- Full Vitest suite passed in commit hooks after each slice.
