### PR TITLE
Improve headless extension command handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 - Use Bun for installs and scripts; keep the app runtime on Node.js/Electron.
 - In dev, assume the app dev server is already running; do not start it manually, and use Electron CDP at `127.0.0.1:39217`.
-- Pre-commit hooks exist; skip separate lint/format/check runs unless asked.
+- You MUST NOT run typechecks and tests; pre-commit hooks run these.
 - Prefer `src/electron/main/**`, `src/electron/preload/**`, and `shared/*` contracts over ad-hoc desktop IPC shims.
 - Keep UI changes optimistic and reuse existing patterns over one-offs.
 - For major changes, validate with a commit and leave the repo committed.

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
-import { bindHeadlessAgentSessionExtensions } from "../runtime/agent-session-extensions.cts";
+import {
+  abortHeadlessExtensionCommand,
+  bindHeadlessAgentSessionExtensions,
+} from "../runtime/agent-session-extensions.cts";
 import { buildComposerState } from "../runtime/composer-state.cts";
 import { applyHeadlessPiTheme } from "../runtime/headless-pi-theme.cts";
 import type { PiRuntime } from "../runtime/types.cts";
@@ -211,6 +214,16 @@ async function createRuntime(options: {
   });
 
   await bindHeadlessAgentSessionExtensions(session, {
+    onExtensionCommandStateChange: () => {
+      void buildComposerState(runtime)
+        .then((composer) =>
+          publishComposerUpdate(composer, {
+            projectId: runtime.cwd,
+            sessionPath: runtime.session.sessionFile,
+          }),
+        )
+        .catch((error) => console.warn("Failed to publish extension command state", error));
+    },
     onExtensionError: (error) => {
       const extensionLabel = getRuntimeDiagnosticExtensionLabel(error.extensionPath);
       emitDesktopEvent({
@@ -224,6 +237,10 @@ async function createRuntime(options: {
     },
   });
   return runtime;
+}
+
+export function abortRuntimeExtensionCommand(runtime: PiRuntime) {
+  return abortHeadlessExtensionCommand(runtime.session);
 }
 
 function registerRuntime(runtimeKey: string, runtimePromise: Promise<PiRuntime>) {

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -15,6 +15,12 @@ import {
 import { emitDesktopEvent } from "./host-events.cts";
 import { clearRuntimeToolProgress, rememberRuntimeToolProgress } from "./live-tool-progress.cts";
 
+function getRuntimeDiagnosticExtensionLabel(extensionPath: string) {
+  if (extensionPath.startsWith("command:")) return `/${extensionPath.slice("command:".length)}`;
+  if (extensionPath.startsWith("<")) return extensionPath.replace(/[<>]/g, "");
+  return path.basename(extensionPath).replace(/\.(ts|js)$/, "");
+}
+
 type RuntimeRecord = {
   runtimePromise: Promise<PiRuntime>;
   disposeTimeout: ReturnType<typeof setTimeout> | null;
@@ -206,11 +212,12 @@ async function createRuntime(options: {
 
   await bindHeadlessAgentSessionExtensions(session, {
     onExtensionError: (error) => {
+      const extensionLabel = getRuntimeDiagnosticExtensionLabel(error.extensionPath);
       emitDesktopEvent({
         type: "runtime-diagnostic",
         severity: "error",
-        message: `Extension error (${error.extensionPath}): ${error.error}`,
-        details: error,
+        message: `${extensionLabel} extension error: ${error.error}`,
+        details: { ...error, extensionLabel },
         projectId: runtime.cwd,
         sessionPath: runtime.session.sessionFile ?? null,
       });

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -227,6 +227,14 @@ async function createRuntime(options: {
           }),
         )
         .catch((error) => console.warn("Failed to publish extension command state", error));
+      if (!isRuntimeExtensionCommandRunning(runtime)) {
+        const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+        if (runtimeKey) {
+          void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {
+            // Keep stale settings marked; the next safe point retries silently.
+          });
+        }
+      }
     },
     onExtensionError: (error) => {
       const extensionLabel = getRuntimeDiagnosticExtensionLabel(error.extensionPath);
@@ -262,6 +270,14 @@ export async function refreshRuntimeExtensionBindings(runtime: PiRuntime) {
           }),
         )
         .catch((error) => console.warn("Failed to publish extension command state", error));
+      if (!isRuntimeExtensionCommandRunning(runtime)) {
+        const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+        if (runtimeKey) {
+          void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {
+            // Keep stale settings marked; the next safe point retries silently.
+          });
+        }
+      }
     },
   });
 }

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -4,9 +4,10 @@ import { getPiModule } from "../pi-module.cts";
 import {
   abortHeadlessExtensionCommand,
   bindHeadlessAgentSessionExtensions,
+  isHeadlessExtensionCommandRunning,
+  refreshHeadlessAgentSessionExtensionBindings,
 } from "../runtime/agent-session-extensions.cts";
 import { buildComposerState } from "../runtime/composer-state.cts";
-import { applyHeadlessPiTheme } from "../runtime/headless-pi-theme.cts";
 import type { PiRuntime } from "../runtime/types.cts";
 import {
   cancelLiveThreadUpdate,
@@ -96,7 +97,6 @@ async function createRuntime(options: {
     settingsManager,
     sessionManager: options.sessionManager ?? SessionManager.create(options.cwd, sessionDir),
   });
-  await applyHeadlessPiTheme(session);
   const runtime = { cwd: options.cwd, session } satisfies PiRuntime;
 
   session.subscribe((event) => {
@@ -243,6 +243,25 @@ export function abortRuntimeExtensionCommand(runtime: PiRuntime) {
   return abortHeadlessExtensionCommand(runtime.session);
 }
 
+export function isRuntimeExtensionCommandRunning(runtime: PiRuntime) {
+  return isHeadlessExtensionCommandRunning(runtime.session);
+}
+
+export async function refreshRuntimeExtensionBindings(runtime: PiRuntime) {
+  await refreshHeadlessAgentSessionExtensionBindings(runtime.session, {
+    onExtensionCommandStateChange: () => {
+      void buildComposerState(runtime)
+        .then((composer) =>
+          publishComposerUpdate(composer, {
+            projectId: runtime.cwd,
+            sessionPath: runtime.session.sessionFile,
+          }),
+        )
+        .catch((error) => console.warn("Failed to publish extension command state", error));
+    },
+  });
+}
+
 function registerRuntime(runtimeKey: string, runtimePromise: Promise<PiRuntime>) {
   staleRuntimeGenerations.delete(runtimeKey);
   const record: RuntimeRecord = { runtimePromise, disposeTimeout: null };
@@ -315,7 +334,7 @@ async function reloadRuntimeSettings(
 ) {
   if (runtime.session.isStreaming || runtime.session.isCompacting) return false;
   await runtime.session.reload();
-  await applyHeadlessPiTheme(runtime.session);
+  await refreshRuntimeExtensionBindings(runtime);
   const composer = await buildComposerState(runtime);
   publishComposerUpdate(composer, {
     projectId: runtime.cwd,

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -57,7 +57,11 @@ export function scheduleRuntimeDisposal(runtimeKey: string) {
       if (!currentRecord || currentRecord !== record) return;
       try {
         const runtime = await record.runtimePromise;
-        if (runtime.session.isStreaming || runtime.session.isCompacting) {
+        if (
+          runtime.session.isStreaming ||
+          runtime.session.isCompacting ||
+          isRuntimeExtensionCommandRunning(runtime)
+        ) {
           scheduleRuntimeDisposal(runtimeKey);
           return;
         }
@@ -332,7 +336,12 @@ async function reloadRuntimeSettings(
   runtime: PiRuntime,
   staleGeneration: number,
 ) {
-  if (runtime.session.isStreaming || runtime.session.isCompacting) return false;
+  if (
+    runtime.session.isStreaming ||
+    runtime.session.isCompacting ||
+    isRuntimeExtensionCommandRunning(runtime)
+  )
+    return false;
   await runtime.session.reload();
   await refreshRuntimeExtensionBindings(runtime);
   const composer = await buildComposerState(runtime);

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -3,7 +3,7 @@ import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { bindHeadlessAgentSessionExtensions } from "../runtime/agent-session-extensions.cts";
 import { buildComposerState } from "../runtime/composer-state.cts";
-import { initHeadlessPiTheme } from "../runtime/headless-pi-theme.cts";
+import { applyHeadlessPiTheme } from "../runtime/headless-pi-theme.cts";
 import type { PiRuntime } from "../runtime/types.cts";
 import {
   cancelLiveThreadUpdate,
@@ -78,7 +78,6 @@ async function createRuntime(options: {
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(options.cwd, agentDir);
-  await initHeadlessPiTheme(settingsManager);
   const sessionDir = settingsManager.getSessionDir() ?? undefined;
   const { session } = await createAgentSession({
     cwd: options.cwd,
@@ -88,6 +87,7 @@ async function createRuntime(options: {
     settingsManager,
     sessionManager: options.sessionManager ?? SessionManager.create(options.cwd, sessionDir),
   });
+  await applyHeadlessPiTheme(session);
   const runtime = { cwd: options.cwd, session } satisfies PiRuntime;
 
   session.subscribe((event) => {
@@ -291,6 +291,7 @@ async function reloadRuntimeSettings(
 ) {
   if (runtime.session.isStreaming || runtime.session.isCompacting) return false;
   await runtime.session.reload();
+  await applyHeadlessPiTheme(runtime.session);
   const composer = await buildComposerState(runtime);
   publishComposerUpdate(composer, {
     projectId: runtime.cwd,

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -3,6 +3,7 @@ import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { bindHeadlessAgentSessionExtensions } from "../runtime/agent-session-extensions.cts";
 import { buildComposerState } from "../runtime/composer-state.cts";
+import { initHeadlessPiTheme } from "../runtime/headless-pi-theme.cts";
 import type { PiRuntime } from "../runtime/types.cts";
 import {
   cancelLiveThreadUpdate,
@@ -77,6 +78,7 @@ async function createRuntime(options: {
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(options.cwd, agentDir);
+  await initHeadlessPiTheme(settingsManager);
   const sessionDir = settingsManager.getSessionDir() ?? undefined;
   const { session } = await createAgentSession({
     cwd: options.cwd,

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -283,10 +283,11 @@ export async function stopComposerRun(request: ComposerStateRequest) {
   if (cachedRuntimePromise) {
     const cachedRuntime = await cachedRuntimePromise;
     const abortedExtensionCommand = abortRuntimeExtensionCommand(cachedRuntime);
-    if (cachedRuntime.session.isStreaming) {
+    const wasStreaming = cachedRuntime.session.isStreaming;
+    if (wasStreaming) {
       await cachedRuntime.session.abort();
     }
-    if (abortedExtensionCommand || cachedRuntime.session.isStreaming) {
+    if (abortedExtensionCommand || wasStreaming) {
       scheduleRuntimeDisposal(persistedSessionPath);
       await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
       return { ok: true as const };

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -54,6 +54,12 @@ async function emitComposerUpdate(request: ComposerStateRequest = {}) {
   return { composer, runtime };
 }
 
+function isExtensionCommandPrompt(runtime: PiRuntime, text: string) {
+  if (!text.startsWith("/")) return false;
+  const commandName = text.slice(1).split(/\s+/, 1)[0];
+  return Boolean(runtime.session.extensionRunner.getCommand(commandName));
+}
+
 async function promptAndReturnAfterPreflight({
   runtime,
   message,
@@ -232,14 +238,18 @@ export async function sendComposerPrompt(
         throw new Error("Wait for the current compaction to finish before sending another prompt.");
       if (runtime.session.isStreaming) {
         if (streamingBehavior === "stop") {
-          await runtime.session.abort();
-          await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-          return "stopped" as const;
+          if (!isExtensionCommandPrompt(runtime, request.text)) {
+            await runtime.session.abort();
+            await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+            return "stopped" as const;
+          }
         }
+        const promptStreamingBehavior =
+          streamingBehavior === "stop" ? "followUp" : streamingBehavior;
         await promptAndReturnAfterPreflight({
           runtime,
           message,
-          options: { streamingBehavior },
+          options: { streamingBehavior: promptStreamingBehavior },
           request: { ...request, sessionPath: persistedSessionPath },
         });
       } else {
@@ -299,10 +309,11 @@ export async function stopComposerRun(request: ComposerStateRequest) {
       suspendDisposal: true,
     });
     const abortedExtensionCommand = abortRuntimeExtensionCommand(runtime);
-    if (runtime.session.isStreaming) {
+    const wasStreaming = runtime.session.isStreaming;
+    if (wasStreaming) {
       await runtime.session.abort();
     }
-    if (!abortedExtensionCommand && !runtime.session.isStreaming) await runtime.session.abort();
+    if (!abortedExtensionCommand && !wasStreaming) await runtime.session.abort();
     scheduleRuntimeDisposal(persistedSessionPath);
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -217,6 +217,8 @@ export async function sendComposerPrompt(
     const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
     try {
       if (compactInstructions !== null) {
+        if (isRuntimeExtensionCommandRunning(runtime))
+          throw new Error("Wait for the current extension command to finish before compacting.");
         if (runtime.session.isStreaming)
           throw new Error("Wait for the current response to finish before compacting.");
         if (runtime.session.isCompacting)

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -34,6 +34,7 @@ import {
   scheduleRuntimeDisposal,
   withRuntimeMutationLock,
   abortRuntimeExtensionCommand,
+  isRuntimeExtensionCommandRunning,
 } from "./live-runtime-registry.cts";
 import { mapSessionCommands } from "./slash-command-service.cts";
 
@@ -263,7 +264,9 @@ export async function sendComposerPrompt(
   const cachedRuntimePromise = getCachedRuntimeForSessionPath(persistedSessionPath);
   if (cachedRuntimePromise) {
     const cachedRuntime = await cachedRuntimePromise;
-    if (cachedRuntime.session.isStreaming) return await runSend(cachedRuntime);
+    if (cachedRuntime.session.isStreaming || isRuntimeExtensionCommandRunning(cachedRuntime)) {
+      return await runSend(cachedRuntime);
+    }
   }
   return await withRuntimeMutationLock(persistedSessionPath, async () => {
     await reloadRuntimeSettingsIfSafe(persistedSessionPath, { useMutationLock: false });
@@ -276,14 +279,29 @@ export async function sendComposerPrompt(
 export async function stopComposerRun(request: ComposerStateRequest) {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   if (!persistedSessionPath) return { ok: true as const };
+  const cachedRuntimePromise = getCachedRuntimeForSessionPath(persistedSessionPath);
+  if (cachedRuntimePromise) {
+    const cachedRuntime = await cachedRuntimePromise;
+    const abortedExtensionCommand = abortRuntimeExtensionCommand(cachedRuntime);
+    if (cachedRuntime.session.isStreaming) {
+      await cachedRuntime.session.abort();
+    }
+    if (abortedExtensionCommand || cachedRuntime.session.isStreaming) {
+      scheduleRuntimeDisposal(persistedSessionPath);
+      await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+      return { ok: true as const };
+    }
+  }
   await withRuntimeMutationLock(persistedSessionPath, async () => {
     await reloadRuntimeSettingsIfSafe(persistedSessionPath, { useMutationLock: false });
     const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
       suspendDisposal: true,
     });
-    if (!abortRuntimeExtensionCommand(runtime)) {
+    const abortedExtensionCommand = abortRuntimeExtensionCommand(runtime);
+    if (runtime.session.isStreaming) {
       await runtime.session.abort();
     }
+    if (!abortedExtensionCommand && !runtime.session.isStreaming) await runtime.session.abort();
     scheduleRuntimeDisposal(persistedSessionPath);
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -33,6 +33,7 @@ import {
   reloadRuntimeSettingsIfSafe,
   scheduleRuntimeDisposal,
   withRuntimeMutationLock,
+  abortRuntimeExtensionCommand,
 } from "./live-runtime-registry.cts";
 import { mapSessionCommands } from "./slash-command-service.cts";
 
@@ -280,7 +281,9 @@ export async function stopComposerRun(request: ComposerStateRequest) {
     const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
       suspendDisposal: true,
     });
-    await runtime.session.abort();
+    if (!abortRuntimeExtensionCommand(runtime)) {
+      await runtime.session.abort();
+    }
     scheduleRuntimeDisposal(persistedSessionPath);
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -7,6 +7,11 @@ import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 const howcodeExtensionErrorMessageType = "howcode.extension.error";
 const extensionCommandCancelledResult = { cancelled: true };
 const sessionsWithHowcodeContextFilter = new WeakSet<AgentSession>();
+const sessionsWithCommandAbort = new WeakSet<AgentSession>();
+const activeExtensionCommands = new WeakMap<
+  AgentSession,
+  { commandName: string; abortController: AbortController }
+>();
 
 type ExtensionBindings = Parameters<AgentSession["bindExtensions"]>[0];
 type ExtensionCommandContextActions = NonNullable<ExtensionBindings["commandContextActions"]>;
@@ -83,7 +88,19 @@ function buildExtensionResourcePaths(entries: ExtensionResourceEntry[]) {
 
 type HeadlessAgentSessionExtensionOptions = {
   onExtensionError?: (error: Parameters<NonNullable<ExtensionBindings["onError"]>>[0]) => void;
+  onExtensionCommandStateChange?: () => void;
 };
+
+export function isHeadlessExtensionCommandRunning(session: AgentSession) {
+  return activeExtensionCommands.has(session);
+}
+
+export function abortHeadlessExtensionCommand(session: AgentSession) {
+  const activeCommand = activeExtensionCommands.get(session);
+  if (!activeCommand) return false;
+  activeCommand.abortController.abort();
+  return true;
+}
 
 function isHowcodeExtensionErrorMessage(message: AgentMessage) {
   return (
@@ -151,6 +168,47 @@ function createHeadlessCommandContextActions(
   };
 }
 
+function bindHeadlessCommandAbort(
+  session: AgentSession,
+  options: HeadlessAgentSessionExtensionOptions,
+) {
+  if (sessionsWithCommandAbort.has(session)) return;
+  sessionsWithCommandAbort.add(session);
+
+  const extensionRunner = session.extensionRunner;
+  const originalGetCommand = extensionRunner.getCommand.bind(extensionRunner);
+  type ExtensionCommand = NonNullable<ReturnType<typeof originalGetCommand>>;
+  type ExtensionCommandContext = Parameters<ExtensionCommand["handler"]>[1];
+
+  extensionRunner.getCommand = (name: string) => {
+    const command = originalGetCommand(name);
+    if (!command) return command;
+
+    return {
+      ...command,
+      handler: async (args: string, ctx: ExtensionCommandContext) => {
+        const abortController = new AbortController();
+        activeExtensionCommands.set(session, { commandName: name, abortController });
+        options.onExtensionCommandStateChange?.();
+        Object.defineProperty(ctx, "signal", {
+          configurable: true,
+          get: () => abortController.signal,
+        });
+        ctx.abort = () => abortController.abort();
+
+        try {
+          await command.handler?.(args, ctx);
+        } finally {
+          if (activeExtensionCommands.get(session)?.abortController === abortController) {
+            activeExtensionCommands.delete(session);
+            options.onExtensionCommandStateChange?.();
+          }
+        }
+      },
+    };
+  };
+}
+
 export async function discoverHeadlessAgentSessionResources(session: AgentSession) {
   if (!session.extensionRunner.hasHandlers("resources_discover")) {
     return;
@@ -176,6 +234,7 @@ export async function bindHeadlessAgentSessionExtensions(
   options: HeadlessAgentSessionExtensionOptions = {},
 ) {
   bindHowcodeContextFilter(session);
+  bindHeadlessCommandAbort(session, options);
   await applyHeadlessPiTheme(session);
   await session.bindExtensions({
     commandContextActions: createHeadlessCommandContextActions(session),

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -1,13 +1,16 @@
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
+import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 
 const howcodeExtensionErrorMessageType = "howcode.extension.error";
+const howcodeExtensionStatusMessageType = "howcode.extension.status";
 const extensionCommandCancelledResult = { cancelled: true };
 const sessionsWithHowcodeContextFilter = new WeakSet<AgentSession>();
 
 type ExtensionBindings = Parameters<AgentSession["bindExtensions"]>[0];
 type ExtensionCommandContextActions = NonNullable<ExtensionBindings["commandContextActions"]>;
+type ExtensionUIContext = NonNullable<ExtensionBindings["uiContext"]>;
 type ResourceExtensionPaths = Parameters<AgentSession["resourceLoader"]["extendResources"]>[0];
 
 type ExtensionResourceEntry = { path: string; extensionPath: string };
@@ -47,7 +50,8 @@ function isHowcodeExtensionErrorMessage(message: AgentMessage) {
   return (
     message.role === "custom" &&
     "customType" in message &&
-    message.customType === howcodeExtensionErrorMessageType
+    (message.customType === howcodeExtensionErrorMessageType ||
+      message.customType === howcodeExtensionStatusMessageType)
   );
 }
 
@@ -82,6 +86,41 @@ async function reportHeadlessExtensionError(
     console.warn("Failed to surface Pi extension error in session", messageError);
   }
   options.onExtensionError?.(error);
+}
+
+function sendHeadlessExtensionStatus(
+  session: AgentSession,
+  content: string,
+  details?: Record<string, unknown>,
+) {
+  void session
+    .sendCustomMessage(
+      {
+        customType: howcodeExtensionStatusMessageType,
+        content,
+        display: true,
+        details,
+      },
+      { triggerTurn: false },
+    )
+    .catch((error) => {
+      console.warn("Failed to surface Pi extension status in session", error);
+    });
+}
+
+function createHeadlessUIContext(session: AgentSession): ExtensionUIContext {
+  const baseContext = session.extensionRunner.getUIContext() as ExtensionUIContext;
+
+  return {
+    ...baseContext,
+    notify: (message, level) => {
+      sendHeadlessExtensionStatus(session, message, { kind: "notification", level });
+    },
+    setWorkingMessage: (message) => {
+      if (!message) return;
+      sendHeadlessExtensionStatus(session, message, { kind: "working" });
+    },
+  };
 }
 
 function createHeadlessCommandContextActions(
@@ -123,6 +162,7 @@ export async function discoverHeadlessAgentSessionResources(session: AgentSessio
     themePaths: buildExtensionResourcePaths(themePaths),
   };
   session.resourceLoader.extendResources(extensionPaths);
+  await applyHeadlessPiTheme(session);
 }
 
 export async function bindHeadlessAgentSessionExtensions(
@@ -130,11 +170,14 @@ export async function bindHeadlessAgentSessionExtensions(
   options: HeadlessAgentSessionExtensionOptions = {},
 ) {
   bindHowcodeContextFilter(session);
+  await applyHeadlessPiTheme(session);
   await session.bindExtensions({
+    uiContext: createHeadlessUIContext(session),
     commandContextActions: createHeadlessCommandContextActions(session),
     shutdownHandler: () => undefined,
     onError: (error) => {
       void reportHeadlessExtensionError(session, error, options);
     },
   });
+  await applyHeadlessPiTheme(session);
 }

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -4,13 +4,11 @@ import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 
 const howcodeExtensionErrorMessageType = "howcode.extension.error";
-const howcodeExtensionStatusMessageType = "howcode.extension.status";
 const extensionCommandCancelledResult = { cancelled: true };
 const sessionsWithHowcodeContextFilter = new WeakSet<AgentSession>();
 
 type ExtensionBindings = Parameters<AgentSession["bindExtensions"]>[0];
 type ExtensionCommandContextActions = NonNullable<ExtensionBindings["commandContextActions"]>;
-type ExtensionUIContext = NonNullable<ExtensionBindings["uiContext"]>;
 type ResourceExtensionPaths = Parameters<AgentSession["resourceLoader"]["extendResources"]>[0];
 
 type ExtensionResourceEntry = { path: string; extensionPath: string };
@@ -50,8 +48,7 @@ function isHowcodeExtensionErrorMessage(message: AgentMessage) {
   return (
     message.role === "custom" &&
     "customType" in message &&
-    (message.customType === howcodeExtensionErrorMessageType ||
-      message.customType === howcodeExtensionStatusMessageType)
+    message.customType === howcodeExtensionErrorMessageType
   );
 }
 
@@ -86,41 +83,6 @@ async function reportHeadlessExtensionError(
     console.warn("Failed to surface Pi extension error in session", messageError);
   }
   options.onExtensionError?.(error);
-}
-
-function sendHeadlessExtensionStatus(
-  session: AgentSession,
-  content: string,
-  details?: Record<string, unknown>,
-) {
-  void session
-    .sendCustomMessage(
-      {
-        customType: howcodeExtensionStatusMessageType,
-        content,
-        display: true,
-        details,
-      },
-      { triggerTurn: false },
-    )
-    .catch((error) => {
-      console.warn("Failed to surface Pi extension status in session", error);
-    });
-}
-
-function createHeadlessUIContext(session: AgentSession): ExtensionUIContext {
-  const baseContext = session.extensionRunner.getUIContext() as ExtensionUIContext;
-
-  return {
-    ...baseContext,
-    notify: (message, level) => {
-      sendHeadlessExtensionStatus(session, message, { kind: "notification", level });
-    },
-    setWorkingMessage: (message) => {
-      if (!message) return;
-      sendHeadlessExtensionStatus(session, message, { kind: "working" });
-    },
-  };
 }
 
 function createHeadlessCommandContextActions(
@@ -172,7 +134,6 @@ export async function bindHeadlessAgentSessionExtensions(
   bindHowcodeContextFilter(session);
   await applyHeadlessPiTheme(session);
   await session.bindExtensions({
-    uiContext: createHeadlessUIContext(session),
     commandContextActions: createHeadlessCommandContextActions(session),
     shutdownHandler: () => undefined,
     onError: (error) => {

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
@@ -12,6 +13,46 @@ type ExtensionCommandContextActions = NonNullable<ExtensionBindings["commandCont
 type ResourceExtensionPaths = Parameters<AgentSession["resourceLoader"]["extendResources"]>[0];
 
 type ExtensionResourceEntry = { path: string; extensionPath: string };
+
+function findPackageName(startPath: string) {
+  let directory =
+    fs.existsSync(startPath) && fs.statSync(startPath).isDirectory()
+      ? startPath
+      : path.dirname(startPath);
+
+  while (true) {
+    const packageJsonPath = path.join(directory, "package.json");
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as { name?: unknown };
+        if (typeof parsed.name === "string" && parsed.name.trim().length > 0) {
+          return parsed.name;
+        }
+      } catch {
+        return null;
+      }
+    }
+
+    const parent = path.dirname(directory);
+    if (parent === directory) return null;
+    directory = parent;
+  }
+}
+
+function getExtensionDisplayLabel(extensionPath: string) {
+  if (extensionPath.startsWith("command:")) {
+    return `/${extensionPath.slice("command:".length)}`;
+  }
+
+  if (extensionPath.startsWith("<")) {
+    return extensionPath.replace(/[<>]/g, "");
+  }
+
+  const packageName = findPackageName(extensionPath);
+  if (packageName) return packageName;
+
+  return path.basename(extensionPath).replace(/\.(ts|js)$/, "");
+}
 
 function getExtensionSourceLabel(extensionPath: string) {
   if (extensionPath.startsWith("<")) {
@@ -69,13 +110,14 @@ async function reportHeadlessExtensionError(
   options: HeadlessAgentSessionExtensionOptions = {},
 ) {
   console.warn("Pi extension error", error);
+  const extensionLabel = getExtensionDisplayLabel(error.extensionPath);
   try {
     await session.sendCustomMessage(
       {
         customType: howcodeExtensionErrorMessageType,
-        content: `Extension error (${error.extensionPath}): ${error.error}`,
+        content: `${extensionLabel} extension error: ${error.error}`,
         display: true,
-        details: error,
+        details: { ...error, extensionLabel },
       },
       { triggerTurn: false },
     );

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -239,7 +239,9 @@ export async function refreshHeadlessAgentSessionExtensionBindings(
 ) {
   bindHowcodeContextFilter(session);
   bindHeadlessCommandAbort(session, options);
-  await applyHeadlessPiTheme(session);
+  await applyHeadlessPiTheme(session).catch((error) => {
+    console.warn("Failed to initialize headless Pi theme", error);
+  });
 }
 
 export async function bindHeadlessAgentSessionExtensions(

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -6,8 +6,8 @@ import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 
 const howcodeExtensionErrorMessageType = "howcode.extension.error";
 const extensionCommandCancelledResult = { cancelled: true };
-const sessionsWithHowcodeContextFilter = new WeakSet<AgentSession>();
-const sessionsWithCommandAbort = new WeakSet<AgentSession>();
+const runnersWithHowcodeContextFilter = new WeakSet<object>();
+const runnersWithCommandAbort = new WeakSet<object>();
 const activeExtensionCommands = new WeakMap<
   AgentSession,
   { commandName: string; abortController: AbortController }
@@ -111,11 +111,12 @@ function isHowcodeExtensionErrorMessage(message: AgentMessage) {
 }
 
 function bindHowcodeContextFilter(session: AgentSession) {
-  if (sessionsWithHowcodeContextFilter.has(session)) return;
-  sessionsWithHowcodeContextFilter.add(session);
+  const extensionRunner = session.extensionRunner;
+  if (runnersWithHowcodeContextFilter.has(extensionRunner)) return;
+  runnersWithHowcodeContextFilter.add(extensionRunner);
 
-  const originalEmitContext = session.extensionRunner.emitContext.bind(session.extensionRunner);
-  session.extensionRunner.emitContext = async (messages: AgentMessage[]) => {
+  const originalEmitContext = extensionRunner.emitContext.bind(extensionRunner);
+  extensionRunner.emitContext = async (messages: AgentMessage[]) => {
     const nextMessages = await originalEmitContext(messages);
     return nextMessages.filter((message) => !isHowcodeExtensionErrorMessage(message));
   };
@@ -146,6 +147,7 @@ async function reportHeadlessExtensionError(
 
 function createHeadlessCommandContextActions(
   session: AgentSession,
+  options: HeadlessAgentSessionExtensionOptions,
 ): ExtensionCommandContextActions {
   return {
     waitForIdle: () => session.agent.waitForIdle(),
@@ -163,6 +165,8 @@ function createHeadlessCommandContextActions(
     switchSession: async () => extensionCommandCancelledResult,
     reload: async () => {
       await session.reload();
+      bindHowcodeContextFilter(session);
+      bindHeadlessCommandAbort(session, options);
       await applyHeadlessPiTheme(session);
     },
   };
@@ -172,10 +176,10 @@ function bindHeadlessCommandAbort(
   session: AgentSession,
   options: HeadlessAgentSessionExtensionOptions,
 ) {
-  if (sessionsWithCommandAbort.has(session)) return;
-  sessionsWithCommandAbort.add(session);
-
   const extensionRunner = session.extensionRunner;
+  if (runnersWithCommandAbort.has(extensionRunner)) return;
+  runnersWithCommandAbort.add(extensionRunner);
+
   const originalGetCommand = extensionRunner.getCommand.bind(extensionRunner);
   type ExtensionCommand = NonNullable<ReturnType<typeof originalGetCommand>>;
   type ExtensionCommandContext = Parameters<ExtensionCommand["handler"]>[1];
@@ -229,19 +233,26 @@ export async function discoverHeadlessAgentSessionResources(session: AgentSessio
   session.resourceLoader.extendResources(extensionPaths);
 }
 
-export async function bindHeadlessAgentSessionExtensions(
+export async function refreshHeadlessAgentSessionExtensionBindings(
   session: AgentSession,
   options: HeadlessAgentSessionExtensionOptions = {},
 ) {
   bindHowcodeContextFilter(session);
   bindHeadlessCommandAbort(session, options);
   await applyHeadlessPiTheme(session);
+}
+
+export async function bindHeadlessAgentSessionExtensions(
+  session: AgentSession,
+  options: HeadlessAgentSessionExtensionOptions = {},
+) {
+  await refreshHeadlessAgentSessionExtensionBindings(session, options);
   await session.bindExtensions({
-    commandContextActions: createHeadlessCommandContextActions(session),
+    commandContextActions: createHeadlessCommandContextActions(session, options),
     shutdownHandler: () => undefined,
     onError: (error) => {
       void reportHeadlessExtensionError(session, error, options);
     },
   });
-  await applyHeadlessPiTheme(session);
+  await refreshHeadlessAgentSessionExtensionBindings(session, options);
 }

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -165,9 +165,7 @@ function createHeadlessCommandContextActions(
     switchSession: async () => extensionCommandCancelledResult,
     reload: async () => {
       await session.reload();
-      bindHowcodeContextFilter(session);
-      bindHeadlessCommandAbort(session, options);
-      await applyHeadlessPiTheme(session);
+      await refreshHeadlessAgentSessionExtensionBindings(session, options);
     },
   };
 }

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -144,7 +144,10 @@ function createHeadlessCommandContextActions(
       return { cancelled: result.cancelled };
     },
     switchSession: async () => extensionCommandCancelledResult,
-    reload: () => session.reload(),
+    reload: async () => {
+      await session.reload();
+      await applyHeadlessPiTheme(session);
+    },
   };
 }
 

--- a/desktop/runtime/agent-session-extensions.cts
+++ b/desktop/runtime/agent-session-extensions.cts
@@ -169,7 +169,6 @@ export async function discoverHeadlessAgentSessionResources(session: AgentSessio
     themePaths: buildExtensionResourcePaths(themePaths),
   };
   session.resourceLoader.extendResources(extensionPaths);
-  await applyHeadlessPiTheme(session);
 }
 
 export async function bindHeadlessAgentSessionExtensions(

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -30,6 +30,7 @@ import {
   scheduleRuntimeDisposalForRuntime,
   withRuntimeMutationLock,
   abortRuntimeExtensionCommand,
+  isRuntimeExtensionCommandRunning,
 } from "./runtime-registry.cts";
 import {
   getLiveThread,
@@ -289,7 +290,7 @@ export async function sendComposerPrompt(
   const cachedRuntimePromise = getCachedRuntimeForSessionPath(persistedSessionPath);
   if (cachedRuntimePromise) {
     const cachedRuntime = await cachedRuntimePromise;
-    if (cachedRuntime.session.isStreaming) {
+    if (cachedRuntime.session.isStreaming || isRuntimeExtensionCommandRunning(cachedRuntime)) {
       return await runSend(cachedRuntime);
     }
   }
@@ -314,7 +315,7 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
     const cachedRuntime = await cachedRuntimePromise;
     const abortedExtensionCommand = abortRuntimeExtensionCommand(cachedRuntime);
     if (abortedExtensionCommand || cachedRuntime.session.isStreaming) {
-      if (!abortedExtensionCommand) {
+      if (cachedRuntime.session.isStreaming) {
         await cachedRuntime.session.abort();
       }
       scheduleRuntimeDisposalForRuntime(cachedRuntime);
@@ -328,9 +329,11 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
       suspendDisposal: true,
     });
 
-    if (!abortRuntimeExtensionCommand(runtime)) {
+    const abortedExtensionCommand = abortRuntimeExtensionCommand(runtime);
+    if (runtime.session.isStreaming) {
       await runtime.session.abort();
     }
+    if (!abortedExtensionCommand && !runtime.session.isStreaming) await runtime.session.abort();
     scheduleRuntimeDisposalForRuntime(runtime);
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -221,6 +221,10 @@ export async function sendComposerPrompt(
   const runSend = async (runtime: Awaited<ReturnType<typeof getOrCreateRuntimeForSessionPath>>) => {
     if (compactInstructions !== null) {
       try {
+        if (isRuntimeExtensionCommandRunning(runtime)) {
+          throw new Error("Wait for the current extension command to finish before compacting.");
+        }
+
         if (runtime.session.isStreaming) {
           throw new Error("Wait for the current response to finish before compacting.");
         }

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -29,6 +29,7 @@ import {
   getOrCreateRuntimeForSessionPath,
   scheduleRuntimeDisposalForRuntime,
   withRuntimeMutationLock,
+  abortRuntimeExtensionCommand,
 } from "./runtime-registry.cts";
 import {
   getLiveThread,
@@ -311,8 +312,11 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
   const cachedRuntimePromise = getCachedRuntimeForSessionPath(persistedSessionPath);
   if (cachedRuntimePromise) {
     const cachedRuntime = await cachedRuntimePromise;
-    if (cachedRuntime.session.isStreaming) {
-      await cachedRuntime.session.abort();
+    const abortedExtensionCommand = abortRuntimeExtensionCommand(cachedRuntime);
+    if (abortedExtensionCommand || cachedRuntime.session.isStreaming) {
+      if (!abortedExtensionCommand) {
+        await cachedRuntime.session.abort();
+      }
       scheduleRuntimeDisposalForRuntime(cachedRuntime);
       await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
       return;
@@ -324,7 +328,9 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
       suspendDisposal: true,
     });
 
-    await runtime.session.abort();
+    if (!abortRuntimeExtensionCommand(runtime)) {
+      await runtime.session.abort();
+    }
     scheduleRuntimeDisposalForRuntime(runtime);
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -64,6 +64,12 @@ async function emitComposerUpdate(request: ComposerStateRequest = {}) {
   };
 }
 
+function isExtensionCommandPrompt(runtime: PiRuntime, text: string) {
+  if (!text.startsWith("/")) return false;
+  const commandName = text.slice(1).split(/\s+/, 1)[0];
+  return Boolean(runtime.session.extensionRunner.getCommand(commandName));
+}
+
 async function promptAndReturnAfterPreflight({
   runtime,
   message,
@@ -252,15 +258,19 @@ export async function sendComposerPrompt(
 
       if (runtime.session.isStreaming) {
         if (streamingBehavior === "stop") {
-          await runtime.session.abort();
-          await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-          return "stopped";
+          if (!isExtensionCommandPrompt(runtime, request.text)) {
+            await runtime.session.abort();
+            await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
+            return "stopped";
+          }
         }
 
+        const promptStreamingBehavior =
+          streamingBehavior === "stop" ? "followUp" : streamingBehavior;
         await promptAndReturnAfterPreflight({
           runtime,
           message,
-          options: { streamingBehavior },
+          options: { streamingBehavior: promptStreamingBehavior },
           request: { ...request, sessionPath: persistedSessionPath },
         });
       } else {
@@ -330,10 +340,11 @@ export async function stopComposerRun(request: ComposerStateRequest): Promise<vo
     });
 
     const abortedExtensionCommand = abortRuntimeExtensionCommand(runtime);
-    if (runtime.session.isStreaming) {
+    const wasStreaming = runtime.session.isStreaming;
+    if (wasStreaming) {
       await runtime.session.abort();
     }
-    if (!abortedExtensionCommand && !runtime.session.isStreaming) await runtime.session.abort();
+    if (!abortedExtensionCommand && !wasStreaming) await runtime.session.abort();
     scheduleRuntimeDisposalForRuntime(runtime);
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
   });

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -13,7 +13,7 @@ import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directo
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { buildQueuedPrompts } from "./composer-queue";
-import { initHeadlessPiTheme } from "./headless-pi-theme.cts";
+import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 import type { PiRuntime } from "./types.cts";
 
 export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
@@ -185,7 +185,6 @@ export async function createComposerSnapshotSession(request: ComposerStateReques
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(cwd, agentDir);
-  await initHeadlessPiTheme(settingsManager);
   const sessionManager = persistedSessionPath
     ? SessionManager.open(persistedSessionPath)
     : SessionManager.inMemory();
@@ -198,6 +197,7 @@ export async function createComposerSnapshotSession(request: ComposerStateReques
     sessionManager,
     tools: [],
   });
+  await applyHeadlessPiTheme(session);
 
   return {
     cwd,

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -13,7 +13,6 @@ import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directo
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { buildQueuedPrompts } from "./composer-queue";
-import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 import type { PiRuntime } from "./types.cts";
 
 export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
@@ -197,7 +196,6 @@ export async function createComposerSnapshotSession(request: ComposerStateReques
     sessionManager,
     tools: [],
   });
-  await applyHeadlessPiTheme(session);
 
   return {
     cwd,

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -13,6 +13,7 @@ import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directo
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { buildQueuedPrompts } from "./composer-queue";
+import { initHeadlessPiTheme } from "./headless-pi-theme.cts";
 import type { PiRuntime } from "./types.cts";
 
 export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
@@ -184,6 +185,7 @@ export async function createComposerSnapshotSession(request: ComposerStateReques
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(cwd, agentDir);
+  await initHeadlessPiTheme(settingsManager);
   const sessionManager = persistedSessionPath
     ? SessionManager.open(persistedSessionPath)
     : SessionManager.inMemory();

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -12,6 +12,7 @@ import type {
 import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
+import { isHeadlessExtensionCommandRunning } from "./agent-session-extensions.cts";
 import { buildQueuedPrompts } from "./composer-queue";
 import type { PiRuntime } from "./types.cts";
 
@@ -232,6 +233,7 @@ export async function buildComposerStateSnapshot(
     queuedPrompts: [],
     contextUsage: snapshot.contextUsage,
     isCompacting: false,
+    isExtensionCommandRunning: false,
   };
 }
 
@@ -255,5 +257,6 @@ export async function buildComposerState(
     queuedPrompts: buildSessionQueuedPrompts(runtime.session),
     contextUsage: getContextUsageForComposerState(runtime.session, options),
     isCompacting: runtime.session.isCompacting,
+    isExtensionCommandRunning: isHeadlessExtensionCommandRunning(runtime.session),
   };
 }

--- a/desktop/runtime/headless-pi-theme.cts
+++ b/desktop/runtime/headless-pi-theme.cts
@@ -1,0 +1,10 @@
+import { getPiModule } from "../pi-module.cts";
+
+type PiThemeSettings = {
+  getTheme(): string | undefined;
+};
+
+export async function initHeadlessPiTheme(settingsManager: PiThemeSettings) {
+  const { initTheme } = await getPiModule();
+  initTheme(settingsManager.getTheme(), false);
+}

--- a/desktop/runtime/headless-pi-theme.cts
+++ b/desktop/runtime/headless-pi-theme.cts
@@ -1,10 +1,38 @@
-import { getPiModule } from "../pi-module.cts";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { AgentSession } from "@mariozechner/pi-coding-agent";
 
-type PiThemeSettings = {
-  getTheme(): string | undefined;
+const require = createRequire(import.meta.url);
+
+type PiThemeModule = {
+  initTheme(themeName?: string, enableWatcher?: boolean): void;
+  setRegisteredThemes(
+    themes: AgentSession["resourceLoader"]["getThemes"] extends () => infer Result
+      ? Result extends { themes: infer Themes }
+        ? Themes
+        : never
+      : never,
+  ): void;
 };
 
-export async function initHeadlessPiTheme(settingsManager: PiThemeSettings) {
-  const { initTheme } = await getPiModule();
-  initTheme(settingsManager.getTheme(), false);
+let themeModulePromise: Promise<PiThemeModule> | null = null;
+
+async function getPiThemeModule() {
+  if (!themeModulePromise) {
+    const piEntryPath = require.resolve("@mariozechner/pi-coding-agent");
+    const themeModulePath = path.join(
+      path.dirname(piEntryPath),
+      "modes/interactive/theme/theme.js",
+    );
+    themeModulePromise = import(pathToFileURL(themeModulePath).href) as Promise<PiThemeModule>;
+  }
+
+  return themeModulePromise;
+}
+
+export async function applyHeadlessPiTheme(session: AgentSession) {
+  const { initTheme, setRegisteredThemes } = await getPiThemeModule();
+  setRegisteredThemes(session.resourceLoader.getThemes().themes);
+  initTheme(session.settingsManager.getTheme(), false);
 }

--- a/desktop/runtime/headless-pi-theme.cts
+++ b/desktop/runtime/headless-pi-theme.cts
@@ -18,6 +18,12 @@ type PiThemeModule = {
 
 let themeModulePromise: Promise<PiThemeModule> | null = null;
 
+async function resolvePiPackageRootFromImport() {
+  const entryUrl = await import.meta.resolve("@mariozechner/pi-coding-agent");
+  const entryPath = fileURLToPath(entryUrl);
+  return path.resolve(path.dirname(entryPath), "..");
+}
+
 function findPiPackageRoot() {
   let directory = path.dirname(fileURLToPath(import.meta.url));
 
@@ -37,11 +43,8 @@ function findPiPackageRoot() {
 
 async function getPiThemeModule() {
   if (!themeModulePromise) {
-    const themeModulePath = path.join(
-      findPiPackageRoot(),
-      "dist",
-      "modes/interactive/theme/theme.js",
-    );
+    const piPackageRoot = await resolvePiPackageRootFromImport().catch(() => findPiPackageRoot());
+    const themeModulePath = path.join(piPackageRoot, "dist", "modes/interactive/theme/theme.js");
     themeModulePromise = import(pathToFileURL(themeModulePath).href) as Promise<PiThemeModule>;
   }
 

--- a/desktop/runtime/headless-pi-theme.cts
+++ b/desktop/runtime/headless-pi-theme.cts
@@ -1,9 +1,9 @@
-import { createRequire } from "node:module";
+import fs from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 
-const require = createRequire(import.meta.url);
+const piPackagePath = path.join("node_modules", "@mariozechner", "pi-coding-agent");
 
 type PiThemeModule = {
   initTheme(themeName?: string, enableWatcher?: boolean): void;
@@ -18,11 +18,28 @@ type PiThemeModule = {
 
 let themeModulePromise: Promise<PiThemeModule> | null = null;
 
+function findPiPackageRoot() {
+  let directory = path.dirname(fileURLToPath(import.meta.url));
+
+  while (true) {
+    const candidate = path.join(directory, piPackagePath);
+    if (fs.existsSync(path.join(candidate, "package.json"))) {
+      return candidate;
+    }
+
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      throw new Error("Could not locate @mariozechner/pi-coding-agent package root.");
+    }
+    directory = parent;
+  }
+}
+
 async function getPiThemeModule() {
   if (!themeModulePromise) {
-    const piEntryPath = require.resolve("@mariozechner/pi-coding-agent");
     const themeModulePath = path.join(
-      path.dirname(piEntryPath),
+      findPiPackageRoot(),
+      "dist",
       "modes/interactive/theme/theme.js",
     );
     themeModulePromise = import(pathToFileURL(themeModulePath).href) as Promise<PiThemeModule>;

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -2,6 +2,7 @@ import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { bindHeadlessAgentSessionExtensions } from "./agent-session-extensions.cts";
 import { buildComposerState } from "./composer-state.cts";
+import { initHeadlessPiTheme } from "./headless-pi-theme.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
 import { createRuntimeSettingsRefreshController, isRuntimeBusy } from "./settings-refresh.ts";
 import {
@@ -164,6 +165,7 @@ async function createRuntime(options: {
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(options.cwd, agentDir);
+  await initHeadlessPiTheme(settingsManager);
   const sessionDir = settingsManager.getSessionDir() ?? undefined;
   const { session } = await createAgentSession({
     cwd: options.cwd,

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -2,7 +2,7 @@ import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
 import { bindHeadlessAgentSessionExtensions } from "./agent-session-extensions.cts";
 import { buildComposerState } from "./composer-state.cts";
-import { initHeadlessPiTheme } from "./headless-pi-theme.cts";
+import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
 import { createRuntimeSettingsRefreshController, isRuntimeBusy } from "./settings-refresh.ts";
 import {
@@ -32,6 +32,7 @@ const settingsRefreshController = createRuntimeSettingsRefreshController({
       runtimePromise: record.runtimePromise,
     })),
   withRuntimeMutationLock,
+  afterReload: (runtime) => applyHeadlessPiTheme(runtime.session),
   buildComposerState,
   publishComposerUpdate,
 });
@@ -165,7 +166,6 @@ async function createRuntime(options: {
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
   const settingsManager = SettingsManager.create(options.cwd, agentDir);
-  await initHeadlessPiTheme(settingsManager);
   const sessionDir = settingsManager.getSessionDir() ?? undefined;
   const { session } = await createAgentSession({
     cwd: options.cwd,
@@ -175,6 +175,7 @@ async function createRuntime(options: {
     settingsManager,
     sessionManager: options.sessionManager ?? SessionManager.create(options.cwd, sessionDir),
   });
+  await applyHeadlessPiTheme(session);
 
   const runtime = {
     cwd: options.cwd,

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -3,9 +3,10 @@ import { getPiModule } from "../pi-module.cts";
 import {
   abortHeadlessExtensionCommand,
   bindHeadlessAgentSessionExtensions,
+  isHeadlessExtensionCommandRunning,
+  refreshHeadlessAgentSessionExtensionBindings,
 } from "./agent-session-extensions.cts";
 import { buildComposerState } from "./composer-state.cts";
-import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
 import { createRuntimeSettingsRefreshController, isRuntimeBusy } from "./settings-refresh.ts";
 import {
@@ -35,7 +36,7 @@ const settingsRefreshController = createRuntimeSettingsRefreshController({
       runtimePromise: record.runtimePromise,
     })),
   withRuntimeMutationLock,
-  afterReload: (runtime) => applyHeadlessPiTheme(runtime.session),
+  afterReload: (runtime) => refreshRuntimeExtensionBindings(runtime),
   buildComposerState,
   publishComposerUpdate,
 });
@@ -178,8 +179,6 @@ async function createRuntime(options: {
     settingsManager,
     sessionManager: options.sessionManager ?? SessionManager.create(options.cwd, sessionDir),
   });
-  await applyHeadlessPiTheme(session);
-
   const runtime = {
     cwd: options.cwd,
     session,
@@ -347,6 +346,27 @@ async function createRuntime(options: {
 
 export function abortRuntimeExtensionCommand(runtime: PiRuntime) {
   return abortHeadlessExtensionCommand(runtime.session);
+}
+
+export function isRuntimeExtensionCommandRunning(runtime: PiRuntime) {
+  return isHeadlessExtensionCommandRunning(runtime.session);
+}
+
+export async function refreshRuntimeExtensionBindings(runtime: PiRuntime) {
+  await refreshHeadlessAgentSessionExtensionBindings(runtime.session, {
+    onExtensionCommandStateChange: () => {
+      void buildComposerState(runtime)
+        .then((composer) => {
+          publishComposerUpdate(composer, {
+            projectId: runtime.cwd,
+            sessionPath: runtime.session.sessionFile,
+          });
+        })
+        .catch(() => {
+          // Ignore transient composer snapshot errors; a later runtime event will republish state.
+        });
+    },
+  });
 }
 
 function registerRuntime(runtimeKey: string, runtimePromise: Promise<PiRuntime>) {

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -37,9 +37,14 @@ const settingsRefreshController = createRuntimeSettingsRefreshController({
     })),
   withRuntimeMutationLock,
   afterReload: (runtime) => refreshRuntimeExtensionBindings(runtime),
+  isRuntimeBusy: isHowcodeRuntimeBusy,
   buildComposerState,
   publishComposerUpdate,
 });
+
+function isHowcodeRuntimeBusy(runtime: PiRuntime) {
+  return isRuntimeBusy(runtime) || isRuntimeExtensionCommandRunning(runtime);
+}
 
 function clearRuntimeDisposeTimeout(runtimeKey: string) {
   const record = runtimeRecords.get(runtimeKey);
@@ -72,7 +77,7 @@ function scheduleRuntimeDisposal(runtimeKey: string) {
 
       try {
         const runtime = await record.runtimePromise;
-        if (isRuntimeBusy(runtime)) {
+        if (isHowcodeRuntimeBusy(runtime)) {
           scheduleRuntimeDisposal(runtimeKey);
           return;
         }
@@ -409,7 +414,7 @@ export async function getOrCreateRuntimeForSessionPath(
     }
 
     const runtime = await existingRuntime.runtimePromise;
-    if (!isRuntimeBusy(runtime)) {
+    if (!isHowcodeRuntimeBusy(runtime)) {
       await reloadRuntimeSettingsIfSafe(persistedSessionPath, { useMutationLock: false });
     }
     return runtime;

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -343,6 +343,14 @@ async function createRuntime(options: {
         .catch(() => {
           // Ignore transient composer snapshot errors; a later runtime event will republish state.
         });
+      if (!isRuntimeExtensionCommandRunning(runtime)) {
+        const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+        if (runtimeKey) {
+          void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {
+            // Keep stale settings marked; the next safe point retries silently.
+          });
+        }
+      }
     },
   });
 
@@ -370,6 +378,14 @@ export async function refreshRuntimeExtensionBindings(runtime: PiRuntime) {
         .catch(() => {
           // Ignore transient composer snapshot errors; a later runtime event will republish state.
         });
+      if (!isRuntimeExtensionCommandRunning(runtime)) {
+        const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+        if (runtimeKey) {
+          void reloadRuntimeSettingsIfSafe(runtimeKey).catch(() => {
+            // Keep stale settings marked; the next safe point retries silently.
+          });
+        }
+      }
     },
   });
 }

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -1,6 +1,9 @@
 import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
-import { bindHeadlessAgentSessionExtensions } from "./agent-session-extensions.cts";
+import {
+  abortHeadlessExtensionCommand,
+  bindHeadlessAgentSessionExtensions,
+} from "./agent-session-extensions.cts";
 import { buildComposerState } from "./composer-state.cts";
 import { applyHeadlessPiTheme } from "./headless-pi-theme.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
@@ -324,9 +327,26 @@ async function createRuntime(options: {
     }
   });
 
-  await bindHeadlessAgentSessionExtensions(session);
+  await bindHeadlessAgentSessionExtensions(session, {
+    onExtensionCommandStateChange: () => {
+      void buildComposerState(runtime)
+        .then((composer) => {
+          publishComposerUpdate(composer, {
+            projectId: runtime.cwd,
+            sessionPath: runtime.session.sessionFile,
+          });
+        })
+        .catch(() => {
+          // Ignore transient composer snapshot errors; a later runtime event will republish state.
+        });
+    },
+  });
 
   return runtime;
+}
+
+export function abortRuntimeExtensionCommand(runtime: PiRuntime) {
+  return abortHeadlessExtensionCommand(runtime.session);
 }
 
 function registerRuntime(runtimeKey: string, runtimePromise: Promise<PiRuntime>) {

--- a/desktop/runtime/settings-refresh.ts
+++ b/desktop/runtime/settings-refresh.ts
@@ -13,6 +13,7 @@ type RuntimeSettingsRefreshControllerOptions = {
   getRuntimeRecords: () => RuntimeRecordSnapshot[];
   withRuntimeMutationLock: <T>(runtimeKey: string, task: () => Promise<T>) => Promise<T>;
   afterReload?: (runtime: PiRuntime) => Promise<void>;
+  isRuntimeBusy?: (runtime: PiRuntime) => boolean;
   buildComposerState: (runtime: PiRuntime) => Promise<ComposerState>;
   publishComposerUpdate: (
     composer: ComposerState,
@@ -29,6 +30,7 @@ export function createRuntimeSettingsRefreshController({
   getRuntimeRecords,
   withRuntimeMutationLock,
   afterReload,
+  isRuntimeBusy: isRuntimeBusyOption = isRuntimeBusy,
   buildComposerState,
   publishComposerUpdate,
 }: RuntimeSettingsRefreshControllerOptions) {
@@ -36,7 +38,7 @@ export function createRuntimeSettingsRefreshController({
   const activeReloads = new Map<string, Promise<void>>();
 
   async function reloadRuntimeSettings(runtimeKey: string, runtime: PiRuntime) {
-    if (isRuntimeBusy(runtime)) {
+    if (isRuntimeBusyOption(runtime)) {
       return false;
     }
 
@@ -86,7 +88,7 @@ export function createRuntimeSettingsRefreshController({
     try {
       let reloaded = false;
       let reloadedGeneration: number | null = null;
-      while (!isRuntimeBusy(runtime)) {
+      while (!isRuntimeBusyOption(runtime)) {
         const generation = staleGenerations.get(runtimeKey);
         if (generation === undefined) {
           break;

--- a/desktop/runtime/settings-refresh.ts
+++ b/desktop/runtime/settings-refresh.ts
@@ -46,15 +46,18 @@ export function createRuntimeSettingsRefreshController({
       return false;
     }
 
-    const reload = runtime.session.reload().finally(() => {
-      if (activeReloads.get(runtimeKey) === reload) {
-        activeReloads.delete(runtimeKey);
-      }
-    });
+    const reload = runtime.session
+      .reload()
+      .then(() => afterReload?.(runtime))
+      .then(() => undefined)
+      .finally(() => {
+        if (activeReloads.get(runtimeKey) === reload) {
+          activeReloads.delete(runtimeKey);
+        }
+      });
 
     activeReloads.set(runtimeKey, reload);
     await reload;
-    await afterReload?.(runtime);
     return true;
   }
 

--- a/desktop/runtime/settings-refresh.ts
+++ b/desktop/runtime/settings-refresh.ts
@@ -12,6 +12,7 @@ type RuntimeSettingsRefreshControllerOptions = {
   getCachedRuntimeForSessionPath: (sessionPath: string) => Promise<PiRuntime> | null;
   getRuntimeRecords: () => RuntimeRecordSnapshot[];
   withRuntimeMutationLock: <T>(runtimeKey: string, task: () => Promise<T>) => Promise<T>;
+  afterReload?: (runtime: PiRuntime) => Promise<void>;
   buildComposerState: (runtime: PiRuntime) => Promise<ComposerState>;
   publishComposerUpdate: (
     composer: ComposerState,
@@ -27,6 +28,7 @@ export function createRuntimeSettingsRefreshController({
   getCachedRuntimeForSessionPath,
   getRuntimeRecords,
   withRuntimeMutationLock,
+  afterReload,
   buildComposerState,
   publishComposerUpdate,
 }: RuntimeSettingsRefreshControllerOptions) {
@@ -52,6 +54,7 @@ export function createRuntimeSettingsRefreshController({
 
     activeReloads.set(runtimeKey, reload);
     await reload;
+    await afterReload?.(runtime);
     return true;
   }
 

--- a/shared/desktop-composer-contracts.ts
+++ b/shared/desktop-composer-contracts.ts
@@ -32,6 +32,7 @@ export type ComposerState = {
   queuedPrompts: ComposerQueuedPrompt[];
   contextUsage: ComposerContextUsage | null;
   isCompacting: boolean;
+  isExtensionCommandRunning: boolean;
 };
 
 export type ComposerAttachment = {

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -20,6 +20,7 @@ export type ComposerProps = {
   availableModels: ComposerModel[];
   isStreaming: boolean;
   isCompacting: boolean;
+  isExtensionCommandRunning: boolean;
   thinkingLevel: ComposerThinkingLevel;
   restoredQueuedPrompt: string | null;
   streamingBehaviorPreference: ComposerStreamingBehavior;

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -473,7 +473,7 @@ export function ComposerPromptSurface({
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
                 onClick={() => void stop()}
-                disabled={(!composerIsStreaming && !extensionRunning) || isSending}
+                disabled={(!composerIsStreaming && !extensionRunning) || isSending || !sessionPath}
                 aria-label="Stop Pi"
                 data-tooltip="Stop Pi"
               >

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -257,6 +257,7 @@ export function ComposerPromptSurface({
 
   const placeholderText =
     errorMessage ??
+    (isSending && !composerIsStreaming && !isCompacting ? "Pi extension running…" : null) ??
     (activeView === "thread"
       ? "Ask for follow-up changes"
       : "Ask Pi anything, @ to add files, / for commands, $ for skills");
@@ -442,7 +443,13 @@ export function ComposerPromptSurface({
                   ariaExpanded={slashCommands.open}
                   placeholder={placeholderText}
                   placeholderTone={errorMessage ? "error" : "muted"}
-                  statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
+                  statusMessage={
+                    errorMessage && draft.length > 0
+                      ? errorMessage
+                      : isSending && !composerIsStreaming && !isCompacting
+                        ? "Pi extension running…"
+                        : null
+                  }
                   reservedLineCount={1}
                   onHeightChange={onLayoutChange}
                 />
@@ -481,8 +488,8 @@ export function ComposerPromptSurface({
                 )}
                 onClick={slashCommands.submit}
                 disabled={!canSend}
-                aria-label="Send"
-                data-tooltip="Send"
+                aria-label={isSending && !composerIsStreaming ? "Pi extension running" : "Send"}
+                data-tooltip={isSending && !composerIsStreaming ? "Pi extension running" : "Send"}
               >
                 <Send size={14} />
               </button>

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -72,6 +72,7 @@ export function ComposerPromptSurface({
     dictationMissingModel,
     dictationSupported,
     errorMessage,
+    extensionCommandRunning,
     isSending,
     isStreaming: composerIsStreaming,
     pickerButtonRef,
@@ -89,6 +90,7 @@ export function ComposerPromptSurface({
     runComposerAction,
     compact,
     send,
+    sendExtensionCommand,
     setDraft,
     setOpenMenu,
     stop,
@@ -124,6 +126,7 @@ export function ComposerPromptSurface({
     sessionPath,
     setDraft,
     send,
+    sendExtensionCommand,
     onOpenSettingsView,
   });
   const slashCommandListSignature = slashCommands.commands
@@ -255,7 +258,7 @@ export function ComposerPromptSurface({
     };
   }, [handleDrop]);
 
-  const extensionRunning = isSending && !composerIsStreaming && !isCompacting;
+  const extensionRunning = extensionCommandRunning;
   const placeholderText =
     errorMessage ??
     (activeView === "thread"

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -484,21 +484,20 @@ export function ComposerPromptSurface({
                   <Loader2 size={12} className="animate-spin" />
                   <span>Pi extension running</span>
                 </div>
-              ) : (
-                <button
-                  type="button"
-                  className={cn(
-                    compactIconButtonClass,
-                    "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
-                  )}
-                  onClick={slashCommands.submit}
-                  disabled={!canSend}
-                  aria-label="Send"
-                  data-tooltip="Send"
-                >
-                  <Send size={14} />
-                </button>
-              )}
+              ) : null}
+              <button
+                type="button"
+                className={cn(
+                  compactIconButtonClass,
+                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
+                )}
+                onClick={slashCommands.submit}
+                disabled={!canSend}
+                aria-label="Send"
+                data-tooltip="Send"
+              >
+                <Send size={14} />
+              </button>
             </div>
           </div>
         </div>

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -1,4 +1,4 @@
-import { Paperclip, Send, Square, X } from "lucide-react";
+import { Loader2, Paperclip, Send, Square, X } from "lucide-react";
 import { type ClipboardEvent, type RefObject, useEffect, useRef } from "react";
 import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
@@ -255,9 +255,9 @@ export function ComposerPromptSurface({
     };
   }, [handleDrop]);
 
+  const extensionRunning = isSending && !composerIsStreaming && !isCompacting;
   const placeholderText =
     errorMessage ??
-    (isSending && !composerIsStreaming && !isCompacting ? "Pi extension running…" : null) ??
     (activeView === "thread"
       ? "Ask for follow-up changes"
       : "Ask Pi anything, @ to add files, / for commands, $ for skills");
@@ -443,13 +443,7 @@ export function ComposerPromptSurface({
                   ariaExpanded={slashCommands.open}
                   placeholder={placeholderText}
                   placeholderTone={errorMessage ? "error" : "muted"}
-                  statusMessage={
-                    errorMessage && draft.length > 0
-                      ? errorMessage
-                      : isSending && !composerIsStreaming && !isCompacting
-                        ? "Pi extension running…"
-                        : null
-                  }
+                  statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                   reservedLineCount={1}
                   onHeightChange={onLayoutChange}
                 />
@@ -480,19 +474,26 @@ export function ComposerPromptSurface({
               >
                 <Square size={11} fill="currentColor" />
               </button>
-              <button
-                type="button"
-                className={cn(
-                  compactIconButtonClass,
-                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
-                )}
-                onClick={slashCommands.submit}
-                disabled={!canSend}
-                aria-label={isSending && !composerIsStreaming ? "Pi extension running" : "Send"}
-                data-tooltip={isSending && !composerIsStreaming ? "Pi extension running" : "Send"}
-              >
-                <Send size={14} />
-              </button>
+              {extensionRunning ? (
+                <div className="inline-flex h-6 items-center gap-1.5 rounded-full border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.045)] px-2.5 text-[12px] text-[color:var(--muted)]">
+                  <Loader2 size={12} className="animate-spin" />
+                  <span>Pi extension running</span>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className={cn(
+                    compactIconButtonClass,
+                    "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
+                  )}
+                  onClick={slashCommands.submit}
+                  disabled={!canSend}
+                  aria-label="Send"
+                  data-tooltip="Send"
+                >
+                  <Send size={14} />
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -37,6 +37,7 @@ export function ComposerPromptSurface({
   availableModels,
   isStreaming,
   isCompacting,
+  isExtensionCommandRunning,
   thinkingLevel,
   restoredQueuedPrompt,
   streamingBehaviorPreference,
@@ -112,6 +113,7 @@ export function ComposerPromptSurface({
     dictationMaxDurationSeconds,
     isStreaming,
     isCompacting,
+    isExtensionCommandRunning,
     restoredQueuedPrompt,
     streamingBehaviorPreference,
     onAction,
@@ -471,7 +473,7 @@ export function ComposerPromptSurface({
                   "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1] disabled:cursor-not-allowed disabled:opacity-45",
                 )}
                 onClick={() => void stop()}
-                disabled={!composerIsStreaming || isSending}
+                disabled={(!composerIsStreaming && !extensionRunning) || isSending}
                 aria-label="Stop Pi"
                 data-tooltip="Stop Pi"
               >

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -213,6 +213,11 @@ export function useComposerController({
   const canSend =
     (draft.trim().length > 0 || attachments.length > 0) && !isSending && !isCompacting;
 
+  useEffect(() => {
+    void composerScopeKey;
+    setLocalExtensionCommandRunning(false);
+  }, [composerScopeKey]);
+
   const {
     cancelDictation,
     dictationActive,

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -91,6 +91,7 @@ export function useComposerController({
   const [draft, setDraft] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [openMenu, setOpenMenu] = useState<"model" | "picker" | null>(null);
+  const [extensionCommandRunning, setExtensionCommandRunning] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const composerScopeKey = useMemo(
@@ -264,7 +265,7 @@ export function useComposerController({
     }
   };
 
-  const { compact, send, stop } = useComposerSubmission({
+  const { compact, send, sendExtensionCommand, stop } = useComposerSubmission({
     composerScopeKey,
     draftThreadId,
     isSending,
@@ -276,6 +277,7 @@ export function useComposerController({
     setAttachments: setAttachmentValue,
     setDraftValue,
     setErrorMessage,
+    setExtensionCommandRunning,
     setIsSending,
     setOpenMenu,
     stopDictationAndFlush,
@@ -310,6 +312,7 @@ export function useComposerController({
     dictationMissingModel,
     dictationSupported,
     errorMessage,
+    extensionCommandRunning,
     isSending,
     pickerButtonRef,
     pickerLoading,
@@ -328,6 +331,7 @@ export function useComposerController({
     runComposerAction,
     compact,
     send,
+    sendExtensionCommand,
     setDraft: setDraftValue,
     setOpenMenu,
     stop,

--- a/src/app/components/workspace/composer/useComposerController.ts
+++ b/src/app/components/workspace/composer/useComposerController.ts
@@ -55,6 +55,7 @@ type UseComposerControllerProps = {
   dictationMaxDurationSeconds: number;
   isStreaming: boolean;
   isCompacting: boolean;
+  isExtensionCommandRunning: boolean;
   restoredQueuedPrompt: string | null;
   streamingBehaviorPreference: ComposerStreamingBehavior;
   onAction: DesktopActionInvoker;
@@ -78,6 +79,7 @@ export function useComposerController({
   dictationMaxDurationSeconds,
   isStreaming,
   isCompacting,
+  isExtensionCommandRunning,
   restoredQueuedPrompt,
   streamingBehaviorPreference,
   onAction,
@@ -91,7 +93,7 @@ export function useComposerController({
   const [draft, setDraft] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [openMenu, setOpenMenu] = useState<"model" | "picker" | null>(null);
-  const [extensionCommandRunning, setExtensionCommandRunning] = useState(false);
+  const [localExtensionCommandRunning, setLocalExtensionCommandRunning] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const composerScopeKey = useMemo(
@@ -207,6 +209,7 @@ export function useComposerController({
     };
   }, [composerPanelRef, mainViewRef, openMenu, workspaceFooterRef]);
 
+  const extensionCommandRunning = isExtensionCommandRunning || localExtensionCommandRunning;
   const canSend =
     (draft.trim().length > 0 || attachments.length > 0) && !isSending && !isCompacting;
 
@@ -277,7 +280,8 @@ export function useComposerController({
     setAttachments: setAttachmentValue,
     setDraftValue,
     setErrorMessage,
-    setExtensionCommandRunning,
+    extensionCommandRunning,
+    setExtensionCommandRunning: setLocalExtensionCommandRunning,
     setIsSending,
     setOpenMenu,
     stopDictationAndFlush,

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -117,7 +117,7 @@ export function useComposerSlashCommands({
         return;
       }
 
-      if (loading && draft.trim() !== "/settings") {
+      if (loading && draft.trim() !== "/settings" && draft.trim().length <= 1) {
         return;
       }
     }

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -78,6 +78,7 @@ export function useComposerSlashCommands({
   const candidateFilter = getSlashCommandFilter(draft);
   const filter = draft === dismissedDraft ? null : candidateFilter;
   const open = filter !== null;
+  const commandScopeKey = `${projectId}\0${sessionPath ?? ""}`;
   const filteredCommands = useMemo(() => {
     if (filter === null) {
       return [];
@@ -98,6 +99,13 @@ export function useComposerSlashCommands({
 
   const isExactCommandDraft = (command: ComposerSlashCommand) =>
     draft.trim() === `/${command.name}` && !draft.endsWith(" ");
+
+  const getDraftCommand = () => {
+    const trimmedDraft = draft.trim();
+    if (!trimmedDraft.startsWith("/")) return null;
+    const commandName = trimmedDraft.slice(1).split(/\s+/, 1)[0];
+    return commands.find((command) => command.name === commandName) ?? null;
+  };
 
   const selectCommand = (command: ComposerSlashCommand) => {
     if (command.source === "app" && command.name === "settings") {
@@ -144,7 +152,12 @@ export function useComposerSlashCommands({
     }
 
     if (draft.trim().startsWith("/")) {
+      const draftCommand = getDraftCommand();
       dismiss();
+      if (draftCommand?.source === "extension" && sendExtensionCommand) {
+        sendExtensionCommand();
+        return;
+      }
     }
 
     send();
@@ -214,7 +227,6 @@ export function useComposerSlashCommands({
   useEffect(() => {
     if (!open) {
       setSelectedIndex(0);
-      setCommands([]);
       setLoading(false);
       return;
     }
@@ -244,6 +256,11 @@ export function useComposerSlashCommands({
       cancelled = true;
     };
   }, [open, projectId, sessionPath]);
+
+  useEffect(() => {
+    void commandScopeKey;
+    setCommands([]);
+  }, [commandScopeKey]);
 
   useEffect(() => {
     if (selectedIndex >= filteredCommands.length) {

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -158,6 +158,20 @@ export function useComposerSlashCommands({
         sendExtensionCommand();
         return;
       }
+      if (!draftCommand && sendExtensionCommand && (loading || commands.length === 0)) {
+        void getComposerSlashCommandsQuery({ projectId, sessionPath })
+          .then((nextCommands) => {
+            const commandName = draft.trim().slice(1).split(/\s+/, 1)[0];
+            const resolvedCommand = nextCommands.find((command) => command.name === commandName);
+            if (resolvedCommand?.source === "extension") {
+              sendExtensionCommand();
+            } else {
+              send();
+            }
+          })
+          .catch(() => send());
+        return;
+      }
     }
 
     send();

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -45,6 +45,11 @@ function getSlashCommandFilter(draft: string) {
   return query.toLowerCase();
 }
 
+function shouldWaitForSlashCommands(draft: string) {
+  const trimmedDraft = draft.trim();
+  return trimmedDraft.length <= 1 && trimmedDraft !== "/settings";
+}
+
 type UseComposerSlashCommandsOptions = {
   draft: string;
   projectId: string;
@@ -117,7 +122,7 @@ export function useComposerSlashCommands({
         return;
       }
 
-      if (loading && draft.trim() !== "/settings" && draft.trim().length <= 1) {
+      if (loading && shouldWaitForSlashCommands(draft)) {
         return;
       }
     }
@@ -185,7 +190,7 @@ export function useComposerSlashCommands({
       return true;
     }
 
-    if (event.key === "Enter" && !event.shiftKey && loading) {
+    if (event.key === "Enter" && !event.shiftKey && loading && shouldWaitForSlashCommands(draft)) {
       event.preventDefault();
       return true;
     }

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -134,6 +134,10 @@ export function useComposerSlashCommands({
       return;
     }
 
+    if (draft.trim().startsWith("/")) {
+      dismiss();
+    }
+
     send();
   };
 

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
+import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   appSettingsSlashCommand,
   fallbackAppSlashCommands,
@@ -79,6 +79,10 @@ export function useComposerSlashCommands({
   const filter = draft === dismissedDraft ? null : candidateFilter;
   const open = filter !== null;
   const commandScopeKey = `${projectId}\0${sessionPath ?? ""}`;
+  const draftRef = useRef(draft);
+  const commandScopeKeyRef = useRef(commandScopeKey);
+  draftRef.current = draft;
+  commandScopeKeyRef.current = commandScopeKey;
   const filteredCommands = useMemo(() => {
     if (filter === null) {
       return [];
@@ -159,17 +163,27 @@ export function useComposerSlashCommands({
         return;
       }
       if (!draftCommand && sendExtensionCommand && (loading || commands.length === 0)) {
+        const submittedDraft = draft;
+        const submittedScopeKey = commandScopeKey;
         void getComposerSlashCommandsQuery({ projectId, sessionPath })
           .then((nextCommands) => {
-            const commandName = draft.trim().slice(1).split(/\s+/, 1)[0];
+            if (
+              draftRef.current !== submittedDraft ||
+              commandScopeKeyRef.current !== submittedScopeKey
+            ) {
+              return;
+            }
+            const commandName = submittedDraft.trim().slice(1).split(/\s+/, 1)[0];
             const resolvedCommand = nextCommands.find((command) => command.name === commandName);
             if (resolvedCommand?.source === "extension") {
               sendExtensionCommand();
-            } else {
+            } else if (resolvedCommand) {
               send();
             }
           })
-          .catch(() => send());
+          .catch(() => {
+            // Keep slash text in the editor rather than leaking an unresolved command to the model.
+          });
         return;
       }
     }

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -56,6 +56,7 @@ type UseComposerSlashCommandsOptions = {
   sessionPath: string | null;
   setDraft: (draft: string) => void;
   send: () => void;
+  sendExtensionCommand?: () => void;
   onOpenSettingsView: () => void;
 };
 
@@ -65,6 +66,7 @@ export function useComposerSlashCommands({
   sessionPath,
   setDraft,
   send,
+  sendExtensionCommand,
   onOpenSettingsView,
 }: UseComposerSlashCommandsOptions) {
   const [commands, setCommands] = useState<ComposerSlashCommand[]>([]);
@@ -103,7 +105,12 @@ export function useComposerSlashCommands({
     }
 
     if (isExactCommandDraft(command)) {
-      send();
+      dismiss();
+      if (command.source === "extension" && sendExtensionCommand) {
+        sendExtensionCommand();
+      } else {
+        send();
+      }
       return;
     }
 

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -47,7 +47,9 @@ function getSlashCommandFilter(draft: string) {
 
 function shouldWaitForSlashCommands(draft: string) {
   const trimmedDraft = draft.trim();
-  return trimmedDraft.length <= 1 && trimmedDraft !== "/settings";
+  return (
+    trimmedDraft.startsWith("/") && !trimmedDraft.includes(" ") && trimmedDraft !== "/settings"
+  );
 }
 
 type UseComposerSlashCommandsOptions = {

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -125,6 +125,7 @@ type UseComposerSubmissionProps = {
   setAttachments: Dispatch<SetStateAction<ComposerAttachment[]>>;
   setDraftValue: Dispatch<SetStateAction<string>>;
   setErrorMessage: Dispatch<SetStateAction<string | null>>;
+  setExtensionCommandRunning: Dispatch<SetStateAction<boolean>>;
   setIsSending: Dispatch<SetStateAction<boolean>>;
   setOpenMenu: Dispatch<SetStateAction<"model" | "picker" | null>>;
   stopDictationAndFlush: () => Promise<void>;
@@ -149,6 +150,7 @@ export function useComposerSubmission({
   setAttachments,
   setDraftValue,
   setErrorMessage,
+  setExtensionCommandRunning,
   setIsSending,
   setOpenMenu,
   stopDictationAndFlush,
@@ -160,6 +162,67 @@ export function useComposerSubmission({
   sendLockRef,
   skipNextDraftPersistenceRef,
 }: UseComposerSubmissionProps) {
+  const sendExtensionCommand = useCallback(() => {
+    if (isCompacting || sendLockRef.current) {
+      return;
+    }
+
+    const submittedScopeKey = composerScopeKey;
+    const submittedDraftThreadId = draftThreadId;
+    const submittedDraft = draftValueRef.current.trim();
+    if (submittedDraft.length === 0) {
+      return;
+    }
+
+    const submittedAttachments = attachmentsRef.current;
+    setErrorMessage(null);
+    setOpenMenu(null);
+    setExtensionCommandRunning(true);
+
+    if (activeComposerScopeKeyRef.current === submittedScopeKey) {
+      setDraftValue("");
+      if (submittedDraftThreadId) {
+        composerDraftStore.setPrompt(submittedDraftThreadId, "");
+      }
+    }
+
+    void submitComposerDraft({
+      draft: submittedDraft,
+      attachments: submittedAttachments,
+      isSending: false,
+      projectId,
+      sessionPath,
+      streamingBehaviorPreference,
+      onAction,
+    })
+      .then((result) => {
+        if (result.status === "error" && activeComposerScopeKeyRef.current === submittedScopeKey) {
+          setErrorMessage(result.errorMessage);
+        }
+      })
+      .finally(() => {
+        if (activeComposerScopeKeyRef.current === submittedScopeKey) {
+          setExtensionCommandRunning(false);
+        }
+      });
+  }, [
+    activeComposerScopeKeyRef,
+    attachmentsRef,
+    composerScopeKey,
+    draftThreadId,
+    draftValueRef,
+    isCompacting,
+    onAction,
+    projectId,
+    sendLockRef,
+    sessionPath,
+    setDraftValue,
+    setErrorMessage,
+    setExtensionCommandRunning,
+    setOpenMenu,
+    streamingBehaviorPreference,
+  ]);
+
   const send = useCallback(async () => {
     if (isSending || isCompacting || sendLockRef.current) {
       return;
@@ -358,6 +421,7 @@ export function useComposerSubmission({
   return {
     compact,
     send,
+    sendExtensionCommand,
     stop,
   };
 }

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -173,7 +173,7 @@ export function useComposerSubmission({
   const extensionCommandRunIdRef = useRef(0);
 
   const sendExtensionCommand = useCallback(() => {
-    if (isCompacting || extensionCommandRunning) {
+    if (isCompacting || extensionCommandRunning || sendLockRef.current) {
       return;
     }
 
@@ -183,7 +183,7 @@ export function useComposerSubmission({
     setOpenMenu(null);
     setExtensionCommandRunning(true);
 
-    void (async () => {
+    void withComposerSendLock(sendLockRef, async () => {
       const submittedScopeKey = composerScopeKey;
       const submittedDraftThreadId = draftThreadId;
 
@@ -214,9 +214,13 @@ export function useComposerSubmission({
           onAction,
         });
 
-        if (result.status === "error" && activeComposerScopeKeyRef.current === submittedScopeKey) {
-          setDraftValue(result.text);
-          setErrorMessage(result.errorMessage);
+        if (activeComposerScopeKeyRef.current === submittedScopeKey) {
+          if (result.status === "error") {
+            setDraftValue(result.text);
+            setErrorMessage(result.errorMessage);
+          } else if (result.status === "stopped") {
+            setDraftValue(result.text);
+          }
         }
       } catch (error) {
         if (activeComposerScopeKeyRef.current === submittedScopeKey) {
@@ -227,7 +231,7 @@ export function useComposerSubmission({
           setExtensionCommandRunning(false);
         }
       }
-    })();
+    });
   }, [
     activeComposerScopeKeyRef,
     composerScopeKey,
@@ -238,6 +242,7 @@ export function useComposerSubmission({
     onAction,
     projectId,
     sessionPath,
+    sendLockRef,
     setDraftValue,
     setErrorMessage,
     setExtensionCommandRunning,

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -177,46 +177,57 @@ export function useComposerSubmission({
       return;
     }
 
-    const submittedScopeKey = composerScopeKey;
-    const submittedDraftThreadId = draftThreadId;
-    const submittedDraft = draftValueRef.current.trim();
     const runId = extensionCommandRunIdRef.current + 1;
     extensionCommandRunIdRef.current = runId;
-    if (submittedDraft.length === 0) {
-      return;
-    }
-
     setErrorMessage(null);
     setOpenMenu(null);
     setExtensionCommandRunning(true);
 
-    if (activeComposerScopeKeyRef.current === submittedScopeKey) {
-      setDraftValue("");
-      if (submittedDraftThreadId) {
-        composerDraftStore.setPrompt(submittedDraftThreadId, "");
-      }
-    }
+    void (async () => {
+      const submittedScopeKey = composerScopeKey;
+      const submittedDraftThreadId = draftThreadId;
 
-    void submitComposerDraft({
-      draft: submittedDraft,
-      attachments: [],
-      isSending: false,
-      projectId,
-      sessionPath,
-      streamingBehaviorPreference,
-      onAction,
-    })
-      .then((result) => {
+      try {
+        await stopDictationAndFlush();
+
+        if (activeComposerScopeKeyRef.current !== submittedScopeKey) {
+          return;
+        }
+
+        const submittedDraft = draftValueRef.current.trim();
+        if (submittedDraft.length === 0) {
+          return;
+        }
+
+        setDraftValue("");
+        if (submittedDraftThreadId) {
+          composerDraftStore.setPrompt(submittedDraftThreadId, "");
+        }
+
+        const result = await submitComposerDraft({
+          draft: submittedDraft,
+          attachments: [],
+          isSending: false,
+          projectId,
+          sessionPath,
+          streamingBehaviorPreference,
+          onAction,
+        });
+
         if (result.status === "error" && activeComposerScopeKeyRef.current === submittedScopeKey) {
           setDraftValue(result.text);
           setErrorMessage(result.errorMessage);
         }
-      })
-      .finally(() => {
+      } catch (error) {
+        if (activeComposerScopeKeyRef.current === submittedScopeKey) {
+          setErrorMessage(getErrorMessage(error, "Could not send prompt."));
+        }
+      } finally {
         if (extensionCommandRunIdRef.current === runId) {
           setExtensionCommandRunning(false);
         }
-      });
+      }
+    })();
   }, [
     activeComposerScopeKeyRef,
     composerScopeKey,
@@ -231,6 +242,7 @@ export function useComposerSubmission({
     setErrorMessage,
     setExtensionCommandRunning,
     setOpenMenu,
+    stopDictationAndFlush,
     streamingBehaviorPreference,
   ]);
 

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -379,7 +379,7 @@ export function useComposerSubmission({
   ]);
 
   const stop = useCallback(async () => {
-    if ((!isStreaming && !extensionCommandRunning) || isSending) {
+    if ((!isStreaming && !extensionCommandRunning) || isSending || !sessionPath) {
       return;
     }
 

--- a/src/app/components/workspace/composer/useComposerSubmission.ts
+++ b/src/app/components/workspace/composer/useComposerSubmission.ts
@@ -1,4 +1,10 @@
-import { useCallback, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import {
+  useCallback,
+  useRef,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
 import { getErrorMessage } from "../../../desktop/error-messages";
 import type {
@@ -119,6 +125,7 @@ type UseComposerSubmissionProps = {
   isSending: boolean;
   isStreaming: boolean;
   isCompacting: boolean;
+  extensionCommandRunning: boolean;
   onAction: DesktopActionInvoker;
   projectId: string;
   sessionPath: string | null;
@@ -144,6 +151,7 @@ export function useComposerSubmission({
   isSending,
   isStreaming,
   isCompacting,
+  extensionCommandRunning,
   onAction,
   projectId,
   sessionPath,
@@ -162,19 +170,22 @@ export function useComposerSubmission({
   sendLockRef,
   skipNextDraftPersistenceRef,
 }: UseComposerSubmissionProps) {
+  const extensionCommandRunIdRef = useRef(0);
+
   const sendExtensionCommand = useCallback(() => {
-    if (isCompacting || sendLockRef.current) {
+    if (isCompacting || extensionCommandRunning) {
       return;
     }
 
     const submittedScopeKey = composerScopeKey;
     const submittedDraftThreadId = draftThreadId;
     const submittedDraft = draftValueRef.current.trim();
+    const runId = extensionCommandRunIdRef.current + 1;
+    extensionCommandRunIdRef.current = runId;
     if (submittedDraft.length === 0) {
       return;
     }
 
-    const submittedAttachments = attachmentsRef.current;
     setErrorMessage(null);
     setOpenMenu(null);
     setExtensionCommandRunning(true);
@@ -188,7 +199,7 @@ export function useComposerSubmission({
 
     void submitComposerDraft({
       draft: submittedDraft,
-      attachments: submittedAttachments,
+      attachments: [],
       isSending: false,
       projectId,
       sessionPath,
@@ -197,24 +208,24 @@ export function useComposerSubmission({
     })
       .then((result) => {
         if (result.status === "error" && activeComposerScopeKeyRef.current === submittedScopeKey) {
+          setDraftValue(result.text);
           setErrorMessage(result.errorMessage);
         }
       })
       .finally(() => {
-        if (activeComposerScopeKeyRef.current === submittedScopeKey) {
+        if (extensionCommandRunIdRef.current === runId) {
           setExtensionCommandRunning(false);
         }
       });
   }, [
     activeComposerScopeKeyRef,
-    attachmentsRef,
     composerScopeKey,
     draftThreadId,
     draftValueRef,
+    extensionCommandRunning,
     isCompacting,
     onAction,
     projectId,
-    sendLockRef,
     sessionPath,
     setDraftValue,
     setErrorMessage,
@@ -351,7 +362,7 @@ export function useComposerSubmission({
   ]);
 
   const stop = useCallback(async () => {
-    if (!isStreaming || isSending) {
+    if ((!isStreaming && !extensionCommandRunning) || isSending) {
       return;
     }
 
@@ -373,7 +384,16 @@ export function useComposerSubmission({
     } finally {
       setIsSending(false);
     }
-  }, [isSending, isStreaming, onAction, projectId, sessionPath, setErrorMessage, setIsSending]);
+  }, [
+    extensionCommandRunning,
+    isSending,
+    isStreaming,
+    onAction,
+    projectId,
+    sessionPath,
+    setErrorMessage,
+    setIsSending,
+  ]);
 
   const compact = useCallback(async () => {
     if (isSending || isStreaming || isCompacting || !sessionPath || sendLockRef.current) {

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Bot, Paperclip, Send, Square, X } from "lucide-react";
+import { ArrowUpRight, Bot, Loader2, Paperclip, Send, Square, X } from "lucide-react";
 import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
 import { getErrorMessage } from "../../../desktop/error-messages";
@@ -109,6 +109,7 @@ export function InboxComposer({
   const draftValueRef = useRef(draft);
   const attachmentsRef = useRef(attachments);
   const sendLockRef = useRef(false);
+  const extensionRunning = isSending && !isStreaming && !isCompacting;
   const [localActionPending, setLocalActionPending] = useState(false);
   const canSend =
     (draft.trim().length > 0 || attachments.length > 0) &&
@@ -544,20 +545,9 @@ export function InboxComposer({
                   ariaActiveDescendant={slashCommands.activeDescendantId}
                   ariaControls={slashCommands.open ? slashCommands.listboxId : undefined}
                   ariaExpanded={slashCommands.open}
-                  placeholder={
-                    errorMessage ??
-                    (isSending && !isStreaming && !isCompacting
-                      ? "Pi extension running…"
-                      : "Reply to this thread…")
-                  }
+                  placeholder={errorMessage ?? "Reply to this thread…"}
                   placeholderTone={errorMessage ? "error" : "muted"}
-                  statusMessage={
-                    errorMessage && draft.length > 0
-                      ? errorMessage
-                      : isSending && !isStreaming && !isCompacting
-                        ? "Pi extension running…"
-                        : null
-                  }
+                  statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                   reservedLineCount={1}
                 />
               </div>
@@ -587,19 +577,26 @@ export function InboxComposer({
               >
                 <Square size={11} fill="currentColor" />
               </button>
-              <button
-                type="button"
-                className={cn(
-                  compactIconButtonClass,
-                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
-                )}
-                onClick={() => slashCommands.submit()}
-                disabled={!canSend}
-                aria-label="Send"
-                data-tooltip="Send"
-              >
-                <Send size={14} />
-              </button>
+              {extensionRunning ? (
+                <div className="inline-flex h-6 items-center gap-1.5 rounded-full border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.045)] px-2.5 text-[12px] text-[color:var(--muted)]">
+                  <Loader2 size={12} className="animate-spin" />
+                  <span>Pi extension running</span>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className={cn(
+                    compactIconButtonClass,
+                    "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
+                  )}
+                  onClick={() => slashCommands.submit()}
+                  disabled={!canSend}
+                  aria-label="Send"
+                  data-tooltip="Send"
+                >
+                  <Send size={14} />
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -544,9 +544,20 @@ export function InboxComposer({
                   ariaActiveDescendant={slashCommands.activeDescendantId}
                   ariaControls={slashCommands.open ? slashCommands.listboxId : undefined}
                   ariaExpanded={slashCommands.open}
-                  placeholder={errorMessage ?? "Reply to this thread…"}
+                  placeholder={
+                    errorMessage ??
+                    (isSending && !isStreaming && !isCompacting
+                      ? "Pi extension running…"
+                      : "Reply to this thread…")
+                  }
                   placeholderTone={errorMessage ? "error" : "muted"}
-                  statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
+                  statusMessage={
+                    errorMessage && draft.length > 0
+                      ? errorMessage
+                      : isSending && !isStreaming && !isCompacting
+                        ? "Pi extension running…"
+                        : null
+                  }
                   reservedLineCount={1}
                 />
               </div>

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Bot, Loader2, Paperclip, Send, Square, X } from "lucide-react";
+import { ArrowUpRight, Bot, Paperclip, Send, Square, X } from "lucide-react";
 import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
 import { getErrorMessage } from "../../../desktop/error-messages";
@@ -109,7 +109,6 @@ export function InboxComposer({
   const draftValueRef = useRef(draft);
   const attachmentsRef = useRef(attachments);
   const sendLockRef = useRef(false);
-  const extensionRunning = isSending && !isStreaming && !isCompacting;
   const [localActionPending, setLocalActionPending] = useState(false);
   const canSend =
     (draft.trim().length > 0 || attachments.length > 0) &&
@@ -577,26 +576,19 @@ export function InboxComposer({
               >
                 <Square size={11} fill="currentColor" />
               </button>
-              {extensionRunning ? (
-                <div className="inline-flex h-6 items-center gap-1.5 rounded-full border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.045)] px-2.5 text-[12px] text-[color:var(--muted)]">
-                  <Loader2 size={12} className="animate-spin" />
-                  <span>Pi extension running</span>
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  className={cn(
-                    compactIconButtonClass,
-                    "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
-                  )}
-                  onClick={() => slashCommands.submit()}
-                  disabled={!canSend}
-                  aria-label="Send"
-                  data-tooltip="Send"
-                >
-                  <Send size={14} />
-                </button>
-              )}
+              <button
+                type="button"
+                className={cn(
+                  compactIconButtonClass,
+                  "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
+                )}
+                onClick={() => slashCommands.submit()}
+                disabled={!canSend}
+                aria-label="Send"
+                data-tooltip="Send"
+              >
+                <Send size={14} />
+              </button>
             </div>
           </div>
         </div>

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -240,6 +240,9 @@ export function CodeWorkspaceView({
                       availableModels={activeComposerState?.availableModels ?? []}
                       isStreaming={activeThreadData?.isStreaming ?? false}
                       isCompacting={activeComposerState?.isCompacting ?? false}
+                      isExtensionCommandRunning={
+                        activeComposerState?.isExtensionCommandRunning ?? false
+                      }
                       thinkingLevel={activeComposerState?.currentThinkingLevel ?? "off"}
                       restoredQueuedPrompt={scopedRestoredQueuedPrompt}
                       streamingBehaviorPreference={

--- a/src/test/controller-post-action-effects.test.ts
+++ b/src/test/controller-post-action-effects.test.ts
@@ -41,6 +41,7 @@ function buildShellState(): ShellState {
       queuedPrompts: [],
       contextUsage: null,
       isCompacting: false,
+      isExtensionCommandRunning: false,
     },
     projects: [
       {

--- a/src/test/runtime-settings-refresh.test.ts
+++ b/src/test/runtime-settings-refresh.test.ts
@@ -37,6 +37,7 @@ describe("runtime settings refresh", () => {
         queuedPrompts: [],
         contextUsage: null,
         isCompacting: false,
+        isExtensionCommandRunning: false,
       }),
       publishComposerUpdate,
     });
@@ -65,6 +66,7 @@ describe("runtime settings refresh", () => {
         queuedPrompts: [],
         contextUsage: null,
         isCompacting: false,
+        isExtensionCommandRunning: false,
       }),
       publishComposerUpdate: vi.fn(),
     });


### PR DESCRIPTION
## Summary
- initialize and refresh Pi theme support for headless runtimes without advertising a full UI
- surface extension errors with clearer labels and show non-blocking extension-running status in composer controls
- track active headless extension commands so Stop can abort them and normal composer sends remain available
- harden slash command submit/loading behavior for extension commands with arguments

## Validation
- pre-push hooks ran lint and typecheck on push
- commit hooks ran typecheck and vitest during commits