### PR TITLE
Improve GitOps feedback and defaults

### DIFF
--- a/desktop/app-settings.cts
+++ b/desktop/app-settings.cts
@@ -3,6 +3,7 @@ import type {
   ComposerThinkingLevel,
   ComposerStreamingBehavior,
   DictationModelId,
+  GitOpsMode,
   ModelSelection,
   ProjectDeletionMode,
 } from "../shared/desktop-contracts.ts";
@@ -24,6 +25,7 @@ const favoriteFoldersKey = "favoriteFolders";
 const projectImportStateKey = "projectImportState";
 const preferredProjectLocationKey = "preferredProjectLocation";
 const initializeGitOnProjectCreateKey = "initializeGitOnProjectCreate";
+const gitOpsDefaultModeKey = "gitOpsDefaultMode";
 const projectDeletionModeKey = "projectDeletionMode";
 const useAgentsSkillsPathsKey = "useAgentsSkillsPaths";
 const piTuiTakeoverKey = "piTuiTakeover";
@@ -140,6 +142,19 @@ function parseProjectDeletionModePreference(
   try {
     const parsed = JSON.parse(valueJson) as unknown;
     return parsed === "pi-only" || parsed === "full-clean" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseGitOpsModePreference(valueJson: string | null | undefined): GitOpsMode | null {
+  if (!valueJson) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(valueJson) as unknown;
+    return parsed === "commit" || parsed === "commit-push" ? parsed : null;
   } catch {
     return null;
   }
@@ -290,6 +305,15 @@ export function loadAppSettings(): AppSettings {
       `,
     )
     .get(projectDeletionModeKey) as PreferenceRow | undefined;
+  const gitOpsDefaultModeRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(gitOpsDefaultModeKey) as PreferenceRow | undefined;
   const useAgentsSkillsPathsRow = db
     .prepare(
       `
@@ -357,6 +381,7 @@ export function loadAppSettings(): AppSettings {
     preferredProjectLocation: parseStringPreference(preferredProjectLocationRow?.valueJson),
     initializeGitOnProjectCreate:
       parseBooleanPreference(initializeGitOnProjectCreateRow?.valueJson) ?? false,
+    gitOpsDefaultMode: parseGitOpsModePreference(gitOpsDefaultModeRow?.valueJson) ?? "commit",
     projectDeletionMode:
       parseProjectDeletionModePreference(projectDeletionModeRow?.valueJson) ?? "pi-only",
     useAgentsSkillsPaths: parseBooleanPreference(useAgentsSkillsPathsRow?.valueJson) ?? false,
@@ -462,6 +487,15 @@ export function setPreferredProjectLocation(preferredProjectLocation: string | n
 
 export function setInitializeGitOnProjectCreate(enabled: boolean) {
   writeAppPreference(initializeGitOnProjectCreateKey, JSON.stringify(enabled));
+}
+
+export function setGitOpsDefaultMode(mode: GitOpsMode) {
+  if (mode === "commit") {
+    deleteAppPreference(gitOpsDefaultModeKey);
+    return;
+  }
+
+  writeAppPreference(gitOpsDefaultModeKey, JSON.stringify(mode));
 }
 
 export function setProjectDeletionMode(mode: ProjectDeletionMode) {

--- a/desktop/pi-threads/settings-actions.cts
+++ b/desktop/pi-threads/settings-actions.cts
@@ -24,6 +24,7 @@ import {
   setFavoriteFolders,
   setGitCommitMessageModelSelection,
   setGitCommitMessageThinkingLevel,
+  setGitOpsDefaultMode,
   setInitializeGitOnProjectCreate,
   setPiTuiTakeover,
   setPreferredProjectLocation,
@@ -136,6 +137,14 @@ export async function handleSettingsDesktopAction(
     const value = getSettingsBooleanValue(payload);
     if (value !== null) {
       setInitializeGitOnProjectCreate(value);
+    }
+    return handledAction();
+  }
+
+  if (key === "gitOpsDefaultMode") {
+    const value = payload.value;
+    if (value === "commit" || value === "commit-push") {
+      setGitOpsDefaultMode(value);
     }
     return handledAction();
   }

--- a/desktop/pi-threads/workspace-actions.cts
+++ b/desktop/pi-threads/workspace-actions.cts
@@ -4,6 +4,7 @@ import {
   getComposerRequest,
   getGitCommitMessage,
   getGitIncludeUnstaged,
+  getGitOpsMode,
   getGitPreview,
   getGitPush,
   getGitRepoUrl,
@@ -11,7 +12,7 @@ import {
 } from "../../shared/pi-thread-action-payloads.ts";
 import { generateGitCommitMessage } from "../git-commit-message.cts";
 import { commitProjectChanges, initializeProjectGit, setProjectOrigin } from "../project-git.cts";
-import { setProjectRepoOrigin } from "../thread-state-db.cts";
+import { setProjectGitOpsMode, setProjectRepoOrigin } from "../thread-state-db.cts";
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
 
@@ -47,6 +48,20 @@ export async function handleWorkspaceDesktopAction(
       }
 
       const repoUrl = getGitRepoUrl(payload);
+      const gitOpsMode = getGitOpsMode(payload);
+
+      if (gitOpsMode === "invalid") {
+        return handledAction({ error: "Invalid GitOps mode." });
+      }
+
+      if (gitOpsMode !== undefined && repoUrl) {
+        return handledAction({ error: "GitOps mode and repository URL must be saved separately." });
+      }
+
+      if (gitOpsMode !== undefined) {
+        setProjectGitOpsMode(projectId, gitOpsMode);
+        return handledAction();
+      }
 
       if (repoUrl) {
         await setProjectOrigin(projectId, repoUrl);

--- a/desktop/project-git/commit-actions.cts
+++ b/desktop/project-git/commit-actions.cts
@@ -44,7 +44,7 @@ export async function commitProjectChanges(
   try {
     const context = await prepareCommitMessageContext(projectId, options.includeUnstaged);
     if (!context) {
-      return { committed: false, message: null, previewed: false };
+      return { committed: false, message: null, previewed: false, pushed: false };
     }
 
     const generatedMessage = options.message ? null : await options.generateMessage?.(context);
@@ -55,6 +55,7 @@ export async function commitProjectChanges(
         committed: false,
         message: commitMessage,
         previewed: true,
+        pushed: false,
       };
     }
 
@@ -69,6 +70,7 @@ export async function commitProjectChanges(
         committed: true,
         message: commitMessage,
         previewed: false,
+        pushed: false,
       };
     }
 
@@ -90,6 +92,7 @@ export async function commitProjectChanges(
           committed: true,
           message: commitMessage,
           previewed: false,
+          pushed: false,
           pushFailed: true,
           error: `Committed locally, but push failed: ${formatGitCommandError(pushError)}`,
         };
@@ -100,12 +103,14 @@ export async function commitProjectChanges(
       committed: true,
       message: commitMessage,
       previewed: false,
+      pushed: true,
     };
   } catch (error) {
     return {
       committed: false,
       message: null,
       previewed: false,
+      pushed: false,
       error: formatGitCommandError(error),
     };
   }

--- a/desktop/project-git/project-state.cts
+++ b/desktop/project-git/project-state.cts
@@ -1,4 +1,5 @@
 import type { ProjectGitState } from "../../shared/desktop-contracts.ts";
+import { getThreadStateDatabase } from "../thread-state-db/db.cts";
 import { hasHeadCommit, runGit, runGitWithOptions } from "./git-runner.cts";
 
 function parseShortStat(output: string) {
@@ -93,6 +94,20 @@ function deriveOriginName(originUrl: string | null) {
   return lastPart.replace(/\.git$/i, "") || "origin";
 }
 
+function getProjectGitOpsModeOverride(projectId: string) {
+  const row = getThreadStateDatabase()
+    .prepare(
+      `
+        SELECT git_ops_mode AS gitOpsMode
+        FROM projects
+        WHERE cwd = ?
+      `,
+    )
+    .get(projectId) as { gitOpsMode?: string | null } | undefined;
+
+  return row?.gitOpsMode === "commit" || row?.gitOpsMode === "commit-push" ? row.gitOpsMode : null;
+}
+
 export async function getBranch(projectId: string) {
   try {
     const { stdout } = await runGit(projectId, ["branch", "--show-current"]);
@@ -132,6 +147,8 @@ async function getDiffStats(projectId: string) {
 }
 
 export async function loadProjectGitState(projectId: string): Promise<ProjectGitState> {
+  const gitOpsModeOverride = getProjectGitOpsModeOverride(projectId);
+
   if (!(await isGitRepository(projectId))) {
     return {
       projectId,
@@ -145,6 +162,7 @@ export async function loadProjectGitState(projectId: string): Promise<ProjectGit
       hasOrigin: false,
       originName: null,
       originUrl: null,
+      gitOpsModeOverride,
     };
   }
 
@@ -167,5 +185,6 @@ export async function loadProjectGitState(projectId: string): Promise<ProjectGit
     hasOrigin: originUrl !== null,
     originName: deriveOriginName(originUrl),
     originUrl,
+    gitOpsModeOverride,
   };
 }

--- a/desktop/thread-state-db.cts
+++ b/desktop/thread-state-db.cts
@@ -30,6 +30,7 @@ export {
   renameProject,
   restoreThreads,
   restoreThread,
+  setProjectGitOpsMode,
   setProjectRepoOrigin,
   setProjectCollapsed,
   syncSessionSummaries,

--- a/desktop/thread-state-db/project-writes.cts
+++ b/desktop/thread-state-db/project-writes.cts
@@ -83,6 +83,17 @@ export function setProjectRepoOrigin(projectId: string, originUrl: string | null
   ).run(originUrl, projectId);
 }
 
+export function setProjectGitOpsMode(projectId: string, mode: "commit" | "commit-push" | null) {
+  const db = getThreadStateDatabase();
+  db.prepare(
+    `
+      UPDATE projects
+      SET git_ops_mode = ?, updated_at = CURRENT_TIMESTAMP
+      WHERE cwd = ?
+    `,
+  ).run(mode, projectId);
+}
+
 export function reorderProjects(projectIds: string[]) {
   if (projectIds.length === 0) {
     return;

--- a/desktop/thread-state-db/queries.cts
+++ b/desktop/thread-state-db/queries.cts
@@ -43,6 +43,7 @@ export function listProjects(cwd: string): Project[] {
           projects.collapsed AS collapsed,
           projects.repo_origin_url AS repoOriginUrl,
           projects.repo_origin_checked AS repoOriginChecked,
+          projects.git_ops_mode AS gitOpsMode,
           COUNT(threads.id) AS threadCount,
           COALESCE(MAX(threads.last_modified_ms), 0) AS latestModifiedMs
         FROM projects
@@ -55,7 +56,8 @@ export function listProjects(cwd: string): Project[] {
           projects.pinned,
           projects.collapsed,
           projects.repo_origin_url,
-          projects.repo_origin_checked
+          projects.repo_origin_checked,
+          projects.git_ops_mode
         ORDER BY
           projects.pinned DESC,
           CASE WHEN projects.order_index IS NULL THEN 1 ELSE 0 END,

--- a/desktop/thread-state-db/schema.cts
+++ b/desktop/thread-state-db/schema.cts
@@ -141,6 +141,7 @@ export function ensureThreadStateSchema(database: Database) {
       collapsed INTEGER NOT NULL DEFAULT 1,
       repo_origin_url TEXT,
       repo_origin_checked INTEGER NOT NULL DEFAULT 0,
+      git_ops_mode TEXT,
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );
@@ -210,6 +211,10 @@ export function ensureThreadStateSchema(database: Database) {
 
   if (!hasColumn(database, "projects", "repo_origin_checked")) {
     database.exec("ALTER TABLE projects ADD COLUMN repo_origin_checked INTEGER NOT NULL DEFAULT 0");
+  }
+
+  if (!hasColumn(database, "projects", "git_ops_mode")) {
+    database.exec("ALTER TABLE projects ADD COLUMN git_ops_mode TEXT");
   }
 
   if (!hasColumn(database, "threads", "last_assistant_message_json")) {

--- a/desktop/thread-state-db/types.cts
+++ b/desktop/thread-state-db/types.cts
@@ -16,6 +16,7 @@ export type ProjectRow = {
   latestModifiedMs: number;
   repoOriginUrl: string | null;
   repoOriginChecked: number;
+  gitOpsMode: string | null;
 };
 
 export type ThreadRow = {

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -6,6 +6,7 @@ import type {
   ComposerStreamingBehavior,
   ComposerThinkingLevel,
   DictationModelId,
+  GitOpsMode,
   PiSettings,
   ProjectDeletionMode,
   ProjectImportCandidate,
@@ -17,6 +18,7 @@ export type DesktopActionPayloadFields = {
   attachments?: ComposerAttachment[];
   folders?: string[];
   imported?: boolean | null;
+  gitOpsMode?: GitOpsMode | null;
   includeUnstaged?: boolean;
   key?: keyof AppSettings;
   piSettingsKey?: keyof PiSettings;
@@ -62,6 +64,7 @@ export type DesktopSettingsUpdatePayload =
   | { key: "projectImportState"; imported: boolean | null }
   | { key: "preferredProjectLocation"; value: string | null }
   | { key: "initializeGitOnProjectCreate"; value: boolean }
+  | { key: "gitOpsDefaultMode"; value: GitOpsMode }
   | { key: "projectDeletionMode"; value: ProjectDeletionMode }
   | { key: "useAgentsSkillsPaths"; value: boolean }
   | { key: "piTuiTakeover"; value: boolean };
@@ -100,6 +103,7 @@ export type DesktopActionPayloadMap = {
     projectId?: string | null;
     sessionPath?: string | null;
     repoUrl?: string | null;
+    gitOpsMode?: GitOpsMode | null;
   };
   "composer.model": {
     projectId?: string | null;
@@ -162,6 +166,7 @@ export type DesktopActionResultData = {
   previewed?: boolean;
   projectId?: string;
   projects?: ProjectImportCandidate[];
+  pushed?: boolean;
   pushFailed?: boolean;
   repoProjectCount?: number;
   sessionPath?: string | null;

--- a/shared/desktop-project-git-contracts.ts
+++ b/shared/desktop-project-git-contracts.ts
@@ -1,3 +1,5 @@
+import type { GitOpsMode } from "./desktop-settings-contracts";
+
 export type ProjectGitState = {
   projectId: string;
   isGitRepo: boolean;
@@ -10,6 +12,7 @@ export type ProjectGitState = {
   hasOrigin: boolean;
   originName: string | null;
   originUrl: string | null;
+  gitOpsModeOverride: GitOpsMode | null;
 };
 
 export type ProjectDiffBaseline =

--- a/shared/desktop-settings-contracts.ts
+++ b/shared/desktop-settings-contracts.ts
@@ -12,6 +12,7 @@ export type ModelSelection = {
 };
 
 export type ProjectDeletionMode = "pi-only" | "full-clean";
+export type GitOpsMode = "commit" | "commit-push";
 
 export type AppSettings = {
   gitCommitMessageModel: ModelSelection | null;
@@ -26,6 +27,7 @@ export type AppSettings = {
   projectImportState: boolean | null;
   preferredProjectLocation: string | null;
   initializeGitOnProjectCreate: boolean;
+  gitOpsDefaultMode: GitOpsMode;
   projectDeletionMode: ProjectDeletionMode;
   useAgentsSkillsPaths: boolean;
   piTuiTakeover: boolean;

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -6,6 +6,7 @@ import type {
   ComposerThinkingLevel,
   DesktopActionPayloadInput,
   DictationModelId,
+  GitOpsMode,
   ModelSelection,
   ProjectDeletionMode,
 } from "./desktop-contracts";
@@ -153,6 +154,22 @@ export function getGitRepoUrl(payload: DesktopActionPayloadInput) {
   return repoUrl.length > 0 ? repoUrl : null;
 }
 
+export function getGitOpsMode(
+  payload: DesktopActionPayloadInput,
+): GitOpsMode | null | undefined | "invalid" {
+  if (!("gitOpsMode" in payload) || payload.gitOpsMode === undefined) {
+    return undefined;
+  }
+
+  if (payload.gitOpsMode === null) {
+    return null;
+  }
+
+  return payload.gitOpsMode === "commit" || payload.gitOpsMode === "commit-push"
+    ? payload.gitOpsMode
+    : "invalid";
+}
+
 export function getSettingsKey(payload: DesktopActionPayloadInput) {
   return payload.key === "gitCommitMessageModel" ||
     payload.key === "gitCommitMessageThinkingLevel" ||
@@ -166,6 +183,7 @@ export function getSettingsKey(payload: DesktopActionPayloadInput) {
     payload.key === "projectImportState" ||
     payload.key === "preferredProjectLocation" ||
     payload.key === "initializeGitOnProjectCreate" ||
+    payload.key === "gitOpsDefaultMode" ||
     payload.key === "projectDeletionMode" ||
     payload.key === "useAgentsSkillsPaths" ||
     payload.key === "piTuiTakeover"

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -171,6 +171,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 projectImportState: null,
                 preferredProjectLocation: null,
                 initializeGitOnProjectCreate: false,
+                gitOpsDefaultMode: "commit",
                 projectDeletionMode: "pi-only",
                 useAgentsSkillsPaths: false,
                 piTuiTakeover: false,

--- a/src/app/app-shell/controller-optimistic-updates.ts
+++ b/src/app/app-shell/controller-optimistic-updates.ts
@@ -31,6 +31,7 @@ export function getOptimisticallyUpdatedShellState(
     payload.key !== "projectImportState" &&
     payload.key !== "preferredProjectLocation" &&
     payload.key !== "initializeGitOnProjectCreate" &&
+    payload.key !== "gitOpsDefaultMode" &&
     payload.key !== "projectDeletionMode" &&
     payload.key !== "useAgentsSkillsPaths" &&
     payload.key !== "piTuiTakeover"
@@ -135,6 +136,12 @@ export function getOptimisticallyUpdatedShellState(
       ? payload.value
       : currentState.appSettings.projectDeletionMode;
 
+  const nextGitOpsDefaultMode =
+    payload.key === "gitOpsDefaultMode" &&
+    (payload.value === "commit" || payload.value === "commit-push")
+      ? payload.value
+      : currentState.appSettings.gitOpsDefaultMode;
+
   const nextUseAgentsSkillsPaths =
     payload.key === "useAgentsSkillsPaths" && typeof payload.value === "boolean"
       ? payload.value
@@ -161,6 +168,7 @@ export function getOptimisticallyUpdatedShellState(
       projectImportState: nextProjectImportState,
       preferredProjectLocation: nextPreferredProjectLocation,
       initializeGitOnProjectCreate: nextInitializeGitOnProjectCreate,
+      gitOpsDefaultMode: nextGitOpsDefaultMode,
       projectDeletionMode: nextProjectDeletionMode,
       useAgentsSkillsPaths: nextUseAgentsSkillsPaths,
       piTuiTakeover: nextPiTuiTakeover,

--- a/src/app/components/workspace/GitOpsComposerPanel.tsx
+++ b/src/app/components/workspace/GitOpsComposerPanel.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import type {
   DesktopActionInvoker,
+  AppSettings,
   ProjectDiffBaseline,
   ProjectGitState,
 } from "../../desktop/types";
@@ -14,6 +15,7 @@ type GitOpsComposerPanelProps = {
   projectId: string;
   sessionPath: string | null;
   showDictationButton: boolean;
+  appSettings: AppSettings;
   diffBaseline: ProjectDiffBaseline;
   diffRenderMode: "stacked" | "split";
   diffComments: SavedDiffComment[];
@@ -38,6 +40,7 @@ export function GitOpsComposerPanel({
   projectId,
   sessionPath,
   showDictationButton,
+  appSettings,
   diffBaseline,
   diffRenderMode,
   diffComments,
@@ -71,6 +74,7 @@ export function GitOpsComposerPanel({
         projectId={projectId}
         sessionPath={sessionPath}
         showDictationButton={showDictationButton}
+        appSettings={appSettings}
         diffBaseline={diffBaseline}
         diffRenderMode={diffRenderMode}
         diffComments={diffComments}

--- a/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Columns2, Rows3, Settings } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
-import type { ProjectDiffBaseline, ProjectGitState } from "../../../desktop/types";
+import type { GitOpsMode, ProjectDiffBaseline, ProjectGitState } from "../../../desktop/types";
 import {
   compactIconButtonClass,
   diffPanelIconButtonClass,
@@ -26,6 +26,7 @@ type ComposerGitOpsFooterProps = {
   onToggleIncludeUnstaged: () => void;
   onTogglePreview: () => void;
   onTogglePush: () => void;
+  onSaveProjectGitOpsMode: (mode: GitOpsMode | null) => void;
   previewEnabled: boolean;
   projectGitState: ProjectGitState | null;
   pushEnabled: boolean;
@@ -47,6 +48,7 @@ export function ComposerGitOpsFooter({
   onToggleIncludeUnstaged,
   onTogglePreview,
   onTogglePush,
+  onSaveProjectGitOpsMode,
   previewEnabled,
   projectGitState,
   pushEnabled,
@@ -166,7 +168,19 @@ export function ComposerGitOpsFooter({
                   label="Commit & push"
                   checked={pushEnabled}
                   disabled={!hasOrigin}
-                  onClick={onTogglePush}
+                  onClick={() => {
+                    const nextMode = pushEnabled ? "commit" : "commit-push";
+                    onTogglePush();
+                    void onSaveProjectGitOpsMode(nextMode);
+                  }}
+                  toggleSide="left"
+                />
+                <PlainToggle
+                  label="Use app default"
+                  checked={projectGitState?.gitOpsModeOverride === null}
+                  onClick={() => {
+                    void onSaveProjectGitOpsMode(null);
+                  }}
                   toggleSide="left"
                 />
               </div>

--- a/src/app/components/workspace/composer/ComposerGitOpsMessageField.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsMessageField.tsx
@@ -3,6 +3,8 @@ import { ComposerTextField } from "./ComposerTextField";
 
 type ComposerGitOpsMessageFieldProps = {
   actionErrorMessage: string | null;
+  actionStatusMessage?: string | null;
+  actionStatusTone?: "success" | "error";
   diffCommentError: string | null;
   hasDiffComments: boolean;
   onChange: (message: string) => void;
@@ -19,6 +21,8 @@ type ComposerGitOpsMessageFieldProps = {
 
 export function ComposerGitOpsMessageField({
   actionErrorMessage,
+  actionStatusMessage = null,
+  actionStatusTone = "success",
   diffCommentError,
   hasDiffComments,
   onBlur,
@@ -33,6 +37,8 @@ export function ComposerGitOpsMessageField({
   isGitRepo,
 }: ComposerGitOpsMessageFieldProps) {
   const errorMessage = actionErrorMessage ?? diffCommentError;
+  const statusMessage = errorMessage ?? actionStatusMessage;
+  const statusTone = errorMessage ? "error" : actionStatusTone;
   const placeholder = hasDiffComments
     ? errorMessage
       ? errorMessage
@@ -58,11 +64,15 @@ export function ComposerGitOpsMessageField({
       ariaLabel={hasDiffComments ? "Comment instructions" : "Commit message"}
       placeholder={placeholder}
       placeholderTone={errorMessage ? "error" : "muted"}
-      statusMessage={errorMessage && value.length > 0 ? errorMessage : null}
+      statusMessage={statusMessage && value.length > 0 ? statusMessage : null}
+      statusTone={statusTone}
       reservedLineCount={1}
       onHeightChange={onLayoutChange}
     />
   );
+
+  const visibleStatusMessage =
+    actionStatusMessage && !errorMessage && value.length === 0 ? actionStatusMessage : null;
 
   const liveError = errorMessage ? (
     <span className="sr-only" aria-live="polite">
@@ -75,6 +85,17 @@ export function ComposerGitOpsMessageField({
       <div className="flex items-end justify-between gap-2 px-4 pb-3">
         <div className="min-w-0 flex-1">{field}</div>
         <div className="inline-flex items-center gap-2">{trailingAccessory}</div>
+        {visibleStatusMessage ? (
+          <div
+            className={
+              statusTone === "error"
+                ? "text-[12px] leading-4 text-[#f2a7a7]"
+                : "text-[12px] leading-4 text-[color:var(--green)]"
+            }
+          >
+            {visibleStatusMessage}
+          </div>
+        ) : null}
         {liveError}
       </div>
     );
@@ -87,6 +108,17 @@ export function ComposerGitOpsMessageField({
         <div className="inline-flex items-center gap-2">{trailingAccessory}</div>
         {liveError}
       </div>
+      {visibleStatusMessage ? (
+        <div
+          className={
+            statusTone === "error"
+              ? "mt-1 truncate text-[12px] leading-4 text-[#f2a7a7]"
+              : "mt-1 truncate text-[12px] leading-4 text-[color:var(--green)]"
+          }
+        >
+          {visibleStatusMessage}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
@@ -1,6 +1,7 @@
 import { type RefObject, useEffect, useMemo } from "react";
 import type {
   DesktopActionInvoker,
+  AppSettings,
   ProjectDiffBaseline,
   ProjectGitState,
 } from "../../../desktop/types";
@@ -24,6 +25,7 @@ type ComposerGitOpsSurfaceProps = {
   projectId: string;
   sessionPath: string | null;
   showDictationButton: boolean;
+  appSettings: AppSettings;
   diffBaseline: ProjectDiffBaseline;
   diffRenderMode: "stacked" | "split";
   diffComments: SavedDiffComment[];
@@ -49,6 +51,7 @@ export function ComposerGitOpsSurface({
   projectId,
   sessionPath,
   showDictationButton,
+  appSettings,
   diffBaseline,
   diffRenderMode,
   diffComments,
@@ -68,6 +71,7 @@ export function ComposerGitOpsSurface({
 
   const {
     actionErrorMessage,
+    actionStatusMessage,
     canCommit,
     commentCards,
     commitFocused,
@@ -91,8 +95,10 @@ export function ComposerGitOpsSurface({
     setIncludeUnstaged,
     setPushEnabled,
     setRepoUrl,
+    saveProjectGitOpsMode,
     togglePreviewEnabled,
   } = useComposerGitOpsState({
+    appSettings,
     diffComments,
     diffCommentsSending,
     onAction,
@@ -203,6 +209,7 @@ export function ComposerGitOpsSurface({
         {!hasDiffComments ? (
           <ComposerGitOpsMessageField
             actionErrorMessage={actionErrorMessage}
+            actionStatusMessage={actionStatusMessage}
             commitFocused={commitFocused}
             diffCommentError={diffCommentError ?? diffLoadError}
             hasDiffComments={false}
@@ -231,6 +238,7 @@ export function ComposerGitOpsSurface({
       {hasDiffComments ? (
         <ComposerGitOpsMessageField
           actionErrorMessage={actionErrorMessage}
+          actionStatusMessage={actionStatusMessage}
           commitFocused={commitFocused}
           diffCommentError={diffCommentError ?? diffLoadError}
           hasDiffComments
@@ -273,6 +281,7 @@ export function ComposerGitOpsSurface({
         onToggleIncludeUnstaged={() => setIncludeUnstaged((current) => !current)}
         onTogglePreview={togglePreviewEnabled}
         onTogglePush={() => setPushEnabled((current) => !current)}
+        onSaveProjectGitOpsMode={saveProjectGitOpsMode}
         previewEnabled={previewEnabled}
         projectGitState={projectGitState}
         pushEnabled={pushEnabled}

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -6,6 +6,7 @@ type ComposerTextFieldProps = {
   placeholder: string;
   placeholderTone?: "muted" | "error";
   statusMessage?: string | null;
+  statusTone?: "error" | "success";
   ariaLabel: string;
   ariaActiveDescendant?: string;
   ariaControls?: string;
@@ -26,6 +27,7 @@ export function ComposerTextField({
   placeholder,
   placeholderTone = "muted",
   statusMessage = null,
+  statusTone = "error",
   ariaLabel,
   ariaActiveDescendant,
   ariaControls,
@@ -121,7 +123,14 @@ export function ComposerTextField({
       }}
     >
       {statusMessage ? (
-        <div className="truncate text-[12px] leading-4 text-[#f2a7a7]">{statusMessage}</div>
+        <div
+          className={cn(
+            "truncate text-[12px] leading-4",
+            statusTone === "success" ? "text-[color:var(--green)]" : "text-[#f2a7a7]",
+          )}
+        >
+          {statusMessage}
+        </div>
       ) : null}
       <textarea
         ref={textareaRef}

--- a/src/app/components/workspace/composer/composer-git-ops.helpers.ts
+++ b/src/app/components/workspace/composer/composer-git-ops.helpers.ts
@@ -16,6 +16,10 @@ export function getActionResultCommitted(result: DesktopActionResult | null) {
   return result?.result?.committed === true;
 }
 
+export function getActionResultPushed(result: DesktopActionResult | null) {
+  return result?.result?.pushed === true;
+}
+
 export function getActionResultPreviewed(result: DesktopActionResult | null) {
   return result?.result?.previewed === true;
 }

--- a/src/app/components/workspace/composer/useComposerGitOpsState.ts
+++ b/src/app/components/workspace/composer/useComposerGitOpsState.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction } from "react";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
 import { getErrorMessage } from "../../../desktop/error-messages";
-import type { DesktopActionInvoker, ProjectGitState } from "../../../desktop/types";
+import type {
+  AppSettings,
+  DesktopActionInvoker,
+  GitOpsMode,
+  ProjectGitState,
+} from "../../../desktop/types";
 import type { SavedDiffComment } from "../diff/diffCommentStore";
 import {
   buildGitOpsCommentCards,
@@ -9,6 +14,7 @@ import {
   getActionResultError,
   getActionResultMessage,
   getActionResultPreviewed,
+  getActionResultPushed,
 } from "./composer-git-ops.helpers";
 
 export function useComposerGitOpsState({
@@ -16,12 +22,14 @@ export function useComposerGitOpsState({
   diffCommentsSending,
   onAction,
   onSendDiffComments,
+  appSettings,
   projectGitState,
 }: {
   diffComments: SavedDiffComment[];
   diffCommentsSending: boolean;
   onAction: DesktopActionInvoker;
   onSendDiffComments: (message?: string | null) => void;
+  appSettings: AppSettings;
   projectGitState: ProjectGitState | null;
 }) {
   const [includeUnstaged, setIncludeUnstaged] = useState(true);
@@ -33,6 +41,7 @@ export function useComposerGitOpsState({
   const [persistedCleanMessage, setPersistedCleanMessage] = useState<string | null>(null);
   const [runningPrimaryAction, setRunningPrimaryAction] = useState(false);
   const [actionErrorMessage, setActionErrorMessage] = useState<string | null>(null);
+  const [actionStatusMessage, setActionStatusMessage] = useState<string | null>(null);
   const [repoUrl, setRepoUrl] = useState("");
   const previousProjectIdRef = useRef<string | null>(projectGitState?.projectId ?? null);
   const commitMessageRef = useRef(commitMessage);
@@ -41,6 +50,7 @@ export function useComposerGitOpsState({
 
   const isGitRepo = projectGitState?.isGitRepo ?? false;
   const hasOrigin = projectGitState?.hasOrigin ?? false;
+  const effectiveGitOpsMode = projectGitState?.gitOpsModeOverride ?? appSettings.gitOpsDefaultMode;
   const isGitHubOrigin = projectGitState?.originUrl?.includes("github.com") ?? false;
   const isTreeClean = isGitRepo && (projectGitState?.fileCount ?? 0) === 0;
   const hasDiffComments = diffComments.length > 0;
@@ -69,6 +79,10 @@ export function useComposerGitOpsState({
   }, [hasOrigin]);
 
   useEffect(() => {
+    setPushEnabled(hasOrigin && effectiveGitOpsMode === "commit-push");
+  }, [effectiveGitOpsMode, hasOrigin]);
+
+  useEffect(() => {
     const nextProjectId = projectGitState?.projectId ?? null;
     if (previousProjectIdRef.current === nextProjectId) {
       return;
@@ -79,12 +93,14 @@ export function useComposerGitOpsState({
     setCommitFocused(false);
     setPersistedCleanMessage(null);
     setPreviewPendingCommit(false);
+    setActionStatusMessage(null);
   }, [projectGitState]);
 
   useEffect(() => {
     if (!isTreeClean && persistedCleanMessage && commitMessage === persistedCleanMessage) {
       setCommitMessage("");
       setPersistedCleanMessage(null);
+      setActionStatusMessage(null);
     }
   }, [commitMessage, isTreeClean, persistedCleanMessage]);
 
@@ -94,6 +110,9 @@ export function useComposerGitOpsState({
       if (actionErrorMessage) {
         setActionErrorMessage(null);
       }
+      if (actionStatusMessage) {
+        setActionStatusMessage(null);
+      }
       if (nextMessage.trim().length === 0) {
         setPreviewPendingCommit(false);
       }
@@ -101,7 +120,45 @@ export function useComposerGitOpsState({
         setPersistedCleanMessage(null);
       }
     },
-    [actionErrorMessage, persistedCleanMessage],
+    [actionErrorMessage, actionStatusMessage, persistedCleanMessage],
+  );
+
+  const saveProjectGitOpsMode = useCallback(
+    async (mode: GitOpsMode | null) => {
+      if (!isGitRepo) {
+        return;
+      }
+
+      const previousPushEnabled = pushEnabled;
+      setPushEnabled(
+        hasOrigin &&
+          (mode === null
+            ? appSettings.gitOpsDefaultMode === "commit-push"
+            : mode === "commit-push"),
+      );
+
+      try {
+        const result = await onAction("workspace.commit-options", { gitOpsMode: mode });
+        const actionErrorMessage = getDesktopActionErrorMessage(
+          result,
+          "Could not update the project GitOps default.",
+        );
+        if (actionErrorMessage) {
+          setPushEnabled(previousPushEnabled);
+          setActionErrorMessage(actionErrorMessage);
+          return;
+        }
+        setActionErrorMessage(null);
+        setActionStatusMessage(null);
+      } catch (error) {
+        setPushEnabled(previousPushEnabled);
+        setActionErrorMessage(
+          getErrorMessage(error, "Could not update the project GitOps default."),
+        );
+        setActionStatusMessage(null);
+      }
+    },
+    [appSettings.gitOpsDefaultMode, hasOrigin, isGitRepo, onAction, pushEnabled],
   );
 
   const setCommitMessageValue = useCallback(
@@ -130,9 +187,11 @@ export function useComposerGitOpsState({
         return;
       }
       setActionErrorMessage(null);
+      setActionStatusMessage(null);
       setRepoUrl("");
     } catch (error) {
       setActionErrorMessage(getErrorMessage(error, "Could not update the repository remote."));
+      setActionStatusMessage(null);
     }
   }, [isGitRepo, onAction, repoUrl]);
 
@@ -175,6 +234,7 @@ export function useComposerGitOpsState({
 
     try {
       setActionErrorMessage(null);
+      setActionStatusMessage(null);
       const result = await onAction("workspace.commit", {
         includeUnstaged,
         message: trimmedCommitMessage.length > 0 ? trimmedCommitMessage : null,
@@ -201,10 +261,19 @@ export function useComposerGitOpsState({
           setCommitMessage(finalMessage);
           setPersistedCleanMessage(finalMessage);
         }
+        const resultError = getActionResultError(result);
+        setActionStatusMessage(
+          resultError
+            ? null
+            : getActionResultPushed(result)
+              ? "Committed and pushed successfully."
+              : "Committed successfully.",
+        );
       }
       setActionErrorMessage(getActionResultError(result));
     } catch (error) {
       setActionErrorMessage(getErrorMessage(error, "Could not commit changes."));
+      setActionStatusMessage(null);
     } finally {
       setRunningPrimaryAction(false);
     }
@@ -229,6 +298,7 @@ export function useComposerGitOpsState({
 
   return {
     actionErrorMessage,
+    actionStatusMessage,
     canCommit,
     commentCards,
     commitFocused,
@@ -247,6 +317,7 @@ export function useComposerGitOpsState({
     pushEnabled,
     repoUrl,
     runningPrimaryAction,
+    saveProjectGitOpsMode,
     setCommitFocused,
     setActionErrorMessage,
     setIncludeUnstaged,

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -31,6 +31,7 @@ export type {
   DictationState,
   DictationTranscriptionRequest,
   DictationTranscriptionResult,
+  GitOpsMode,
   ModelSelection,
   PiSettings,
   PiConfiguredPackage,

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -146,6 +146,7 @@ export function CodeWorkspaceView({
                     projectImportState: null,
                     preferredProjectLocation: null,
                     initializeGitOnProjectCreate: false,
+                    gitOpsDefaultMode: "commit",
                     projectDeletionMode: "pi-only",
                     useAgentsSkillsPaths: false,
                     piTuiTakeover: false,
@@ -201,6 +202,26 @@ export function CodeWorkspaceView({
                     projectId={composerProjectId}
                     sessionPath={terminalSessionPath}
                     showDictationButton={shellState?.appSettings.showDictationButton ?? true}
+                    appSettings={
+                      shellState?.appSettings ?? {
+                        gitCommitMessageModel: null,
+                        gitCommitMessageThinkingLevel: "off",
+                        skillCreatorModel: null,
+                        skillCreatorThinkingLevel: "off",
+                        composerStreamingBehavior: "followUp",
+                        dictationModelId: null,
+                        dictationMaxDurationSeconds: 180,
+                        showDictationButton: true,
+                        favoriteFolders: [],
+                        projectImportState: null,
+                        preferredProjectLocation: null,
+                        initializeGitOnProjectCreate: false,
+                        gitOpsDefaultMode: "commit",
+                        projectDeletionMode: "pi-only",
+                        useAgentsSkillsPaths: false,
+                        piTuiTakeover: false,
+                      }
+                    }
                     diffBaseline={diffBaseline}
                     diffRenderMode={diffRenderMode}
                     diffComments={diffComments}

--- a/src/app/views/settings/settingsDescriptors.tsx
+++ b/src/app/views/settings/settingsDescriptors.tsx
@@ -582,6 +582,36 @@ export function buildSettingsDescriptors({
       ),
     },
     {
+      id: "projects.gitops-default",
+      category: "projects",
+      title: "GitOps default",
+      description: "Default commit action for projects that do not have their own override.",
+      keywords: "gitops commit push default project",
+      render: () => (
+        <div className="grid grid-cols-2 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)]">
+          {[
+            ["commit", "Commit"],
+            ["commit-push", "Commit & push"],
+          ].map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              className={cn(
+                "rounded-full px-3 py-1 transition-colors active:scale-[0.96]",
+                appSettings.gitOpsDefaultMode === value &&
+                  "bg-[rgba(255,255,255,0.18)] text-[color:var(--text)] shadow-[inset_0_0_0_1px_rgba(183,186,245,0.5)]",
+              )}
+              onClick={() =>
+                controller.setGitOpsDefaultMode(value as AppSettings["gitOpsDefaultMode"])
+              }
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      ),
+    },
+    {
       id: "projects.deletion-mode",
       category: "projects",
       title: "Project deletion cleanup",

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -229,6 +229,11 @@ export function useSettingsController({
         key: "projectDeletionMode",
         value,
       }),
+    setGitOpsDefaultMode: (value: AppSettings["gitOpsDefaultMode"]) =>
+      void onAction("settings.update", {
+        key: "gitOpsDefaultMode",
+        value,
+      }),
     updatePiSetting: <Key extends keyof PiSettings>(key: Key, value: PiSettings[Key]) =>
       void onAction("pi-settings.update", {
         piSettingsKey: key,

--- a/src/test/controller-post-action-effects.test.ts
+++ b/src/test/controller-post-action-effects.test.ts
@@ -28,6 +28,7 @@ function buildShellState(): ShellState {
       projectImportState: null,
       preferredProjectLocation: null,
       initializeGitOnProjectCreate: false,
+      gitOpsDefaultMode: "commit",
       projectDeletionMode: "pi-only",
       useAgentsSkillsPaths: false,
       piTuiTakeover: false,
@@ -122,6 +123,13 @@ describe("controller post action effects", () => {
         value: "full-clean",
       }),
     ).toMatchObject({ appSettings: { projectDeletionMode: "full-clean" } });
+
+    expect(
+      getOptimisticallyUpdatedShellState(state, {
+        key: "gitOpsDefaultMode",
+        value: "commit-push",
+      }),
+    ).toMatchObject({ appSettings: { gitOpsDefaultMode: "commit-push" } });
 
     expect(
       getOptimisticallyUpdatedShellState(state, {


### PR DESCRIPTION
## Summary
- Add explicit GitOps success/failure feedback after commit and commit/push actions.
- Persist an app-wide GitOps default, defaulting to commit.
- Add per-project GitOps mode overrides with an option to return to the app default.
- Track whether a backend commit actually pushed before showing push success copy.

Closes #130

## Validation
- Commit hooks passed: Biome, typecheck, Vitest
- Vitest: 31 files / 138 tests passed
- `/review` findings addressed