### PR TITLE
Fix image path paste attachments

### DIFF
--- a/desktop/pi-threads/action-router.cts
+++ b/desktop/pi-threads/action-router.cts
@@ -22,7 +22,7 @@ export async function handleDesktopAction(
     await handleThreadDesktopAction(action, payload),
     await handleComposerDesktopAction(action, payload),
     await handleWorkspaceDesktopAction(action, payload),
-    handleSettingsDesktopAction(action, payload),
+    await handleSettingsDesktopAction(action, payload),
     await handlePiSettingsDesktopAction(action, payload),
   ];
 

--- a/desktop/pi-threads/settings-actions.cts
+++ b/desktop/pi-threads/settings-actions.cts
@@ -1,3 +1,6 @@
+import { readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { DesktopAction } from "../../shared/desktop-actions.ts";
 import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts";
 import {
@@ -34,10 +37,41 @@ import {
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
 
-export function handleSettingsDesktopAction(
+const clipboardImageTempDir = path.join(tmpdir(), "howcode-clipboard-images");
+
+async function clearClipboardImageTempFiles() {
+  let entries: Array<{ isFile(): boolean; name: string }>;
+  try {
+    entries = await readdir(clipboardImageTempDir, { withFileTypes: true });
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return { clearedCount: 0, clearFailedCount: 0 };
+    }
+
+    return { clearedCount: 0, clearFailedCount: 1 };
+  }
+
+  const targets = entries.filter(
+    (entry) =>
+      entry.isFile() && entry.name.startsWith("howcode-clipboard-") && entry.name.endsWith(".png"),
+  );
+  const results = await Promise.allSettled(
+    targets.map((entry) => rm(path.join(clipboardImageTempDir, entry.name), { force: true })),
+  );
+  return {
+    clearedCount: results.filter((result) => result.status === "fulfilled").length,
+    clearFailedCount: results.filter((result) => result.status === "rejected").length,
+  };
+}
+
+export async function handleSettingsDesktopAction(
   action: DesktopAction,
   payload: AnyDesktopActionPayload,
-): ActionHandlerResult {
+): Promise<ActionHandlerResult> {
+  if (action === "settings.clear-clipboard-images") {
+    return handledAction(await clearClipboardImageTempFiles());
+  }
+
   if (action !== "settings.update") {
     return unhandledAction();
   }

--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -44,6 +44,7 @@ terminalManager.subscribeTerminalEvents((event) => {
 });
 
 const handlers: DesktopRequestHandlerMap = {
+  clearClipboardImages: () => ({ clearedCount: 0, clearFailedCount: 0 }),
   getShellState: () => piThreads.loadShellState(getDesktopWorkingDirectory()),
   getProjectGitState: ({ projectId }) => piThreads.loadProjectGitState(projectId),
   getProjectDiff: ({ projectId, baseline }) =>
@@ -67,6 +68,7 @@ const handlers: DesktopRequestHandlerMap = {
   pickComposerAttachments: () => [],
   readClipboardSnapshot: () => ({ formats: [], valuesByFormat: {} }),
   readClipboardFilePaths: () => ({ filePaths: [], text: null }),
+  readClipboardImage: () => null,
   getAttachmentKindsForPaths: async ({ paths }) => {
     const uniquePaths = [...new Set(Array.isArray(paths) ? paths : [])].filter(
       (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,

--- a/shared/composer-attachments.ts
+++ b/shared/composer-attachments.ts
@@ -2,9 +2,15 @@ import type { ComposerAttachment } from "./desktop-data-contracts";
 import { getSafeExternalUrl } from "./external-url";
 
 const imageAttachmentPattern = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
+const wrappingWhitespacePattern =
+  /^[\s\u00A0\u2000-\u200A\u202F\u205F\u3000]+|[\s\u00A0\u2000-\u200A\u202F\u205F\u3000]+$/g;
+
+function trimWrappingWhitespace(value: string) {
+  return value.replace(wrappingWhitespacePattern, "");
+}
 
 function stripWrappingCharacters(value: string) {
-  const trimmed = value.trim();
+  const trimmed = trimWrappingWhitespace(value);
 
   if (trimmed.length >= 2) {
     const first = trimmed[0];
@@ -15,11 +21,21 @@ function stripWrappingCharacters(value: string) {
       (first === "'" && last === "'") ||
       (first === "<" && last === ">")
     ) {
-      return trimmed.slice(1, -1).trim();
+      return trimWrappingWhitespace(trimmed.slice(1, -1));
     }
   }
 
   return trimmed;
+}
+
+function unescapeShellPath(value: string) {
+  // File paths copied from shells are often escaped as `/tmp/My\ Image.png`.
+  // Only do this for POSIX-looking paths so Windows separators stay intact.
+  if (!value.startsWith("/")) {
+    return value;
+  }
+
+  return value.replace(/\\([\\\s'"()\[\]{}&;!$`*?|<>])/g, "$1");
 }
 
 function decodeFileUrlPath(url: URL) {
@@ -127,7 +143,7 @@ export function normalizeComposerAttachments(
 }
 
 export function parseComposerAttachmentReference(rawReference: string): ComposerAttachment | null {
-  const candidate = stripWrappingCharacters(rawReference);
+  const candidate = unescapeShellPath(stripWrappingCharacters(rawReference));
   if (!candidate) {
     return null;
   }
@@ -161,7 +177,7 @@ export function parseComposerAttachmentReference(rawReference: string): Composer
 
 export function extractComposerAttachmentsFromPaste(
   pastedText: string,
-  options?: { sourceType?: string | null },
+  options?: { sourceType?: string | null; allowPartial?: boolean },
 ): ComposerAttachment[] {
   const trimmed = pastedText.trim();
   if (!trimmed) {
@@ -179,5 +195,9 @@ export function extractComposerAttachmentsFromPaste(
     .map((candidate) => parseComposerAttachmentReference(candidate))
     .filter((attachment): attachment is ComposerAttachment => attachment !== null);
 
-  return attachments.length === candidates.length ? mergeComposerAttachments([], attachments) : [];
+  if (attachments.length === candidates.length || options?.allowPartial) {
+    return mergeComposerAttachments([], attachments);
+  }
+
+  return [];
 }

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -131,6 +131,7 @@ export type DesktopActionPayloadMap = {
   "inbox.mark-read": { sessionPath: string; projectId?: string | null };
   "inbox.dismiss": { sessionPath: string; projectId?: string | null };
   "settings.update": DesktopSettingsUpdatePayload;
+  "settings.clear-clipboard-images": EmptyActionPayload;
   "pi-settings.update": { piSettingsKey: keyof PiSettings; value: string | number | boolean };
   "projects.import.scan": { projectIds: string[] };
   "projects.import.apply": { projectIds: string[] };
@@ -143,6 +144,8 @@ export type DesktopActionPayload<A extends DesktopAction = DesktopAction> =
 
 export type DesktopActionResultData = {
   checkedProjectCount?: number;
+  clearedCount?: number;
+  clearFailedCount?: number;
   committed?: boolean;
   composer?: ComposerState;
   composerSendOutcome?: "sent" | "stopped";

--- a/shared/desktop-actions.ts
+++ b/shared/desktop-actions.ts
@@ -31,6 +31,7 @@ export const desktopActions = [
   "inbox.mark-read",
   "inbox.dismiss",
   "settings.update",
+  "settings.clear-clipboard-images",
   "pi-settings.update",
   "projects.import.scan",
   "projects.import.apply",

--- a/shared/desktop-clipboard-contracts.ts
+++ b/shared/desktop-clipboard-contracts.ts
@@ -7,3 +7,8 @@ export type DesktopClipboardFilePaths = {
   filePaths: string[];
   text: string | null;
 };
+
+export type DesktopClipboardImage = {
+  path: string;
+  mimeType: string;
+} | null;

--- a/shared/desktop-ipc.ts
+++ b/shared/desktop-ipc.ts
@@ -4,6 +4,7 @@ import type {
   ArchivedThread,
   ComposerAttachment,
   DesktopClipboardFilePaths,
+  DesktopClipboardImage,
   DesktopClipboardSnapshot,
   ComposerFilePickerState,
   ComposerSlashCommand,
@@ -49,6 +50,10 @@ import type {
 } from "./terminal-contracts";
 
 export type DesktopRequestMap = {
+  clearClipboardImages: {
+    params: Record<string, never>;
+    response: { clearedCount: number; clearFailedCount: number };
+  };
   getShellState: { params: Record<string, never>; response: ShellState };
   getProjectGitState: { params: { projectId: string }; response: ProjectGitState | null };
   getProjectDiff: {
@@ -122,6 +127,10 @@ export type DesktopRequestMap = {
   readClipboardFilePaths: {
     params: Record<string, never>;
     response: DesktopClipboardFilePaths;
+  };
+  readClipboardImage: {
+    params: Record<string, never>;
+    response: DesktopClipboardImage;
   };
   getAttachmentKindsForPaths: {
     params: { paths: string[] };

--- a/src/app/components/workspace/composer/composer-paste-attachments.ts
+++ b/src/app/components/workspace/composer/composer-paste-attachments.ts
@@ -209,7 +209,10 @@ function getClipboardTextAttachments(clipboardData: ComposerClipboardDataLike) {
 
     attachments = mergeComposerAttachments(
       attachments,
-      extractComposerAttachmentsFromPaste(normalizedValue, { sourceType: type }),
+      extractComposerAttachmentsFromPaste(normalizedValue, {
+        sourceType: type,
+        allowPartial: attachmentHintClipboardTypes.has(type),
+      }),
     );
   }
 
@@ -300,7 +303,7 @@ export function getComposerAttachmentsFromClipboardFilePaths(
     return pathAttachments;
   }
 
-  return extractComposerAttachmentsFromPaste(clipboardFilePaths.text ?? "");
+  return extractComposerAttachmentsFromPaste(clipboardFilePaths.text ?? "", { allowPartial: true });
 }
 
 function createClipboardSnapshotSource(

--- a/src/app/components/workspace/composer/useComposerClipboardHandlers.ts
+++ b/src/app/components/workspace/composer/useComposerClipboardHandlers.ts
@@ -12,6 +12,7 @@ import {
   getAttachmentKindsForPathsQuery,
   getPathForFileQuery,
   readClipboardFilePathsQuery,
+  readClipboardImageQuery,
   readClipboardSnapshotQuery,
 } from "../../../query/desktop-query";
 import {
@@ -23,6 +24,7 @@ import {
   getPreferredClipboardTextFromClipboardFilePaths,
   getPreferredClipboardTextFromClipboardSnapshot,
   hasAttachmentHintInClipboardData,
+  hasFilePayloadInClipboardData,
 } from "./composer-paste-attachments";
 import { buildLocalAttachmentKindLookup } from "./composer-attachment-kind-lookup";
 
@@ -83,10 +85,13 @@ export function useComposerClipboardHandlers({
     }) => {
       const { clipboardData, textarea } = request;
       const directPastedText = getPreferredClipboardTextFromClipboardData(clipboardData);
+      const hasDirectAttachmentHint = hasAttachmentHintInClipboardData(clipboardData);
+      const hasDirectFilePayload = hasFilePayloadInClipboardData(clipboardData);
 
       const directAttachments = getComposerAttachmentsFromClipboardData(clipboardData, {
         resolveFilePath: resolveDesktopFilePath,
       });
+      const hasDirectAttachmentCandidate = directAttachments.length > 0;
       const normalizedDirectAttachments = await normalizeDesktopAttachments(directAttachments);
       if (normalizedDirectAttachments.length > 0) {
         setAttachments((current) => mergeComposerAttachments(current, normalizedDirectAttachments));
@@ -94,7 +99,7 @@ export function useComposerClipboardHandlers({
         return;
       }
 
-      if (directPastedText && !hasAttachmentHintInClipboardData(clipboardData)) {
+      if (directPastedText && !hasDirectAttachmentHint) {
         setDraftValue(applyPastedTextToTextarea(textarea, directPastedText));
         setErrorMessage(null);
         return;
@@ -134,12 +139,33 @@ export function useComposerClipboardHandlers({
         return;
       }
 
+      if (hasDirectFilePayload) {
+        const clipboardImageAttachment = await readClipboardImageQuery().catch(() => null);
+        if (clipboardImageAttachment) {
+          setAttachments((current) =>
+            mergeComposerAttachments(current, [clipboardImageAttachment]),
+          );
+          setErrorMessage(null);
+          return;
+        }
+      }
+
       const pastedText =
         directPastedText ||
         getPreferredClipboardTextFromClipboardFilePaths(fallbackClipboardFilePaths) ||
         getPreferredClipboardTextFromClipboardSnapshot(fallbackSnapshot);
 
       if (!pastedText) {
+        if (hasDirectAttachmentHint) {
+          setErrorMessage(
+            "Could not attach the pasted file path. Check that the file still exists.",
+          );
+        }
+        return;
+      }
+
+      if (hasDirectAttachmentCandidate && hasDirectAttachmentHint) {
+        setErrorMessage("Could not attach the pasted file path. Check that the file still exists.");
         return;
       }
 

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -5,6 +5,7 @@ export type {
   ComposerAttachment,
   ComposerContextUsage,
   DesktopClipboardFilePaths,
+  DesktopClipboardImage,
   DesktopClipboardSnapshot,
   ComposerFilePickerEntry,
   ComposerFilePickerState,

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -112,6 +112,7 @@ export function installDevWebDesktopBridge() {
   window.__howcodeDevWebBridge = true;
 
   window.piDesktop = {
+    clearClipboardImages: () => invokeRequest("clearClipboardImages", {}),
     getShellState: () => invokeRequest("getShellState", {}),
     getProjectGitState: (projectId: string) => invokeRequest("getProjectGitState", { projectId }),
     getProjectDiff: (projectId: string, baseline = null) =>
@@ -138,6 +139,7 @@ export function installDevWebDesktopBridge() {
     readClipboardSnapshot: (formats: string[] | null = null) =>
       invokeRequest("readClipboardSnapshot", { formats }),
     readClipboardFilePaths: () => invokeRequest("readClipboardFilePaths", {}),
+    readClipboardImage: () => invokeRequest("readClipboardImage", {}),
     getAttachmentKindsForPaths: (paths: string[]) =>
       invokeRequest("getAttachmentKindsForPaths", { paths }),
     getPathForFile: () => null,

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -227,6 +227,10 @@ export async function pickComposerAttachmentsQuery(
   return (await window.piDesktop?.pickComposerAttachments?.(projectId ?? null)) ?? [];
 }
 
+export async function clearClipboardImagesQuery() {
+  return (await window.piDesktop?.clearClipboardImages?.()) ?? { clearedCount: 0 };
+}
+
 export async function listComposerAttachmentEntriesQuery(
   request: {
     projectId?: string | null;
@@ -245,6 +249,19 @@ export async function readClipboardSnapshotQuery(
 
 export async function readClipboardFilePathsQuery(): Promise<DesktopClipboardFilePaths | null> {
   return (await window.piDesktop?.readClipboardFilePaths?.()) ?? null;
+}
+
+export async function readClipboardImageQuery(): Promise<ComposerAttachment | null> {
+  const image = await window.piDesktop?.readClipboardImage?.();
+  if (!image) {
+    return null;
+  }
+
+  return {
+    path: image.path,
+    name: image.path.split(/[\\/]/).pop() ?? image.path,
+    kind: "image",
+  };
 }
 
 export async function getAttachmentKindsForPathsQuery(paths: string[]) {

--- a/src/app/views/settings/settingsDescriptors.tsx
+++ b/src/app/views/settings/settingsDescriptors.tsx
@@ -723,6 +723,32 @@ export function buildSettingsDescriptors({
       ),
     },
     {
+      id: "projects.clipboard-images",
+      category: "projects",
+      title: "Clipboard images",
+      description:
+        "Delete temp images created when pasted clipboard screenshots become attachments.",
+      keywords: "clipboard images screenshots attachments delete cleanup temp",
+      render: () => (
+        <div className="grid justify-items-end gap-1.5">
+          <button
+            type="button"
+            className={cn(composerTextActionButtonClass, "text-[#f2a7a7]")}
+            onClick={() => void controller.handleClearClipboardImages()}
+            disabled={controller.clearImagesBusy || !controller.desktopBridgeAvailable}
+          >
+            <Trash2 size={12} />
+            {controller.clearImagesBusy ? "Deleting…" : "Delete images"}
+          </button>
+          {controller.clearImagesStatusMessage ? (
+            <div className="text-right text-[12px] text-[color:var(--muted)]">
+              {controller.clearImagesStatusMessage}
+            </div>
+          ) : null}
+        </div>
+      ),
+    },
+    {
       id: "dictation.models",
       category: "dictation",
       title: "Speech-to-text model",

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -32,6 +32,8 @@ export function useSettingsController({
   const [importBusy, setImportBusy] = useState(false);
   const [importStatusMessage, setImportStatusMessage] = useState<string | null>(null);
   const [importErrorMessage, setImportErrorMessage] = useState<string | null>(null);
+  const [clearImagesBusy, setClearImagesBusy] = useState(false);
+  const [clearImagesStatusMessage, setClearImagesStatusMessage] = useState<string | null>(null);
   const gitCommitButtonRef = useRef<HTMLButtonElement>(null);
   const gitCommitPanelRef = useRef<HTMLDivElement>(null);
   const gitCommitMenuPresent = useAnimatedPresence(gitCommitMenuOpen);
@@ -127,6 +129,36 @@ export function useSettingsController({
     }
   };
 
+  const handleClearClipboardImages = async () => {
+    if (!desktopBridgeAvailable) {
+      setClearImagesStatusMessage(desktopBridgeUnavailableMessage);
+      return;
+    }
+
+    setClearImagesBusy(true);
+    setClearImagesStatusMessage(null);
+    try {
+      const result = await onAction("settings.clear-clipboard-images", {});
+      const error = getActionError(result);
+      if (error) {
+        setClearImagesStatusMessage(error);
+        return;
+      }
+
+      const clearedCount = result?.result?.clearedCount ?? 0;
+      const failedCount = result?.result?.clearFailedCount ?? 0;
+      const deletedMessage =
+        clearedCount === 1
+          ? "Deleted 1 clipboard image."
+          : `Deleted ${clearedCount} clipboard images.`;
+      setClearImagesStatusMessage(
+        failedCount > 0 ? `${deletedMessage} ${failedCount} failed.` : deletedMessage,
+      );
+    } finally {
+      setClearImagesBusy(false);
+    }
+  };
+
   return {
     addFavoriteFolder,
     deleteDictationModel: dictation.deleteDictationModel,
@@ -135,6 +167,8 @@ export function useSettingsController({
     dictationModels: dictation.dictationModels,
     dictationPendingAction: dictation.dictationPendingAction,
     dictationState: dictation.dictationState,
+    clearImagesBusy,
+    clearImagesStatusMessage,
     favoriteFolderDraft,
     gitCommitButtonRef,
     gitCommitCurrentValue: getModelSettingValue(appSettings.gitCommitMessageModel),
@@ -207,6 +241,7 @@ export function useSettingsController({
       }),
     updateFavoriteFolders,
     handleImportProjectUi,
+    handleClearClipboardImages,
     showFirstLaunchReminderAgain: () =>
       void onAction("settings.update", {
         key: "projectImportState",

--- a/src/electron/main/ipc/request-handlers/system.ts
+++ b/src/electron/main/ipc/request-handlers/system.ts
@@ -1,4 +1,7 @@
-import { stat } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { clipboard, dialog, shell } from "electron";
 import { getAttachmentKind } from "../../../../../shared/composer-attachments";
 import { getSafeExternalUrl } from "../../../../../shared/external-url";
@@ -12,17 +15,67 @@ import type { DesktopRequestHandlerMap } from "../../../../../shared/desktop-ipc
 
 type SystemRequestHandlers = Pick<
   DesktopRequestHandlerMap,
+  | "clearClipboardImages"
   | "pickComposerAttachments"
   | "readClipboardSnapshot"
   | "readClipboardFilePaths"
+  | "readClipboardImage"
   | "getAttachmentKindsForPaths"
   | "listComposerAttachmentEntries"
   | "openExternal"
   | "openPath"
 >;
 
+const clipboardImageTempDir = path.join(tmpdir(), "howcode-clipboard-images");
+const maxClipboardImagePixels = 32_000_000;
+const maxClipboardImageBytes = 25 * 1024 * 1024;
+
+function isClipboardImageWithinLimits(size: { width: number; height: number }) {
+  const width = Math.max(0, Math.floor(size.width));
+  const height = Math.max(0, Math.floor(size.height));
+  return width > 0 && height > 0 && width * height <= maxClipboardImagePixels;
+}
+
+async function writeClipboardImageToTempFile(buffer: Buffer) {
+  if (buffer.length === 0 || buffer.length > maxClipboardImageBytes) {
+    return null;
+  }
+
+  await mkdir(clipboardImageTempDir, { recursive: true, mode: 0o700 });
+
+  const filePath = path.join(clipboardImageTempDir, `howcode-clipboard-${randomUUID()}.png`);
+  await writeFile(filePath, buffer, { mode: 0o600 });
+  return filePath;
+}
+
+async function clearClipboardImageTempFiles() {
+  let entries: Array<{ isFile(): boolean; name: string }>;
+  try {
+    entries = await readdir(clipboardImageTempDir, { withFileTypes: true });
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return { clearedCount: 0, clearFailedCount: 0 };
+    }
+
+    return { clearedCount: 0, clearFailedCount: 1 };
+  }
+
+  const targets = entries.filter(
+    (entry) =>
+      entry.isFile() && entry.name.startsWith("howcode-clipboard-") && entry.name.endsWith(".png"),
+  );
+  const results = await Promise.allSettled(
+    targets.map((entry) => rm(path.join(clipboardImageTempDir, entry.name), { force: true })),
+  );
+  return {
+    clearedCount: results.filter((result) => result.status === "fulfilled").length,
+    clearFailedCount: results.filter((result) => result.status === "rejected").length,
+  };
+}
+
 export function createSystemHandlers(): SystemRequestHandlers {
   return {
+    clearClipboardImages: clearClipboardImageTempFiles,
     pickComposerAttachments: async ({ projectId }) => {
       const result = await dialog.showOpenDialog({
         defaultPath: projectId ?? getDesktopWorkingDirectory(),
@@ -64,6 +117,23 @@ export function createSystemHandlers(): SystemRequestHandlers {
       return { formats, valuesByFormat };
     },
     readClipboardFilePaths: () => readNativeClipboardFilePaths(),
+    readClipboardImage: async () => {
+      const image = clipboard.readImage();
+      if (image.isEmpty()) {
+        return null;
+      }
+
+      if (!isClipboardImageWithinLimits(image.getSize())) {
+        return null;
+      }
+
+      const filePath = await writeClipboardImageToTempFile(image.toPNG());
+      if (!filePath) {
+        return null;
+      }
+
+      return { path: filePath, mimeType: "image/png" };
+    },
     getAttachmentKindsForPaths: async ({ paths }) => {
       const uniquePaths = [...new Set(Array.isArray(paths) ? paths : [])].filter(
         (path): path is string => typeof path === "string" && path.trim().length > 0,

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -41,6 +41,7 @@ function subscribeToEvent<K extends DesktopEventChannel>(
 
 export function createDesktopApi() {
   return {
+    clearClipboardImages: () => invokeRequest("clearClipboardImages", {}),
     getShellState: () => invokeRequest("getShellState", {}),
     getProjectGitState: (projectId: string) => invokeRequest("getProjectGitState", { projectId }),
     getProjectDiff: (projectId: string, baseline = null) =>
@@ -87,6 +88,7 @@ export function createDesktopApi() {
     readClipboardSnapshot: (formats: string[] | null = null) =>
       invokeRequest("readClipboardSnapshot", { formats }),
     readClipboardFilePaths: () => invokeRequest("readClipboardFilePaths", {}),
+    readClipboardImage: () => invokeRequest("readClipboardImage", {}),
     getAttachmentKindsForPaths: (paths: string[]) =>
       invokeRequest("getAttachmentKindsForPaths", { paths }),
     getPathForFile: (file: File) => {

--- a/src/test/composer-paste-attachments.test.ts
+++ b/src/test/composer-paste-attachments.test.ts
@@ -62,6 +62,40 @@ describe("getComposerAttachmentsFromClipboardData", () => {
         }),
       ),
     ).toEqual([{ path: "/Users/igorw/Desktop/example.txt", name: "example.txt", kind: "text" }]);
+
+    expect(
+      getComposerAttachmentsFromClipboardData(
+        createClipboardData({
+          data: { "text/plain": '"/home/igorw/Pictures/My\\ Screenshot.png"' },
+        }),
+      ),
+    ).toEqual([
+      {
+        path: "/home/igorw/Pictures/My Screenshot.png",
+        name: "My Screenshot.png",
+        kind: "image",
+      },
+    ]);
+  });
+
+  it("allows partial extraction for file-manager payloads but not plain prose", () => {
+    expect(
+      getComposerAttachmentsFromClipboardData(
+        createClipboardData({
+          data: {
+            "text/uri-list": "# copied from file manager\nfile:///tmp/first.png\nnot-a-path",
+          },
+        }),
+      ),
+    ).toEqual([{ path: "/tmp/first.png", name: "first.png", kind: "image" }]);
+
+    expect(
+      getComposerAttachmentsFromClipboardData(
+        createClipboardData({
+          data: { "text/plain": "/tmp/first.png\nnot-a-path" },
+        }),
+      ),
+    ).toEqual([]);
   });
 
   it("prefers visible clipboard text unless the copied text is the attachment itself", () => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,6 +4,7 @@ import type {
   ArchivedThread,
   ComposerAttachment,
   DesktopClipboardFilePaths,
+  DesktopClipboardImage,
   DesktopClipboardSnapshot,
   ComposerFilePickerState,
   ComposerSlashCommand,
@@ -47,6 +48,7 @@ declare global {
   interface Window {
     __howcodeDevWebBridge?: boolean;
     piDesktop?: {
+      clearClipboardImages?: () => Promise<{ clearedCount: number; clearFailedCount: number }>;
       getShellState: () => Promise<ShellState>;
       getProjectGitState?: (projectId: string) => Promise<ProjectGitState | null>;
       getProjectDiff?: (
@@ -112,6 +114,7 @@ declare global {
       pickComposerAttachments?: (projectId?: string | null) => Promise<ComposerAttachment[]>;
       readClipboardSnapshot?: (formats?: string[] | null) => Promise<DesktopClipboardSnapshot>;
       readClipboardFilePaths?: () => Promise<DesktopClipboardFilePaths>;
+      readClipboardImage?: () => Promise<DesktopClipboardImage>;
       getAttachmentKindsForPaths?: (
         paths: string[],
       ) => Promise<Record<string, ComposerAttachment["kind"] | null>>;


### PR DESCRIPTION
## Summary
- Make pasted local image/file paths attach reliably across plain, quoted, shell-escaped, and file-manager clipboard formats.
- Add a raw Electron clipboard image fallback for Omarchy-style screenshot copies that put PNG bytes, not a path, on the clipboard.
- Add a Settings action to delete temporary pasted clipboard images.

## Details
- Preserves ordinary text paste when no attachment can be extracted.
- Defers raw clipboard image reads until direct/native/snapshot attachment sources fail, so successful file/path pastes do not create unused screenshot copies.
- Writes clipboard image temp files with private permissions and cleanup removes only Howcode-created temp PNG files while reporting per-file failures.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #129
