### PR TITLE
Stream runtime tool and system messages

### DIFF
--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -3,10 +3,16 @@ import { getPiModule } from "../pi-module.cts";
 import { buildComposerState } from "./composer-state.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
 import { createRuntimeSettingsRefreshController, isRuntimeBusy } from "./settings-refresh.ts";
-import { publishComposerUpdate, publishThreadUpdate } from "./thread-publisher.cts";
+import {
+  clearRuntimeToolProgress,
+  publishComposerUpdate,
+  publishThreadUpdate,
+  rememberRuntimeToolProgress,
+} from "./thread-publisher.cts";
 import type { PiRuntime } from "./types.cts";
 
 const RUNTIME_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
+const LIVE_THREAD_UPDATE_THROTTLE_MS = 50;
 
 type RuntimeRecord = {
   runtimePromise: Promise<PiRuntime>;
@@ -15,6 +21,7 @@ type RuntimeRecord = {
 
 const runtimeRecords = new Map<string, RuntimeRecord>();
 const runtimeMutationTails = new Map<string, Promise<void>>();
+const liveThreadUpdateTimers = new WeakMap<PiRuntime, ReturnType<typeof setTimeout>>();
 const settingsRefreshController = createRuntimeSettingsRefreshController({
   getCachedRuntimeForSessionPath,
   getRuntimeRecords: () =>
@@ -73,6 +80,51 @@ function scheduleRuntimeDisposal(runtimeKey: string) {
       }
     })();
   }, RUNTIME_IDLE_TIMEOUT_MS);
+}
+
+function publishLiveThreadUpdate(runtime: PiRuntime) {
+  void publishThreadUpdate(runtime, "update");
+}
+
+function cancelLiveThreadUpdate(runtime: PiRuntime) {
+  const timer = liveThreadUpdateTimers.get(runtime);
+  if (!timer) {
+    return;
+  }
+
+  clearTimeout(timer);
+  liveThreadUpdateTimers.delete(runtime);
+}
+
+function deferLiveThreadUpdate(runtime: PiRuntime, options: { requireStreaming?: boolean } = {}) {
+  cancelLiveThreadUpdate(runtime);
+  const timer = setTimeout(() => {
+    liveThreadUpdateTimers.delete(runtime);
+    if (options.requireStreaming !== false && !runtime.session.isStreaming) {
+      return;
+    }
+
+    publishLiveThreadUpdate(runtime);
+  }, 0);
+
+  liveThreadUpdateTimers.set(runtime, timer);
+}
+
+function scheduleLiveThreadUpdate(runtime: PiRuntime) {
+  if (liveThreadUpdateTimers.has(runtime)) {
+    return;
+  }
+
+  const timer = setTimeout(() => {
+    liveThreadUpdateTimers.delete(runtime);
+    if (!runtime.session.isStreaming) {
+      return;
+    }
+
+    publishLiveThreadUpdate(runtime);
+  }, LIVE_THREAD_UPDATE_THROTTLE_MS);
+
+  liveThreadUpdateTimers.set(runtime, timer);
 }
 
 export async function reloadRuntimeSettingsIfSafe(
@@ -134,9 +186,24 @@ async function createRuntime(options: {
       suspendRuntimeDisposal(runtimeKey);
     }
 
+    if (event.type === "message_start") {
+      scheduleLiveThreadUpdate(runtime);
+      return;
+    }
+
     if (event.type === "message_end") {
       if (event.message.role === "user") {
+        cancelLiveThreadUpdate(runtime);
         void publishThreadUpdate(runtime, "start");
+      } else {
+        if (event.message.role === "toolResult") {
+          const toolCallId = "toolCallId" in event.message ? event.message.toolCallId : undefined;
+          clearRuntimeToolProgress(runtime, {
+            toolCallId: typeof toolCallId === "string" ? toolCallId : undefined,
+            toolName: event.message.toolName,
+          });
+        }
+        deferLiveThreadUpdate(runtime, { requireStreaming: event.message.role === "toolResult" });
       }
 
       if (runtimeKey) {
@@ -147,6 +214,7 @@ async function createRuntime(options: {
     }
 
     if (event.type === "agent_end") {
+      cancelLiveThreadUpdate(runtime);
       void publishThreadUpdate(runtime, "end");
 
       if (runtimeKey && settingsRefreshController.isStale(runtimeKey)) {
@@ -163,6 +231,7 @@ async function createRuntime(options: {
     }
 
     if (event.type === "compaction_start") {
+      cancelLiveThreadUpdate(runtime);
       void publishThreadUpdate(runtime, "compaction-start");
 
       void buildComposerState(runtime)
@@ -181,6 +250,7 @@ async function createRuntime(options: {
 
     if (event.type === "compaction_end") {
       setTimeout(() => {
+        cancelLiveThreadUpdate(runtime);
         void publishThreadUpdate(runtime, "compaction");
 
         void buildComposerState(runtime)
@@ -204,8 +274,30 @@ async function createRuntime(options: {
       return;
     }
 
-    if (event.type === "message_update" && event.message.role === "assistant") {
-      void publishThreadUpdate(runtime, "update");
+    if (event.type === "message_update") {
+      scheduleLiveThreadUpdate(runtime);
+      return;
+    }
+
+    if (
+      event.type === "tool_execution_start" ||
+      event.type === "tool_execution_update" ||
+      event.type === "tool_execution_end"
+    ) {
+      rememberRuntimeToolProgress(runtime, {
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        args: "args" in event ? event.args : undefined,
+        partialResult:
+          event.type === "tool_execution_update"
+            ? event.partialResult
+            : event.type === "tool_execution_end"
+              ? event.result
+              : undefined,
+        isError: event.type === "tool_execution_end" ? event.isError : false,
+        terminal: event.type === "tool_execution_end",
+      });
+      scheduleLiveThreadUpdate(runtime);
       return;
     }
 

--- a/desktop/runtime/thread-publisher.cts
+++ b/desktop/runtime/thread-publisher.cts
@@ -27,6 +27,116 @@ import {
 import { rememberSessionPath } from "./session-path-index.cts";
 import type { PiRuntime, RuntimeThreadReason } from "./types.cts";
 
+type RuntimeToolProgress = {
+  toolCallId: string;
+  toolName: string;
+  args?: unknown;
+  partialResult?: { content?: unknown };
+  isError?: boolean;
+  terminal?: boolean;
+};
+
+const liveToolProgressByRuntime = new WeakMap<PiRuntime, Map<string, RuntimeToolProgress>>();
+
+function getLiveToolProgress(runtime: PiRuntime) {
+  let progress = liveToolProgressByRuntime.get(runtime);
+  if (!progress) {
+    progress = new Map();
+    liveToolProgressByRuntime.set(runtime, progress);
+  }
+
+  return progress;
+}
+
+function getLiveToolProgressMessages(runtime: PiRuntime) {
+  const progress = liveToolProgressByRuntime.get(runtime);
+  if (!progress || progress.size === 0) {
+    return [] as AgentMessage[];
+  }
+
+  return [...progress.values()].map((entry) => {
+    const content = entry.partialResult?.content;
+    const displayContent = hasDisplayableToolContent(content)
+      ? content
+      : [
+          {
+            type: "text",
+            text: entry.terminal
+              ? entry.isError
+                ? `${entry.toolName} failed.`
+                : `${entry.toolName} finished.`
+              : `Running ${entry.toolName}...`,
+          },
+        ];
+
+    return {
+      role: "toolResult",
+      toolName: entry.toolName,
+      isError: Boolean(entry.isError),
+      content: displayContent,
+      timestamp: `tool-progress:${entry.toolCallId}`,
+    } as unknown as AgentMessage;
+  });
+}
+
+function hasDisplayableToolContent(content: unknown): content is string | unknown[] {
+  if (typeof content === "string") {
+    return content.trim().length > 0;
+  }
+
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  return content.some((part) => {
+    if (typeof part === "string") {
+      return part.trim().length > 0;
+    }
+
+    if (!part || typeof part !== "object") {
+      return false;
+    }
+
+    const record = part as Record<string, unknown>;
+    if (record.type === "image") {
+      return true;
+    }
+
+    return typeof record.text === "string" && record.text.trim().length > 0;
+  });
+}
+
+export function rememberRuntimeToolProgress(runtime: PiRuntime, entry: RuntimeToolProgress) {
+  getLiveToolProgress(runtime).set(entry.toolCallId, entry);
+}
+
+export function clearRuntimeToolProgress(
+  runtime: PiRuntime,
+  options: { toolCallId?: string; toolName?: string } = {},
+) {
+  const progress = liveToolProgressByRuntime.get(runtime);
+  if (!progress) {
+    return;
+  }
+
+  if (options.toolCallId) {
+    progress.delete(options.toolCallId);
+  } else if (!options.toolName) {
+    progress.clear();
+  } else {
+    for (const [toolCallId, entry] of progress) {
+      if (entry.toolName === options.toolName) {
+        progress.delete(toolCallId);
+        break;
+      }
+    }
+  }
+
+  if (progress.size === 0) {
+    liveToolProgressByRuntime.delete(runtime);
+  }
+}
+
 function buildLiveThreadData(runtime: PiRuntime) {
   const sessionPath = runtime.session.sessionFile;
   if (!sessionPath) {
@@ -41,6 +151,7 @@ function buildLiveThreadData(runtime: PiRuntime) {
   const sourceMessages = [
     ...historySlice.sourceMessages,
     ...(streamingMessage ? [streamingMessage] : []),
+    ...getLiveToolProgressMessages(runtime),
   ] as AgentMessage[];
 
   return buildThreadData({

--- a/shared/desktop-thread-contracts.ts
+++ b/shared/desktop-thread-contracts.ts
@@ -99,6 +99,13 @@ export type CustomThreadMessage = {
   content: string[];
 };
 
+export type SystemThreadMessage = {
+  id: string;
+  role: "system";
+  label: string;
+  content: string[];
+};
+
 export type SummaryThreadMessage = {
   id: string;
   role: "branchSummary" | "compactionSummary";
@@ -110,6 +117,7 @@ export type Message =
   | ToolResultMessage
   | BashExecutionMessage
   | CustomThreadMessage
+  | SystemThreadMessage
   | SummaryThreadMessage;
 
 export type ThreadData = {

--- a/shared/pi-message-mapper.ts
+++ b/shared/pi-message-mapper.ts
@@ -174,6 +174,30 @@ function extractUserContent(content: RuntimeMessage["content"]) {
   return [text, ...imageLabels].filter(Boolean);
 }
 
+function extractDisplayContent(content: RuntimeMessage["content"]) {
+  if (typeof content === "string") {
+    return splitParagraphs(content);
+  }
+
+  if (!Array.isArray(content)) {
+    return [] as string[];
+  }
+
+  const textParts = getTextParts(content).flatMap((part) => splitParagraphs(part));
+  const imageCount = getImageCount(content);
+  const imageLabels = Array.from(
+    { length: imageCount },
+    (_, index) => `Attached image ${index + 1}`,
+  );
+
+  return [...textParts, ...imageLabels].filter(Boolean);
+}
+
+function normalizeSystemLabel(role: string | undefined) {
+  const label = role?.trim() || "message";
+  return label === "system" ? "System" : label;
+}
+
 function extractAssistantContent(message: RuntimeMessage) {
   const content = getTextParts(message.content)
     .flatMap((part) => splitParagraphs(part))
@@ -288,7 +312,7 @@ export function mapAgentMessageToUiMessage(message: AgentMessage, index: number)
     }
 
     case "custom": {
-      const content = extractUserContent(runtimeMessage.content);
+      const content = extractDisplayContent(runtimeMessage.content);
       if (content.length === 0) {
         return null;
       }
@@ -297,6 +321,20 @@ export function mapAgentMessageToUiMessage(message: AgentMessage, index: number)
         id,
         role: "custom",
         customType: runtimeMessage.customType ?? "custom",
+        content,
+      };
+    }
+
+    case "system": {
+      const content = extractDisplayContent(runtimeMessage.content);
+      if (content.length === 0) {
+        return null;
+      }
+
+      return {
+        id,
+        role: "system",
+        label: "System",
         content,
       };
     }
@@ -314,8 +352,19 @@ export function mapAgentMessageToUiMessage(message: AgentMessage, index: number)
       };
     }
 
-    default:
-      return null;
+    default: {
+      const content = extractDisplayContent(runtimeMessage.content);
+      if (content.length === 0) {
+        return null;
+      }
+
+      return {
+        id,
+        role: "system",
+        label: normalizeSystemLabel(runtimeMessage.role),
+        content,
+      };
+    }
   }
 }
 

--- a/src/app/components/common/ThreadMessage.tsx
+++ b/src/app/components/common/ThreadMessage.tsx
@@ -245,11 +245,22 @@ export const ThreadMessage = memo(function ThreadMessage({
 
   if (message.role === "custom") {
     return (
-      <div className="grid min-w-0 gap-2 rounded-2xl border border-dashed border-[color:var(--border)] px-4 py-3 text-[13px] text-[color:var(--text)]/84">
+      <div className="grid min-w-0 gap-2 rounded-2xl border border-dashed border-[color:var(--border)] bg-[rgba(255,255,255,0.012)] px-4 py-3 text-[13px] text-[color:var(--text)]/84">
         <div className="break-words text-[12px] uppercase tracking-[0.08em] text-[color:var(--muted)] [overflow-wrap:anywhere]">
           {message.customType}
         </div>
         {renderProse(message.content)}
+      </div>
+    );
+  }
+
+  if (message.role === "system") {
+    return (
+      <div className="grid min-w-0 gap-2 rounded-xl border border-[rgba(169,178,215,0.05)] bg-[rgba(255,255,255,0.01)] px-3 py-2 text-[12.5px] italic text-[color:var(--muted)]/92">
+        <div className="break-words text-[11px] not-italic uppercase tracking-[0.08em] text-[color:var(--muted-2)]/84 [overflow-wrap:anywhere]">
+          {message.label}
+        </div>
+        {renderThinking(message.content)}
       </div>
     );
   }

--- a/src/app/components/workspace/thread/thread-timeline-previews.ts
+++ b/src/app/components/workspace/thread/thread-timeline-previews.ts
@@ -6,6 +6,7 @@ export function getMessagePreview(message: Message) {
   switch (message.role) {
     case "user":
     case "custom":
+    case "system":
     case "branchSummary":
     case "compactionSummary":
       return message.content.join(" ").trim();

--- a/src/app/components/workspace/thread/thread-timeline-signatures.ts
+++ b/src/app/components/workspace/thread/thread-timeline-signatures.ts
@@ -27,6 +27,7 @@ export function getMessageRenderSignature(message: Message | undefined) {
     case "user":
     case "toolResult":
     case "custom":
+    case "system":
     case "branchSummary":
     case "compactionSummary":
       return `${message.id}:${message.role}:${getJoinedLength(message.content, 1)}`;

--- a/src/test/pi-message-mapper.test.ts
+++ b/src/test/pi-message-mapper.test.ts
@@ -126,6 +126,48 @@ describe("pi message mapper", () => {
     ]);
   });
 
+  it("preserves displayed extension and system messages", () => {
+    expect(
+      mapAgentMessagesToUiMessages([
+        {
+          role: "custom",
+          timestamp: 1,
+          customType: "review-extension",
+          content: "Review queued\n\nWaiting for Codex",
+        },
+        {
+          role: "system",
+          timestamp: 2,
+          content: [{ type: "text", text: "Extension loaded" }],
+        },
+        {
+          role: "extensionNotice",
+          timestamp: 3,
+          content: [{ type: "text", text: "A non-standard Pi message" }],
+        },
+      ] as never[]),
+    ).toEqual([
+      {
+        id: "1-custom",
+        role: "custom",
+        customType: "review-extension",
+        content: ["Review queued", "Waiting for Codex"],
+      },
+      {
+        id: "2-system",
+        role: "system",
+        label: "System",
+        content: ["Extension loaded"],
+      },
+      {
+        id: "3-extensionNotice",
+        role: "system",
+        label: "extensionNotice",
+        content: ["A non-standard Pi message"],
+      },
+    ]);
+  });
+
   it("preserves thinking-only messages and extracts thinking headers", () => {
     expect(
       mapAgentMessagesToUiMessages([


### PR DESCRIPTION
## Summary
- Publish runtime thread updates for message/tool execution lifecycle events so live tool/subagent output can appear incrementally.
- Track transient live tool progress and render running/terminal fallback text safely until final tool result messages are persisted.
- Preserve and render Pi custom/system/unknown non-empty messages instead of silently dropping them.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 29 files / 127 tests passed

Refs #132
Refs #133