### PR TITLE
Fix Windows launcher install flow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -126,6 +126,7 @@ jobs:
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
             artifacts/electron/*.AppImage
+            artifacts/electron/*.exe
 
   cleanup-dev-artifacts:
     name: Cleanup old dev artifacts
@@ -197,13 +198,13 @@ jobs:
           path: release-assets
 
       - name: List release assets
-        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' \) -print | sort
+        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
 
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' \) -print0 | sort -z)
+          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
             exit 1

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ npm i -g howcode
 howcode
 ```
 
-There's a launcher. It downloads the correct version.
+There's a launcher. It downloads the correct version and relaunches the cached desktop app.
+On Windows, the launcher also creates a Start Menu shortcut after the first successful download.
 
-Or check releases tabs for latest stable-ish version you can just download. 
+Or check releases tabs for latest stable-ish version you can just download. Windows releases include
+an installer; Linux releases include an AppImage.
 
 Built on Linux, compatible with Mac and Windows (hopefully).
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,6 +25,14 @@ linux:
 win:
   target:
     - dir
+    - nsis
+nsis:
+  artifactName: ${productName} Setup ${version}-${arch}.${ext}
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  createDesktopShortcut: false
+  createStartMenuShortcut: true
 asarUnpack:
   - node_modules/**/*.node
   - node_modules/node-pty/build/Release/**

--- a/packages/howcode/README.md
+++ b/packages/howcode/README.md
@@ -24,9 +24,13 @@ This npm package is a small launcher.
 On first run, it downloads the matching desktop app for your platform from GitHub Releases and caches it locally.
 After the first successful download, it can fall back to the cached app if release metadata is temporarily unavailable.
 
+On Windows, the first successful run also creates a Start Menu shortcut for `howcode`, so you do
+not need to find the cached executable or add the cache directory to `PATH`.
+
 ## What you actually get
 
 - macOS, Linux, and Windows desktop builds
+- Windows installer artifacts in GitHub Releases
 - Linux AppImage artifacts for direct installs
 - local cached installs after first download
 - desktop builds that bundle Electron/Chromium for a more consistent renderer

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -88,12 +88,132 @@ function getPaths(target, releaseInfo) {
   const versionsRoot = path.join(cacheRoot, "versions");
   const releaseKey = `${releaseInfo.version}-${releaseInfo.hash}`;
   const installDir = path.join(versionsRoot, releaseKey);
+  const launcherWorkingDirectory = path.dirname(path.join(installDir, target.executable));
   return {
     cacheRoot,
     currentFile: path.join(cacheRoot, "current.json"),
+    windowsCommandFile: path.join(cacheRoot, `${APP_NAME}.cmd`),
+    launcherWorkingDirectory,
     installDir,
     executablePath: path.join(installDir, target.executable),
   };
+}
+
+function getWindowsStartMenuShortcutPath() {
+  const appData = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+  return path.join(appData, "Microsoft", "Windows", "Start Menu", "Programs", `${APP_NAME}.lnk`);
+}
+
+function escapeWindowsCommandValue(value) {
+  return value.replace(/%/g, "%%");
+}
+
+function getWindowsScriptHostPath(executableName) {
+  const systemRoot = process.env.SystemRoot || process.env.SYSTEMROOT;
+  if (systemRoot) {
+    return path.join(systemRoot, "System32", executableName);
+  }
+
+  return path.join("C:", "Windows", "System32", executableName);
+}
+
+async function writeWindowsCommandLauncher(paths) {
+  const commandContents = [
+    "@echo off",
+    "chcp 65001 >nul",
+    "setlocal",
+    "set NODE_TLS_REJECT_UNAUTHORIZED=",
+    `set \"HOWCODE_EXE=${escapeWindowsCommandValue(paths.executablePath)}\"`,
+    `set \"HOWCODE_REPO_ROOT=${escapeWindowsCommandValue(paths.launcherWorkingDirectory)}\"`,
+    'if not exist "%HOWCODE_EXE%" (',
+    `  echo ${APP_NAME}: installed app executable was not found.`,
+    `  echo Run npx ${APP_NAME} to repair the local install.`,
+    "  exit /b 1",
+    ")",
+    'start "" /D "%HOWCODE_REPO_ROOT%" "%HOWCODE_EXE%"',
+    "endlocal",
+    "",
+  ].join("\r\n");
+
+  await fsp.writeFile(paths.windowsCommandFile, commandContents, "utf8");
+}
+
+async function createWindowsStartMenuShortcut(paths) {
+  const shortcutPath = getWindowsStartMenuShortcutPath();
+  const shortcutScriptPath = path.join(
+    paths.cacheRoot,
+    `.create-${APP_NAME}-shortcut-${process.pid}.js`,
+  );
+  await fsp.mkdir(path.dirname(shortcutPath), { recursive: true });
+  await fsp.writeFile(
+    shortcutScriptPath,
+    [
+      "var shell = WScript.CreateObject('WScript.Shell');",
+      "var shortcut = shell.CreateShortcut(WScript.Arguments.Item(0));",
+      "shortcut.TargetPath = WScript.Arguments.Item(1);",
+      "shortcut.WorkingDirectory = WScript.Arguments.Item(2);",
+      "shortcut.IconLocation = WScript.Arguments.Item(3);",
+      "shortcut.Description = WScript.Arguments.Item(4);",
+      "shortcut.Save();",
+      "",
+    ].join("\r\n"),
+    "utf8",
+  );
+
+  try {
+    await new Promise((resolve, reject) => {
+      const child = spawn(
+        getWindowsScriptHostPath("cscript.exe"),
+        [
+          "//NoLogo",
+          shortcutScriptPath,
+          shortcutPath,
+          paths.windowsCommandFile,
+          paths.launcherWorkingDirectory,
+          `${paths.executablePath},0`,
+          "howcode",
+        ],
+        { stdio: "ignore", windowsHide: true },
+      );
+      child.on("error", reject);
+      child.on("exit", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`cscript exited with code ${code} while creating Start Menu shortcut.`));
+        }
+      });
+    });
+  } finally {
+    await fsp.rm(shortcutScriptPath, { force: true });
+  }
+
+  return shortcutPath;
+}
+
+async function ensureWindowsLaunchIntegration(target, paths) {
+  if (target.os !== "win") {
+    return true;
+  }
+
+  try {
+    await writeWindowsCommandLauncher(paths);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`${APP_NAME}: could not create command launcher: ${message}`);
+    console.warn(`${APP_NAME}: Start Menu shortcut was not updated.`);
+    return false;
+  }
+
+  try {
+    await createWindowsStartMenuShortcut(paths);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`${APP_NAME}: could not create Start Menu shortcut: ${message}`);
+    console.warn(`${APP_NAME}: you can still relaunch with ${paths.windowsCommandFile}`);
+    return false;
+  }
 }
 
 async function fetchJson(url) {
@@ -216,16 +336,19 @@ async function pruneOldVersions(cacheRoot, keepDir) {
 }
 
 function spawnLauncherProcess(executablePath, options = {}) {
+  const env = {
+    ...process.env,
+    HOWCODE_REPO_ROOT: process.env.HOWCODE_REPO_ROOT || process.cwd(),
+    ...(options.env || {}),
+  };
+  Reflect.deleteProperty(env, "NODE_TLS_REJECT_UNAUTHORIZED");
+
   return spawn(executablePath, [], {
     detached: true,
     stdio: options.stdio || "ignore",
     windowsHide: true,
     cwd: path.dirname(executablePath),
-    env: {
-      ...process.env,
-      HOWCODE_REPO_ROOT: process.env.HOWCODE_REPO_ROOT || process.cwd(),
-      ...(options.env || {}),
-    },
+    env,
   });
 }
 
@@ -247,6 +370,14 @@ async function main() {
     releaseInfo = await resolveLatestRelease(target);
   } catch (error) {
     if (current?.executablePath && fs.existsSync(current.executablePath)) {
+      await ensureWindowsLaunchIntegration(target, {
+        cacheRoot,
+        currentFile: path.join(cacheRoot, "current.json"),
+        windowsCommandFile: path.join(cacheRoot, `${APP_NAME}.cmd`),
+        installDir: current.installDir || path.dirname(path.dirname(current.executablePath)),
+        launcherWorkingDirectory: path.dirname(current.executablePath),
+        executablePath: current.executablePath,
+      });
       await launch(current.executablePath);
       return;
     }
@@ -255,10 +386,15 @@ async function main() {
   }
 
   const paths = getPaths(target, releaseInfo);
+  const didInstall = !fs.existsSync(paths.executablePath);
   if (!fs.existsSync(paths.executablePath)) {
     await installRelease(target, releaseInfo, paths);
   }
 
+  const launchIntegrationReady = await ensureWindowsLaunchIntegration(target, paths);
+  if (target.os === "win" && didInstall && launchIntegrationReady) {
+    console.log(`${APP_NAME}: installed. You can relaunch it from the Windows Start Menu.`);
+  }
   await pruneOldVersions(cacheRoot, paths.installDir);
   await launch(paths.executablePath);
 }


### PR DESCRIPTION
## Summary
- create a Windows Start Menu shortcut after the npm launcher downloads howcode
- route the shortcut through a cached command launcher that clears insecure TLS env before starting Electron
- ship Windows NSIS installer artifacts with architecture-specific names to avoid release collisions
- document the Windows relaunch behavior in the root and npm package READMEs

## Validation
- Pre-commit hook ran Biome, typechecks, and tests successfully

Closes #145
