### PR TITLE
Add GitHub project link import

### DIFF
--- a/desktop/pi-threads/project-actions.cts
+++ b/desktop/pi-threads/project-actions.cts
@@ -11,7 +11,7 @@ import {
 } from "../../shared/pi-thread-action-payloads.ts";
 import { loadAppSettings } from "../app-settings.cts";
 import { selectProjectRuntime } from "../pi-desktop-runtime.cts";
-import { createProject } from "../project-create.cts";
+import { createProject, createProjectFromGitHubUrl } from "../project-create.cts";
 import { getOriginUrl } from "../project-git/project-state.cts";
 import { importProjects, scanKnownProjects } from "../project-import.cts";
 import { openPathWithSystem } from "../system-open-path.cts";
@@ -173,12 +173,18 @@ export async function handleProjectDesktopAction(
   switch (action) {
     case "project.add": {
       const appSettings = loadAppSettings();
+      const repoUrl = typeof payload.repoUrl === "string" ? payload.repoUrl.trim() : "";
       return handledAction(
-        await createProject({
-          preferredProjectLocation: appSettings.preferredProjectLocation,
-          projectName: getProjectName(payload) ?? "",
-          initializeGit: appSettings.initializeGitOnProjectCreate,
-        }),
+        repoUrl
+          ? await createProjectFromGitHubUrl({
+              preferredProjectLocation: appSettings.preferredProjectLocation,
+              repositoryUrl: repoUrl,
+            })
+          : await createProject({
+              preferredProjectLocation: appSettings.preferredProjectLocation,
+              projectName: getProjectName(payload) ?? "",
+              initializeGit: appSettings.initializeGitOnProjectCreate,
+            }),
       );
     }
 

--- a/desktop/project-create.cts
+++ b/desktop/project-create.cts
@@ -1,8 +1,24 @@
-import { mkdir } from "node:fs/promises";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
+import { getDesktopWorkingDirectory } from "../shared/desktop-working-directory.ts";
 import { startNewThread } from "./pi-desktop-runtime.cts";
 import { initializeProjectGit } from "./project-git.cts";
-import { moveProjectToTop } from "./thread-state-db.cts";
+import { formatGitCommandError, getNonInteractiveGitEnv } from "./project-git/git-runner.cts";
+import { getOriginUrl, isGitRepository } from "./project-git/project-state.cts";
+import {
+  isSameGitHubRepository,
+  parseGitHubRepositoryUrl,
+} from "../shared/github-repository-url.ts";
+import {
+  ensureProject,
+  listProjects,
+  moveProjectToTop,
+  setProjectRepoOrigin,
+} from "./thread-state-db.cts";
+
+const execFile = promisify(execFileCallback);
 
 function sanitizeProjectFolderName(projectName: string) {
   let nextName = projectName
@@ -53,6 +69,122 @@ export async function createProject(options: {
   }
 
   const result = await startNewThread({ projectId: projectPath });
+  moveProjectToTop(projectPath);
+  return result;
+}
+
+async function resolvePathIfPresent(projectPath: string) {
+  try {
+    return await realpath(projectPath);
+  } catch {
+    return path.resolve(projectPath);
+  }
+}
+
+async function directoryExists(directoryPath: string) {
+  try {
+    return (await stat(directoryPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function addExistingRepositoryProject(projectPath: string, repositoryUrl: string) {
+  if (!(await directoryExists(projectPath)) || !(await isGitRepository(projectPath))) {
+    return null;
+  }
+
+  const originUrl = await getOriginUrl(projectPath);
+  if (!isSameGitHubRepository(originUrl, repositoryUrl)) {
+    return null;
+  }
+
+  ensureProject(projectPath);
+  setProjectRepoOrigin(projectPath, originUrl ?? repositoryUrl);
+  moveProjectToTop(projectPath);
+  return { projectId: projectPath };
+}
+
+async function findExistingGitHubProject(repositoryUrl: string) {
+  const projects = listProjects(getDesktopWorkingDirectory());
+
+  for (const project of projects) {
+    if (isSameGitHubRepository(project.repoOriginUrl, repositoryUrl)) {
+      return project.id;
+    }
+  }
+
+  for (const project of projects) {
+    if (!(await isGitRepository(project.id))) {
+      continue;
+    }
+
+    const originUrl = await getOriginUrl(project.id);
+    if (isSameGitHubRepository(originUrl, repositoryUrl)) {
+      setProjectRepoOrigin(project.id, originUrl);
+      return project.id;
+    }
+  }
+
+  return null;
+}
+
+export async function createProjectFromGitHubUrl(options: {
+  preferredProjectLocation: string | null;
+  repositoryUrl: string;
+}) {
+  const preferredProjectLocation = options.preferredProjectLocation?.trim() ?? "";
+  if (preferredProjectLocation.length === 0) {
+    throw new Error("Set a default project location in Settings first.");
+  }
+
+  const repository = parseGitHubRepositoryUrl(options.repositoryUrl);
+  if (!repository) {
+    throw new Error("Paste a GitHub repository URL such as https://github.com/owner/repo.");
+  }
+
+  const existingProjectId = await findExistingGitHubProject(repository.canonicalUrl);
+  if (existingProjectId) {
+    moveProjectToTop(existingProjectId);
+    return { projectId: existingProjectId };
+  }
+
+  const parentDirectory = path.resolve(preferredProjectLocation);
+  const projectPath = path.join(parentDirectory, sanitizeProjectFolderName(repository.folderName));
+  await mkdir(parentDirectory, { recursive: true });
+
+  const existingDirectoryProject = await addExistingRepositoryProject(
+    projectPath,
+    repository.canonicalUrl,
+  );
+  if (existingDirectoryProject) {
+    return existingDirectoryProject;
+  }
+
+  try {
+    await execFile("git", ["clone", "--progress", repository.cloneUrl, projectPath], {
+      cwd: parentDirectory,
+      env: getNonInteractiveGitEnv(),
+      timeout: 120_000,
+      maxBuffer: 1024 * 1024 * 4,
+    });
+  } catch (error) {
+    const resolvedProjectPath = await resolvePathIfPresent(projectPath);
+    const resolvedExistingProject = await findExistingGitHubProject(repository.canonicalUrl);
+    if (
+      resolvedExistingProject &&
+      (await resolvePathIfPresent(resolvedExistingProject)) === resolvedProjectPath
+    ) {
+      moveProjectToTop(resolvedExistingProject);
+      return { projectId: resolvedExistingProject };
+    }
+
+    throw new Error(`Unable to clone ${repository.canonicalUrl}: ${formatGitCommandError(error)}`);
+  }
+
+  const result = await startNewThread({ projectId: projectPath });
+  ensureProject(projectPath);
+  setProjectRepoOrigin(projectPath, repository.canonicalUrl);
   moveProjectToTop(projectPath);
   return result;
 }

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -71,7 +71,7 @@ export type DesktopSettingsUpdatePayload =
 
 export type DesktopActionPayloadMap = {
   "threads.collapse-all": EmptyActionPayload;
-  "project.add": { projectName?: string };
+  "project.add": { projectName?: string; repoUrl?: string | null };
   "project.select": { projectId?: string | null; sessionPath?: string | null };
   "project.expand": { projectId: string };
   "project.collapse": { projectId: string };

--- a/shared/github-repository-url.ts
+++ b/shared/github-repository-url.ts
@@ -1,0 +1,91 @@
+export type GitHubRepositoryLink = {
+  owner: string;
+  repo: string;
+  cloneUrl: string;
+  sshUrl: string;
+  canonicalUrl: string;
+  folderName: string;
+};
+
+const githubHostPattern = /^(?:www\.)?github\.com$/i;
+
+function cleanRepositoryName(repo: string) {
+  return repo.replace(/\.git$/i, "").trim();
+}
+
+function buildGitHubRepositoryLink(
+  owner: string,
+  repo: string,
+  cloneProtocol: "https" | "ssh" = "https",
+): GitHubRepositoryLink | null {
+  const cleanOwner = owner.trim();
+  const cleanRepo = cleanRepositoryName(repo);
+
+  if (!/^[A-Za-z0-9_.-]+$/.test(cleanOwner) || !/^[A-Za-z0-9_.-]+$/.test(cleanRepo)) {
+    return null;
+  }
+
+  const httpsCloneUrl = `https://github.com/${cleanOwner}/${cleanRepo}.git`;
+  const sshUrl = `git@github.com:${cleanOwner}/${cleanRepo}.git`;
+
+  return {
+    owner: cleanOwner,
+    repo: cleanRepo,
+    cloneUrl: cloneProtocol === "ssh" ? sshUrl : httpsCloneUrl,
+    sshUrl,
+    canonicalUrl: `https://github.com/${cleanOwner}/${cleanRepo}`,
+    folderName: cleanRepo,
+  };
+}
+
+export function parseGitHubRepositoryUrl(input: string): GitHubRepositoryLink | null {
+  const value = input.trim();
+  if (!value) {
+    return null;
+  }
+
+  const sshMatch = value.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i);
+  if (sshMatch) {
+    return buildGitHubRepositoryLink(sshMatch[1] ?? "", sshMatch[2] ?? "", "ssh");
+  }
+
+  const shorthandMatch = value.match(/^github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i);
+  if (shorthandMatch) {
+    return buildGitHubRepositoryLink(shorthandMatch[1] ?? "", shorthandMatch[2] ?? "");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (
+    !githubHostPattern.test(url.hostname) ||
+    (url.protocol !== "https:" && url.protocol !== "http:")
+  ) {
+    return null;
+  }
+
+  const [owner, repo] = url.pathname.split("/").filter(Boolean);
+  if (!owner || !repo) {
+    return null;
+  }
+
+  return buildGitHubRepositoryLink(owner, repo);
+}
+
+export function normalizeGitHubRepositoryUrl(input: string) {
+  const link = parseGitHubRepositoryUrl(input);
+  return link?.canonicalUrl ?? null;
+}
+
+export function isSameGitHubRepository(
+  left: string | null | undefined,
+  right: string | null | undefined,
+) {
+  const normalizedLeft = left ? normalizeGitHubRepositoryUrl(left) : null;
+  const normalizedRight = right ? normalizeGitHubRepositoryUrl(right) : null;
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}

--- a/src/app/components/sidebar/projects/AGENTS.md
+++ b/src/app/components/sidebar/projects/AGENTS.md
@@ -1,0 +1,6 @@
+# Sidebar projects UI notes
+
+- Keep create/add-project popovers compact; avoid adding explanatory blocks that increase popover height.
+- Prefer placeholder text, tooltip text, or existing inline error styles over new helper text rows.
+- Reuse existing sidebar row/popover classes before adding custom CSS.
+- If an add/create action may take time, show a lightweight pending project row in the list instead of expanding the popover.

--- a/src/app/components/sidebar/projects/SidebarProjectsCreatePopover.tsx
+++ b/src/app/components/sidebar/projects/SidebarProjectsCreatePopover.tsx
@@ -67,8 +67,8 @@ export function SidebarProjectsCreatePopover({
             }
           }}
           className="sidebar-project-create-input"
-          placeholder="Project name"
-          aria-label="Project name"
+          placeholder="Project name or GitHub URL"
+          aria-label="Project name or GitHub repository URL"
         />
 
         <button
@@ -77,13 +77,12 @@ export function SidebarProjectsCreatePopover({
           onClick={onCreate}
           disabled={!canCreate}
           data-enabled={canCreate ? "true" : "false"}
-          aria-label={busy ? "Creating project" : "Create project"}
-          data-tooltip={busy ? "Creating project" : "Create project"}
+          aria-label={busy ? "Adding project" : "Add project"}
+          data-tooltip={busy ? "Adding project" : "Add project"}
         >
           <FolderPlus size={15} />
         </button>
       </div>
-
       {errorMessage ? <div className="sidebar-inline-error">{errorMessage}</div> : null}
     </dialog>
   );

--- a/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
+++ b/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
@@ -1,5 +1,6 @@
 import { Clock3, FolderPlus, Github, ListFilter, Search, SquareTerminal, Star } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { parseGitHubRepositoryUrl } from "../../../../../shared/github-repository-url";
 import type { AppSettings, DesktopActionInvoker } from "../../../desktop/types";
 import { useDesktopBridgeAvailable } from "../../../hooks/useDesktopBridge";
 import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
@@ -12,6 +13,11 @@ import {
   type SidebarProjectsFilterMode,
   getSidebarVisibleProjects,
 } from "./sidebar-projects.helpers";
+
+type PendingProject = {
+  key: string;
+  name: string;
+};
 
 type SidebarProjectsSectionProps = {
   activeView: View;
@@ -71,6 +77,8 @@ export function SidebarProjectsSection({
   const [projectNameDraft, setProjectNameDraft] = useState("");
   const [createBusy, setCreateBusy] = useState(false);
   const [createErrorMessage, setCreateErrorMessage] = useState<string | null>(null);
+  const [createdProjectIds, setCreatedProjectIds] = useState<string[]>([]);
+  const [pendingProject, setPendingProject] = useState<PendingProject | null>(null);
   const desktopBridgeAvailable = useDesktopBridgeAvailable();
   const createButtonRef = useRef<HTMLButtonElement>(null);
   const createPanelRef = useRef<HTMLDialogElement>(null);
@@ -84,9 +92,11 @@ export function SidebarProjectsSection({
         terminalRunningProjectIds,
         terminalRunningSessionPaths,
         appLaunchedAtMs,
+        priorityProjectIds: createdProjectIds,
       }),
     [
       appLaunchedAtMs,
+      createdProjectIds,
       filterMode,
       projects,
       searchQuery,
@@ -181,24 +191,45 @@ export function SidebarProjectsSection({
       return;
     }
 
-    const projectName = projectNameDraft.trim();
-    if (!projectName) {
+    const draft = projectNameDraft.trim();
+    if (!draft) {
       return;
     }
 
+    const repository = parseGitHubRepositoryUrl(draft);
+    const pendingProjectName = repository?.folderName ?? draft;
+    setPendingProject({ key: `${Date.now()}:${draft}`, name: pendingProjectName });
+    setProjectNameDraft("");
+    setCreateOpen(false);
     setCreateBusy(true);
 
     try {
-      const result = await onAction("project.add", { projectName });
+      const result = await onAction(
+        "project.add",
+        repository ? { repoUrl: repository.canonicalUrl } : { projectName: draft },
+      );
       const error = typeof result?.result?.error === "string" ? result.result.error : null;
 
       if (error) {
         setCreateErrorMessage(error);
+        setProjectNameDraft(draft);
+        setCreateOpen(true);
+        setPendingProject(null);
         return;
       }
 
-      setProjectNameDraft("");
-      setCreateOpen(false);
+      const projectId =
+        typeof result?.result?.projectId === "string" ? result.result.projectId : null;
+      if (projectId) {
+        setCreatedProjectIds((current) => [projectId, ...current.filter((id) => id !== projectId)]);
+      }
+
+      setPendingProject(null);
+    } catch (error) {
+      setCreateErrorMessage(error instanceof Error ? error.message : "Unable to add project.");
+      setProjectNameDraft(draft);
+      setCreateOpen(true);
+      setPendingProject(null);
     } finally {
       setCreateBusy(false);
     }
@@ -286,23 +317,46 @@ export function SidebarProjectsSection({
         ) : null}
       </div>
 
-      {visibleProjects.length > 0 ? (
-        <ProjectTree
-          projects={visibleProjects}
-          protectedProjectId={protectedProjectId}
-          selectedProjectId={selectedProjectId}
-          selectedThreadId={selectedThreadId}
-          terminalRunningSessionPaths={terminalRunningSessionPaths}
-          activeView={activeView}
-          selectionModeActive={selectionModeActive}
-          revealOldThreads={searchQuery.trim().length > 0}
-          collapsedProjectIds={effectiveCollapsedProjectIds}
-          onAction={onAction}
-          onProjectSelect={onProjectSelect}
-          onProjectReorder={onProjectReorder}
-          onThreadOpen={onThreadOpen}
-          onToggleProjectCollapse={onToggleProjectCollapse}
-        />
+      {visibleProjects.length > 0 || pendingProject ? (
+        <>
+          {pendingProject ? (
+            <div className="sidebar-tree-item" aria-live="polite">
+              <div className="sidebar-project-row sidebar-row-surface motion-surface-pulse">
+                <span className="sidebar-project-toggle" data-can-toggle="false">
+                  <FolderPlus
+                    size={12}
+                    className="sidebar-project-icon sidebar-project-origin-icon"
+                  />
+                </span>
+                <div
+                  className="sidebar-project-button"
+                  aria-label={`Adding ${pendingProject.name}`}
+                >
+                  <span className="sidebar-project-title">{pendingProject.name}</span>
+                </div>
+                <span className="text-[11px] text-[color:var(--muted-2)]">Adding…</span>
+              </div>
+            </div>
+          ) : null}
+          {visibleProjects.length > 0 ? (
+            <ProjectTree
+              projects={visibleProjects}
+              protectedProjectId={protectedProjectId}
+              selectedProjectId={selectedProjectId}
+              selectedThreadId={selectedThreadId}
+              terminalRunningSessionPaths={terminalRunningSessionPaths}
+              activeView={activeView}
+              selectionModeActive={selectionModeActive}
+              revealOldThreads={searchQuery.trim().length > 0}
+              collapsedProjectIds={effectiveCollapsedProjectIds}
+              onAction={onAction}
+              onProjectSelect={onProjectSelect}
+              onProjectReorder={onProjectReorder}
+              onThreadOpen={onThreadOpen}
+              onToggleProjectCollapse={onToggleProjectCollapse}
+            />
+          ) : null}
+        </>
       ) : !desktopBridgeAvailable ? (
         <div className="px-2.5 py-2 text-[12px] leading-5 text-[color:var(--muted-2)]">
           Project sync needs the desktop bridge. Restart the dev server or use{" "}

--- a/src/app/components/sidebar/projects/sidebar-projects.helpers.ts
+++ b/src/app/components/sidebar/projects/sidebar-projects.helpers.ts
@@ -8,7 +8,12 @@ function projectMatchesFilter(
   terminalRunningProjectIds: ReadonlySet<string>,
   terminalRunningSessionPaths: ReadonlySet<string>,
   appLaunchedAtMs: number,
+  priorityProjectIds: ReadonlySet<string>,
 ) {
+  if (priorityProjectIds.has(project.id)) {
+    return true;
+  }
+
   if (filterMode === "github") {
     return Boolean(project.repoOriginUrl);
   }
@@ -88,9 +93,11 @@ export function getSidebarVisibleProjects(input: {
   terminalRunningProjectIds: ReadonlySet<string>;
   terminalRunningSessionPaths: ReadonlySet<string>;
   appLaunchedAtMs: number;
+  priorityProjectIds?: readonly string[];
 }) {
   const normalizedQuery = input.searchQuery.trim().toLowerCase();
   const autoExpandedProjectIds = new Set<string>();
+  const priorityProjectIds = new Set(input.priorityProjectIds ?? []);
 
   const projects = input.projects.flatMap((project) => {
     if (
@@ -100,6 +107,7 @@ export function getSidebarVisibleProjects(input: {
         input.terminalRunningProjectIds,
         input.terminalRunningSessionPaths,
         input.appLaunchedAtMs,
+        priorityProjectIds,
       )
     ) {
       return [];
@@ -127,7 +135,11 @@ export function getSidebarVisibleProjects(input: {
       thread.title.toLowerCase().includes(normalizedQuery),
     );
 
-    if (!projectMatchesQuery && matchingThreads.length === 0) {
+    if (
+      !priorityProjectIds.has(project.id) &&
+      !projectMatchesQuery &&
+      matchingThreads.length === 0
+    ) {
       return [];
     }
 
@@ -143,6 +155,25 @@ export function getSidebarVisibleProjects(input: {
         threadsLoaded: project.threadsLoaded || matchingThreads.length > 0,
       },
     ];
+  });
+
+  projects.sort((left, right) => {
+    const leftPriority = input.priorityProjectIds?.indexOf(left.id) ?? -1;
+    const rightPriority = input.priorityProjectIds?.indexOf(right.id) ?? -1;
+
+    if (leftPriority === -1 && rightPriority === -1) {
+      return 0;
+    }
+
+    if (leftPriority === -1) {
+      return 1;
+    }
+
+    if (rightPriority === -1) {
+      return -1;
+    }
+
+    return leftPriority - rightPriority;
   });
 
   return {

--- a/src/test/github-repository-url.test.ts
+++ b/src/test/github-repository-url.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSameGitHubRepository,
+  parseGitHubRepositoryUrl,
+} from "../../shared/github-repository-url";
+
+describe("GitHub repository URL parsing", () => {
+  it("parses common GitHub repository URL formats", () => {
+    expect(parseGitHubRepositoryUrl("https://github.com/owner/repo")?.canonicalUrl).toBe(
+      "https://github.com/owner/repo",
+    );
+    expect(parseGitHubRepositoryUrl("https://github.com/owner/repo.git")?.canonicalUrl).toBe(
+      "https://github.com/owner/repo",
+    );
+    expect(parseGitHubRepositoryUrl("git@github.com:owner/repo.git")?.canonicalUrl).toBe(
+      "https://github.com/owner/repo",
+    );
+    expect(parseGitHubRepositoryUrl("github.com/owner/repo")?.canonicalUrl).toBe(
+      "https://github.com/owner/repo",
+    );
+  });
+
+  it("ignores non-repository and non-GitHub input", () => {
+    expect(parseGitHubRepositoryUrl("repo name")).toBeNull();
+    expect(parseGitHubRepositoryUrl("https://example.com/owner/repo")).toBeNull();
+    expect(parseGitHubRepositoryUrl("https://github.com/owner")).toBeNull();
+  });
+
+  it("compares equivalent GitHub repository origins", () => {
+    expect(
+      isSameGitHubRepository("git@github.com:owner/repo.git", "https://github.com/owner/repo"),
+    ).toBe(true);
+    expect(
+      isSameGitHubRepository("https://github.com/owner/repo", "https://github.com/other/repo"),
+    ).toBe(false);
+  });
+});

--- a/src/test/sidebar-projects.helpers.test.ts
+++ b/src/test/sidebar-projects.helpers.test.ts
@@ -207,4 +207,18 @@ describe("sidebar projects helpers", () => {
     expect(result.projects[0]?.threadsLoaded).toBe(false);
     expect(result.autoExpandedProjectIds.has("/howcode")).toBe(true);
   });
+
+  it("keeps newly created projects visible at the top regardless of filter or search", () => {
+    const result = getSidebarVisibleProjects({
+      projects,
+      searchQuery: "missing",
+      filterMode: "favourites",
+      terminalRunningProjectIds: emptyRunningProjectIds,
+      terminalRunningSessionPaths: emptyRunningSessionPaths,
+      appLaunchedAtMs: 0,
+      priorityProjectIds: ["/beta", "/alpha"],
+    });
+
+    expect(result.projects.map((project) => project.id)).toEqual(["/beta", "/alpha"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Let the sidebar add-project flow accept GitHub repository links as well as project names.
- Clone GitHub repos into the configured default project location and add/select the project.
- Detect existing matching GitHub projects/clones to avoid duplicates.
- Show a pending project row while clone/add is running and keep newly added projects temporarily pinned at the top until restart.

## Validation
- Pre-commit hooks passed: lint, typecheck, tests — 32 files / 142 tests passed.

Closes #143