### PR TITLE
Keep composer content visible until send handoff

### DIFF
--- a/src/app/components/workspace/composer/submitComposerDraft.ts
+++ b/src/app/components/workspace/composer/submitComposerDraft.ts
@@ -16,25 +16,21 @@ type SubmitComposerDraftResult =
 type SubmitComposerDraftOptions = {
   draft: string;
   attachments: ComposerAttachment[];
-  draftThreadId: string | null;
   isSending: boolean;
   projectId: string;
   sessionPath: string | null;
   streamingBehaviorPreference: ComposerStreamingBehavior;
   onAction: DesktopActionInvoker;
-  clearStoredDraft: (threadId: string) => void;
 };
 
 export async function submitComposerDraft({
   draft,
   attachments,
-  draftThreadId,
   isSending,
   projectId,
   sessionPath,
   streamingBehaviorPreference,
   onAction,
-  clearStoredDraft,
 }: SubmitComposerDraftOptions): Promise<SubmitComposerDraftResult> {
   const text = draft.trim();
   if ((text.length === 0 && attachments.length === 0) || isSending) {
@@ -62,10 +58,6 @@ export async function submitComposerDraft({
 
     if (actionResult?.result?.composerSendOutcome === "stopped") {
       return { status: "stopped", text };
-    }
-
-    if (draftThreadId && !isCompactSlashCommand(text)) {
-      clearStoredDraft(draftThreadId);
     }
 
     return { status: "sent", text };

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -121,15 +121,24 @@ export function useComposerController({
     setDraft(nextValue);
   }, []);
 
+  const setAttachmentValue = useCallback((value: SetStateAction<ComposerAttachment[]>) => {
+    const nextValue =
+      typeof value === "function"
+        ? (value as (current: ComposerAttachment[]) => ComposerAttachment[])(attachmentsRef.current)
+        : value;
+    attachmentsRef.current = nextValue;
+    setAttachments(nextValue);
+  }, []);
+
   useEffect(() => {
     skipNextDraftPersistenceRef.current = draftThreadId;
 
     const persistedDraft = draftThreadId ? composerDraftStore.getDraft(draftThreadId) : null;
     setDraftValue(persistedDraft?.prompt ?? "");
-    setAttachments(persistedDraft?.attachments ?? []);
+    setAttachmentValue(persistedDraft?.attachments ?? []);
     setOpenMenu(persistedDraft?.pickerOpen ? "picker" : null);
     setErrorMessage(null);
-  }, [draftThreadId, setDraftValue]);
+  }, [draftThreadId, setAttachmentValue, setDraftValue]);
 
   useEffect(() => {
     if (!draftThreadId) {
@@ -233,7 +242,7 @@ export function useComposerController({
     openMenu,
     pickerRootPath: projectId,
     pickerSessionKey: draftThreadId,
-    setAttachments,
+    setAttachments: setAttachmentValue,
     setErrorMessage,
     setOpenMenu,
     onListAttachmentEntries,
@@ -264,7 +273,7 @@ export function useComposerController({
     onAction,
     projectId,
     sessionPath,
-    setAttachments,
+    setAttachments: setAttachmentValue,
     setDraftValue,
     setErrorMessage,
     setIsSending,
@@ -282,7 +291,7 @@ export function useComposerController({
   const modelLabel = useMemo(() => getModelLabel(model), [model]);
 
   const { handleDrop, handlePaste } = useComposerClipboardHandlers({
-    setAttachments,
+    setAttachments: setAttachmentValue,
     setDraftValue,
     setErrorMessage,
   });

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -11,6 +11,108 @@ import { withComposerSendLock } from "./composerSendLock";
 import { isCompactSlashCommand } from "../../../../../shared/composer-slash-commands";
 import { submitComposerDraft } from "./submitComposerDraft";
 
+function isSameSubmittedDraft(currentDraft: string, submittedRawDraft: string) {
+  return currentDraft === submittedRawDraft;
+}
+
+function areSameAttachments(
+  currentAttachments: ComposerAttachment[],
+  submittedAttachments: ComposerAttachment[],
+) {
+  if (currentAttachments === submittedAttachments) {
+    return true;
+  }
+
+  if (currentAttachments.length !== submittedAttachments.length) {
+    return false;
+  }
+
+  return currentAttachments.every((attachment, index) => {
+    const submittedAttachment = submittedAttachments[index];
+    return (
+      attachment.path === submittedAttachment?.path &&
+      attachment.name === submittedAttachment.name &&
+      attachment.kind === submittedAttachment.kind
+    );
+  });
+}
+
+function isSameAttachment(left: ComposerAttachment, right: ComposerAttachment) {
+  return left.path === right.path && left.name === right.name && left.kind === right.kind;
+}
+
+function removeSubmittedAttachments(
+  currentAttachments: ComposerAttachment[],
+  submittedAttachments: ComposerAttachment[],
+) {
+  const remainingSubmittedAttachments = [...submittedAttachments];
+
+  return currentAttachments.filter((attachment) => {
+    const submittedIndex = remainingSubmittedAttachments.findIndex((submittedAttachment) =>
+      isSameAttachment(attachment, submittedAttachment),
+    );
+
+    if (submittedIndex === -1) {
+      return true;
+    }
+
+    remainingSubmittedAttachments.splice(submittedIndex, 1);
+    return false;
+  });
+}
+
+export type ComposerPostSendCleanup = {
+  clearStoredDraft: boolean;
+  clearStoredPrompt: boolean;
+  clearDraft: boolean;
+  nextAttachments: ComposerAttachment[] | null;
+  skipNextDraftPersistence: boolean;
+};
+
+export function getComposerPostSendCleanup({
+  activeDraftThreadId,
+  submittedDraftThreadId,
+  preserveAttachments,
+  currentDraft,
+  submittedRawDraft,
+  currentAttachments,
+  submittedAttachments,
+}: {
+  activeDraftThreadId: string | null;
+  submittedDraftThreadId: string | null;
+  preserveAttachments: boolean;
+  currentDraft: string;
+  submittedRawDraft: string;
+  currentAttachments: ComposerAttachment[];
+  submittedAttachments: ComposerAttachment[];
+}): ComposerPostSendCleanup {
+  const isActiveSubmittedDraft = activeDraftThreadId === submittedDraftThreadId;
+  const draftUnchanged = currentDraft === submittedRawDraft;
+  const attachmentsUnchanged = areSameAttachments(currentAttachments, submittedAttachments);
+  const nextAttachments =
+    isActiveSubmittedDraft && !preserveAttachments
+      ? removeSubmittedAttachments(currentAttachments, submittedAttachments)
+      : null;
+  const shouldClearStoredDraft = Boolean(
+    submittedDraftThreadId &&
+      !preserveAttachments &&
+      (!isActiveSubmittedDraft || (draftUnchanged && attachmentsUnchanged)),
+  );
+  const shouldClearStoredPrompt = Boolean(
+    submittedDraftThreadId && preserveAttachments && (!isActiveSubmittedDraft || draftUnchanged),
+  );
+  const clearDraft = isActiveSubmittedDraft && draftUnchanged;
+
+  return {
+    clearStoredDraft: shouldClearStoredDraft,
+    clearStoredPrompt: shouldClearStoredPrompt,
+    clearDraft,
+    nextAttachments,
+    skipNextDraftPersistence:
+      shouldClearStoredDraft && isActiveSubmittedDraft && draftUnchanged && attachmentsUnchanged,
+  };
+}
+
 type UseComposerSubmissionProps = {
   composerScopeKey: string;
   draftThreadId: string | null;
@@ -78,7 +180,8 @@ export function useComposerSubmission({
           return;
         }
 
-        const textToSend = draftValueRef.current.trim();
+        const submittedRawDraft = draftValueRef.current;
+        const textToSend = submittedRawDraft.trim();
         const submittedAttachments = attachmentsRef.current;
         if (textToSend.length === 0 && submittedAttachments.length === 0) {
           return;
@@ -89,34 +192,59 @@ export function useComposerSubmission({
 
         setErrorMessage(null);
         setOpenMenu(null);
-        if (!preserveAttachments) {
-          skipNextDraftPersistenceRef.current = submittedDraftThreadId;
-        }
-        setDraftValue("");
-        if (!preserveAttachments) {
-          setAttachments([]);
-        }
 
         const result = await submitComposerDraft({
           draft: submittedDraft,
           attachments: submittedAttachments,
-          draftThreadId: submittedDraftThreadId,
           isSending: false,
           projectId: submittedProjectId,
           sessionPath: submittedSessionPath,
           streamingBehaviorPreference,
           onAction,
-          clearStoredDraft: (threadId) => composerDraftStore.clearThreadDraft(threadId),
         });
+
+        if (result.status === "sent") {
+          const cleanup = getComposerPostSendCleanup({
+            activeDraftThreadId: activeDraftThreadIdRef.current,
+            submittedDraftThreadId,
+            preserveAttachments,
+            currentDraft: draftValueRef.current,
+            submittedRawDraft,
+            currentAttachments: attachmentsRef.current,
+            submittedAttachments,
+          });
+
+          if (cleanup.clearStoredDraft && submittedDraftThreadId) {
+            if (cleanup.skipNextDraftPersistence) {
+              skipNextDraftPersistenceRef.current = submittedDraftThreadId;
+            }
+            composerDraftStore.clearThreadDraft(submittedDraftThreadId);
+          }
+
+          if (cleanup.clearStoredPrompt && submittedDraftThreadId) {
+            composerDraftStore.setPrompt(submittedDraftThreadId, "");
+          }
+
+          if (cleanup.clearDraft) {
+            setDraftValue("");
+          }
+
+          if (cleanup.nextAttachments !== null) {
+            setAttachments(cleanup.nextAttachments);
+          }
+        }
 
         if (
           result.status === "error" &&
           activeDraftThreadIdRef.current === submittedDraftThreadId
         ) {
-          setDraftValue((currentDraft) => (currentDraft.length === 0 ? result.text : currentDraft));
-          setAttachments((currentAttachments) =>
-            currentAttachments.length === 0 ? submittedAttachments : currentAttachments,
-          );
+          if (
+            isSameSubmittedDraft(draftValueRef.current, submittedRawDraft) &&
+            areSameAttachments(attachmentsRef.current, submittedAttachments)
+          ) {
+            setDraftValue(result.text);
+            setAttachments(submittedAttachments);
+          }
           setErrorMessage(result.errorMessage);
         }
 
@@ -124,10 +252,13 @@ export function useComposerSubmission({
           result.status === "stopped" &&
           activeDraftThreadIdRef.current === submittedDraftThreadId
         ) {
-          setDraftValue((currentDraft) => (currentDraft.length === 0 ? result.text : currentDraft));
-          setAttachments((currentAttachments) =>
-            currentAttachments.length === 0 ? submittedAttachments : currentAttachments,
-          );
+          if (
+            isSameSubmittedDraft(draftValueRef.current, submittedRawDraft) &&
+            areSameAttachments(attachmentsRef.current, submittedAttachments)
+          ) {
+            setDraftValue(result.text);
+            setAttachments(submittedAttachments);
+          }
         }
       } finally {
         setIsSending(false);
@@ -196,13 +327,11 @@ export function useComposerSubmission({
         const result = await submitComposerDraft({
           draft: "/compact",
           attachments: [],
-          draftThreadId: null,
           isSending: false,
           projectId,
           sessionPath,
           streamingBehaviorPreference,
           onAction,
-          clearStoredDraft: (threadId) => composerDraftStore.clearThreadDraft(threadId),
         });
 
         if (result.status === "error") {

--- a/src/test/composer-submission-cleanup.test.ts
+++ b/src/test/composer-submission-cleanup.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { getComposerPostSendCleanup } from "../app/components/workspace/composer/useComposerSubmission";
+import type { ComposerAttachment } from "../app/desktop/types";
+
+const submittedAttachments: ComposerAttachment[] = [
+  { path: "/repo/a.png", name: "a.png", kind: "image" },
+];
+const changedAttachments: ComposerAttachment[] = [
+  { path: "/repo/b.png", name: "b.png", kind: "image" },
+];
+
+describe("getComposerPostSendCleanup", () => {
+  it("clears the active unchanged non-compact draft and stored draft", () => {
+    expect(
+      getComposerPostSendCleanup({
+        activeDraftThreadId: "thread:1",
+        submittedDraftThreadId: "thread:1",
+        preserveAttachments: false,
+        currentDraft: "ship it",
+        submittedRawDraft: "ship it",
+        currentAttachments: submittedAttachments,
+        submittedAttachments,
+      }),
+    ).toEqual({
+      clearStoredDraft: true,
+      clearStoredPrompt: false,
+      clearDraft: true,
+      nextAttachments: [],
+      skipNextDraftPersistence: true,
+    });
+  });
+
+  it("clears a submitted stored draft after navigation without touching current UI", () => {
+    expect(
+      getComposerPostSendCleanup({
+        activeDraftThreadId: "thread:2",
+        submittedDraftThreadId: "thread:1",
+        preserveAttachments: false,
+        currentDraft: "other thread draft",
+        submittedRawDraft: "ship it",
+        currentAttachments: [],
+        submittedAttachments,
+      }),
+    ).toEqual({
+      clearStoredDraft: true,
+      clearStoredPrompt: false,
+      clearDraft: false,
+      nextAttachments: null,
+      skipNextDraftPersistence: false,
+    });
+  });
+
+  it("clears sent text but preserves attachments changed during handoff", () => {
+    expect(
+      getComposerPostSendCleanup({
+        activeDraftThreadId: "thread:1",
+        submittedDraftThreadId: "thread:1",
+        preserveAttachments: false,
+        currentDraft: "ship it",
+        submittedRawDraft: "ship it",
+        currentAttachments: changedAttachments,
+        submittedAttachments,
+      }),
+    ).toEqual({
+      clearStoredDraft: false,
+      clearStoredPrompt: false,
+      clearDraft: true,
+      nextAttachments: changedAttachments,
+      skipNextDraftPersistence: false,
+    });
+  });
+
+  it("preserves queued/restored draft text while removing submitted attachments", () => {
+    expect(
+      getComposerPostSendCleanup({
+        activeDraftThreadId: "thread:1",
+        submittedDraftThreadId: "thread:1",
+        preserveAttachments: false,
+        currentDraft: "queued prompt restored while sending",
+        submittedRawDraft: "ship it",
+        currentAttachments: [...submittedAttachments, ...changedAttachments],
+        submittedAttachments,
+      }),
+    ).toEqual({
+      clearStoredDraft: false,
+      clearStoredPrompt: false,
+      clearDraft: false,
+      nextAttachments: changedAttachments,
+      skipNextDraftPersistence: false,
+    });
+  });
+
+  it("preserves compact command attachments and clears only the stored prompt", () => {
+    expect(
+      getComposerPostSendCleanup({
+        activeDraftThreadId: "thread:1",
+        submittedDraftThreadId: "thread:1",
+        preserveAttachments: true,
+        currentDraft: "/compact",
+        submittedRawDraft: "/compact",
+        currentAttachments: submittedAttachments,
+        submittedAttachments,
+      }),
+    ).toEqual({
+      clearStoredDraft: false,
+      clearStoredPrompt: true,
+      clearDraft: true,
+      nextAttachments: null,
+      skipNextDraftPersistence: false,
+    });
+  });
+
+  it("clears compact stored prompt after navigation without touching current UI", () => {
+    expect(
+      getComposerPostSendCleanup({
+        activeDraftThreadId: "thread:2",
+        submittedDraftThreadId: "thread:1",
+        preserveAttachments: true,
+        currentDraft: "other thread draft",
+        submittedRawDraft: "/compact",
+        currentAttachments: [],
+        submittedAttachments,
+      }),
+    ).toEqual({
+      clearStoredDraft: false,
+      clearStoredPrompt: true,
+      clearDraft: false,
+      nextAttachments: null,
+      skipNextDraftPersistence: false,
+    });
+  });
+
+  it("preserves text changed during handoff while removing submitted attachments", () => {
+    expect(
+      getComposerPostSendCleanup({
+        activeDraftThreadId: "thread:1",
+        submittedDraftThreadId: "thread:1",
+        preserveAttachments: false,
+        currentDraft: "ship it please",
+        submittedRawDraft: "ship it",
+        currentAttachments: submittedAttachments,
+        submittedAttachments,
+      }),
+    ).toEqual({
+      clearStoredDraft: false,
+      clearStoredPrompt: false,
+      clearDraft: false,
+      nextAttachments: [],
+      skipNextDraftPersistence: false,
+    });
+  });
+});

--- a/src/test/submit-composer-draft.test.ts
+++ b/src/test/submit-composer-draft.test.ts
@@ -31,20 +31,16 @@ function buildActionSuccessResult(outcome: "sent" | "stopped" = "sent") {
 }
 
 describe("submitComposerDraft", () => {
-  it("clears the stored draft after a successful send", async () => {
+  it("sends a draft successfully", async () => {
     const onAction = vi.fn(async () => buildActionSuccessResult());
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "  ship it  ",
       attachments: [{ path: "/repo/file.ts", name: "file.ts", kind: "text" }],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
       onAction,
-      clearStoredDraft,
     });
 
     expect(result).toEqual({ status: "sent", text: "ship it" });
@@ -55,16 +51,12 @@ describe("submitComposerDraft", () => {
       sessionPath: "/repo/thread.json",
       streamingBehavior: "followUp",
     });
-    expect(clearStoredDraft).toHaveBeenCalledWith("session:/repo/thread.json");
   });
 
   it("keeps the stored draft when send fails", async () => {
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "retry me",
       attachments: [],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
@@ -72,7 +64,6 @@ describe("submitComposerDraft", () => {
       onAction: vi.fn(async () => {
         throw new Error("network down");
       }),
-      clearStoredDraft,
     });
 
     expect(result).toEqual({
@@ -80,22 +71,17 @@ describe("submitComposerDraft", () => {
       errorMessage: "network down",
       text: "retry me",
     });
-    expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
   it("treats non-throwing send failures as errors", async () => {
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "retry me",
       attachments: [],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
       onAction: vi.fn(async () => buildActionFailureResult("composer.send", "bridge failed")),
-      clearStoredDraft,
     });
 
     expect(result).toEqual({
@@ -103,22 +89,17 @@ describe("submitComposerDraft", () => {
       errorMessage: "bridge failed",
       text: "retry me",
     });
-    expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
   it("treats null action results as errors", async () => {
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "retry me",
       attachments: [],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
       onAction: vi.fn(async () => null),
-      clearStoredDraft,
     });
 
     expect(result).toEqual({
@@ -126,22 +107,17 @@ describe("submitComposerDraft", () => {
       errorMessage: "Could not send prompt.",
       text: "retry me",
     });
-    expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
   it("treats non-throwing stop-mode send failures as errors", async () => {
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "stop me",
       attachments: [],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "stop",
       onAction: vi.fn(async () => buildActionFailureResult("composer.send", "stop failed")),
-      clearStoredDraft,
     });
 
     expect(result).toEqual({
@@ -149,67 +125,52 @@ describe("submitComposerDraft", () => {
       errorMessage: "stop failed",
       text: "stop me",
     });
-    expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
   it("returns stopped when runtime converts stop-mode send into a stop", async () => {
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "stop me",
       attachments: [],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "stop",
       onAction: vi.fn(async () => buildActionSuccessResult("stopped")),
-      clearStoredDraft,
     });
 
     expect(result).toEqual({
       status: "stopped",
       text: "stop me",
     });
-    expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
   it("skips blank drafts without dispatching", async () => {
     const onAction = vi.fn(async () => null);
-    const clearStoredDraft = vi.fn();
-
     await expect(
       submitComposerDraft({
         draft: "   ",
         attachments: [],
-        draftThreadId: "session:/repo/thread.json",
         isSending: false,
         projectId: "/repo",
         sessionPath: "/repo/thread.json",
         streamingBehaviorPreference: "followUp",
         onAction,
-        clearStoredDraft,
       }),
     ).resolves.toEqual({ status: "skipped" });
 
     expect(onAction).not.toHaveBeenCalled();
-    expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
   it("sends attachment-only drafts", async () => {
     const onAction = vi.fn(async () => buildActionSuccessResult());
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "   ",
       attachments: [{ path: "/repo/file.ts", name: "file.ts", kind: "text" }],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
       onAction,
-      clearStoredDraft,
     });
 
     expect(result).toEqual({ status: "sent", text: "" });
@@ -220,23 +181,18 @@ describe("submitComposerDraft", () => {
       sessionPath: "/repo/thread.json",
       streamingBehavior: "followUp",
     });
-    expect(clearStoredDraft).toHaveBeenCalledWith("session:/repo/thread.json");
   });
 
   it("sends compact commands without attachments and keeps stored attachments available", async () => {
     const onAction = vi.fn(async () => buildActionSuccessResult());
-    const clearStoredDraft = vi.fn();
-
     const result = await submitComposerDraft({
       draft: "  /compact keep repo state  ",
       attachments: [{ path: "/repo/file.ts", name: "file.ts", kind: "text" }],
-      draftThreadId: "session:/repo/thread.json",
       isSending: false,
       projectId: "/repo",
       sessionPath: "/repo/thread.json",
       streamingBehaviorPreference: "followUp",
       onAction,
-      clearStoredDraft,
     });
 
     expect(result).toEqual({ status: "sent", text: "/compact keep repo state" });
@@ -247,7 +203,6 @@ describe("submitComposerDraft", () => {
       sessionPath: "/repo/thread.json",
       streamingBehavior: "followUp",
     });
-    expect(clearStoredDraft).not.toHaveBeenCalled();
   });
 
   it("skips sends while a request is already in flight", async () => {
@@ -257,13 +212,11 @@ describe("submitComposerDraft", () => {
       submitComposerDraft({
         draft: "ship it",
         attachments: [],
-        draftThreadId: "session:/repo/thread.json",
         isSending: true,
         projectId: "/repo",
         sessionPath: "/repo/thread.json",
         streamingBehaviorPreference: "followUp",
         onAction,
-        clearStoredDraft: vi.fn(),
       }),
     ).resolves.toEqual({ status: "skipped" });
 


### PR DESCRIPTION
## Summary
- Delay composer clearing until `composer.send` has successfully handed off to the runtime.
- Preserve user edits made while a send is in flight, including queued/restored prompt text.
- Remove only attachments that were part of the successful send, while preserving newly-added attachments.
- Keep compact-command attachment preservation while clearing submitted compact prompt text from active and stored drafts.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 30 files / 134 tests passed

Closes #127