### PR TITLE
Persist GitOps diff preferences

### DIFF
--- a/desktop/app-settings.cts
+++ b/desktop/app-settings.cts
@@ -5,6 +5,8 @@ import type {
   DictationModelId,
   GitOpsMode,
   ModelSelection,
+  ProjectDiffDefaultBaseline,
+  ProjectDiffRenderMode,
   ProjectDeletionMode,
 } from "../shared/desktop-contracts.ts";
 import {
@@ -26,6 +28,8 @@ const projectImportStateKey = "projectImportState";
 const preferredProjectLocationKey = "preferredProjectLocation";
 const initializeGitOnProjectCreateKey = "initializeGitOnProjectCreate";
 const gitOpsDefaultModeKey = "gitOpsDefaultMode";
+const gitDiffBaselineDefaultKey = "gitDiffBaselineDefault";
+const gitDiffRenderModeDefaultKey = "gitDiffRenderModeDefault";
 const projectDeletionModeKey = "projectDeletionMode";
 const useAgentsSkillsPathsKey = "useAgentsSkillsPaths";
 const piTuiTakeoverKey = "piTuiTakeover";
@@ -155,6 +159,46 @@ function parseGitOpsModePreference(valueJson: string | null | undefined): GitOps
   try {
     const parsed = JSON.parse(valueJson) as unknown;
     return parsed === "commit" || parsed === "commit-push" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseGitDiffBaselineDefaultPreference(
+  valueJson: string | null | undefined,
+): ProjectDiffDefaultBaseline | null {
+  if (!valueJson) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(valueJson) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    const baseline = parsed as { kind?: unknown };
+    return baseline.kind === "head" ||
+      baseline.kind === "previous" ||
+      baseline.kind === "yesterday" ||
+      baseline.kind === "main-branch" ||
+      baseline.kind === "dev-branch"
+      ? ({ kind: baseline.kind } as ProjectDiffDefaultBaseline)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseGitDiffRenderModePreference(
+  valueJson: string | null | undefined,
+): ProjectDiffRenderMode | null {
+  if (!valueJson) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(valueJson) as unknown;
+    return parsed === "stacked" || parsed === "split" ? parsed : null;
   } catch {
     return null;
   }
@@ -314,6 +358,24 @@ export function loadAppSettings(): AppSettings {
       `,
     )
     .get(gitOpsDefaultModeKey) as PreferenceRow | undefined;
+  const gitDiffBaselineDefaultRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(gitDiffBaselineDefaultKey) as PreferenceRow | undefined;
+  const gitDiffRenderModeDefaultRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(gitDiffRenderModeDefaultKey) as PreferenceRow | undefined;
   const useAgentsSkillsPathsRow = db
     .prepare(
       `
@@ -382,6 +444,11 @@ export function loadAppSettings(): AppSettings {
     initializeGitOnProjectCreate:
       parseBooleanPreference(initializeGitOnProjectCreateRow?.valueJson) ?? false,
     gitOpsDefaultMode: parseGitOpsModePreference(gitOpsDefaultModeRow?.valueJson) ?? "commit",
+    gitDiffBaselineDefault: parseGitDiffBaselineDefaultPreference(
+      gitDiffBaselineDefaultRow?.valueJson,
+    ) ?? { kind: "head" },
+    gitDiffRenderModeDefault:
+      parseGitDiffRenderModePreference(gitDiffRenderModeDefaultRow?.valueJson) ?? "stacked",
     projectDeletionMode:
       parseProjectDeletionModePreference(projectDeletionModeRow?.valueJson) ?? "pi-only",
     useAgentsSkillsPaths: parseBooleanPreference(useAgentsSkillsPathsRow?.valueJson) ?? false,
@@ -496,6 +563,24 @@ export function setGitOpsDefaultMode(mode: GitOpsMode) {
   }
 
   writeAppPreference(gitOpsDefaultModeKey, JSON.stringify(mode));
+}
+
+export function setGitDiffBaselineDefault(baseline: ProjectDiffDefaultBaseline) {
+  if (baseline.kind === "head") {
+    deleteAppPreference(gitDiffBaselineDefaultKey);
+    return;
+  }
+
+  writeAppPreference(gitDiffBaselineDefaultKey, JSON.stringify(baseline));
+}
+
+export function setGitDiffRenderModeDefault(mode: ProjectDiffRenderMode) {
+  if (mode === "stacked") {
+    deleteAppPreference(gitDiffRenderModeDefaultKey);
+    return;
+  }
+
+  writeAppPreference(gitDiffRenderModeDefaultKey, JSON.stringify(mode));
 }
 
 export function setProjectDeletionMode(mode: ProjectDeletionMode) {

--- a/desktop/pi-threads/settings-actions.cts
+++ b/desktop/pi-threads/settings-actions.cts
@@ -12,6 +12,8 @@ import {
   getSettingsModelSelection,
   getSettingsNumberValue,
   getSettingsPreferredProjectLocation,
+  getSettingsProjectDiffBaselineDefault,
+  getSettingsProjectDiffRenderModeDefault,
   getSettingsProjectDeletionMode,
   getSettingsProjectImportState,
   getSettingsReset,
@@ -24,6 +26,8 @@ import {
   setFavoriteFolders,
   setGitCommitMessageModelSelection,
   setGitCommitMessageThinkingLevel,
+  setGitDiffBaselineDefault,
+  setGitDiffRenderModeDefault,
   setGitOpsDefaultMode,
   setInitializeGitOnProjectCreate,
   setPiTuiTakeover,
@@ -145,6 +149,22 @@ export async function handleSettingsDesktopAction(
     const value = payload.value;
     if (value === "commit" || value === "commit-push") {
       setGitOpsDefaultMode(value);
+    }
+    return handledAction();
+  }
+
+  if (key === "gitDiffBaselineDefault") {
+    const value = getSettingsProjectDiffBaselineDefault(payload);
+    if (value) {
+      setGitDiffBaselineDefault(value);
+    }
+    return handledAction();
+  }
+
+  if (key === "gitDiffRenderModeDefault") {
+    const value = getSettingsProjectDiffRenderModeDefault(payload);
+    if (value) {
+      setGitDiffRenderModeDefault(value);
     }
     return handledAction();
   }

--- a/desktop/pi-threads/thread-loader.cts
+++ b/desktop/pi-threads/thread-loader.cts
@@ -8,6 +8,7 @@ import { getLiveThread } from "../pi-desktop-runtime.cts";
 import { invokeRuntimeHost } from "../runtime-host/client.cts";
 import {
   ensureProject,
+  getThreadDiffPreferences,
   listArchivedThreads,
   listInboxThreads,
   listProjectThreads,
@@ -20,6 +21,13 @@ export type LoadedThreadSnapshot = {
   threadId: string;
   thread: ThreadData;
 };
+
+function attachThreadDiffPreferences(thread: ThreadData): ThreadData {
+  return {
+    ...thread,
+    diffPreferences: getThreadDiffPreferences(thread.sessionPath),
+  };
+}
 
 const INBOX_PROMPT_BACKFILL_CONCURRENCY = 6;
 
@@ -70,10 +78,15 @@ export async function loadThreadSnapshot(
   sessionPath: string,
   options?: { historyCompactions?: number },
 ): Promise<LoadedThreadSnapshot> {
-  return invokeRuntimeHost("loadThreadSnapshot", {
+  const snapshot = await invokeRuntimeHost("loadThreadSnapshot", {
     sessionPath,
     historyCompactions: options?.historyCompactions,
   });
+
+  return {
+    ...snapshot,
+    thread: attachThreadDiffPreferences(snapshot.thread),
+  };
 }
 
 export async function loadThread(
@@ -85,7 +98,7 @@ export async function loadThread(
     (liveThread?.isStreaming || liveThread?.isCompacting) &&
     (options?.historyCompactions ?? 0) === 0
   ) {
-    return liveThread;
+    return attachThreadDiffPreferences(liveThread);
   }
 
   return (await loadThreadSnapshot(sessionPath, options)).thread;

--- a/desktop/pi-threads/workspace-actions.cts
+++ b/desktop/pi-threads/workspace-actions.cts
@@ -1,5 +1,6 @@
 import type { DesktopAction } from "../../shared/desktop-actions.ts";
 import type { AnyDesktopActionPayload } from "../../shared/desktop-contracts.ts";
+import { getPersistedSessionPath } from "../../shared/session-paths.ts";
 import {
   getComposerRequest,
   getGitCommitMessage,
@@ -8,11 +9,17 @@ import {
   getGitPreview,
   getGitPush,
   getGitRepoUrl,
+  getProjectDiffBaselinePreference,
+  getProjectDiffRenderModePreference,
   getProjectId,
 } from "../../shared/pi-thread-action-payloads.ts";
 import { generateGitCommitMessage } from "../git-commit-message.cts";
 import { commitProjectChanges, initializeProjectGit, setProjectOrigin } from "../project-git.cts";
-import { setProjectGitOpsMode, setProjectRepoOrigin } from "../thread-state-db.cts";
+import {
+  setProjectGitOpsMode,
+  setProjectRepoOrigin,
+  setThreadDiffPreferences,
+} from "../thread-state-db.cts";
 import type { ActionHandlerResult } from "./action-router-result.cts";
 import { handledAction, unhandledAction } from "./action-router-result.cts";
 
@@ -71,6 +78,37 @@ export async function handleWorkspaceDesktopAction(
 
       await initializeProjectGit(projectId);
       setProjectRepoOrigin(projectId, null);
+      return handledAction();
+    }
+
+    case "workspace.diff-preferences": {
+      const sessionPath = getPersistedSessionPath(
+        typeof payload.sessionPath === "string" ? payload.sessionPath : null,
+      );
+      if (!sessionPath) {
+        return handledAction({
+          error: "Diff preferences can only be saved for persisted sessions.",
+        });
+      }
+
+      const baseline = getProjectDiffBaselinePreference(payload);
+      const renderMode = getProjectDiffRenderModePreference(payload);
+
+      if (baseline === "invalid") {
+        return handledAction({ error: "Invalid diff baseline." });
+      }
+
+      if (renderMode === "invalid") {
+        return handledAction({ error: "Invalid diff render mode." });
+      }
+
+      const saved = setThreadDiffPreferences(sessionPath, {
+        ...(baseline !== undefined ? { baseline } : {}),
+        ...(renderMode !== undefined ? { renderMode } : {}),
+      });
+      if (!saved) {
+        return handledAction({ error: "Could not save diff preferences for this session." });
+      }
       return handledAction();
     }
 

--- a/desktop/thread-state-db.cts
+++ b/desktop/thread-state-db.cts
@@ -9,6 +9,7 @@ export {
   hasInboxItem,
   listInboxThreads,
   listArchivedThreads,
+  getThreadDiffPreferences,
   listProjectThreads,
   listProjects,
 } from "./thread-state-db/queries.cts";
@@ -35,6 +36,7 @@ export {
   setProjectCollapsed,
   syncSessionSummaries,
   setThreadRunningState,
+  setThreadDiffPreferences,
   toggleProjectPinned,
   toggleThreadPinned,
   upsertInboxThreadPrompt,

--- a/desktop/thread-state-db/queries.cts
+++ b/desktop/thread-state-db/queries.cts
@@ -19,12 +19,17 @@ import type {
   ArchivedThreadRow,
   InboxPathRow,
   InboxThreadRow,
+  ThreadDiffPreferencesRow,
   ProjectRow,
   ThreadAssistantSnapshotRow,
   ThreadCwdRow,
   ThreadPathRow,
   ThreadRow,
 } from "./types.cts";
+import type {
+  ProjectDiffBaseline,
+  ProjectDiffPreferences,
+} from "../../shared/desktop-contracts.ts";
 import { getLiveThread } from "../runtime/live-thread-store.cts";
 import { ensureProject } from "./writes.cts";
 
@@ -104,6 +109,66 @@ export function hasRunningProjectThread(projectId: string) {
   return rows.some((row) =>
     getEffectiveThreadRunningState(row.running, getLiveThread(row.sessionPath)),
   );
+}
+
+function parseDiffBaseline(value: string | null): ProjectDiffBaseline | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+
+    const baseline = parsed as Record<string, unknown>;
+    switch (baseline.kind) {
+      case "head":
+      case "previous":
+      case "yesterday":
+      case "main-branch":
+      case "dev-branch":
+        return { kind: baseline.kind };
+      case "last-opened":
+        return typeof baseline.rev === "string" && baseline.rev.trim().length > 0
+          ? {
+              kind: "last-opened",
+              rev: baseline.rev,
+              capturedAt: baseline.capturedAt as string | null | undefined,
+            }
+          : null;
+      case "commit":
+        return typeof baseline.sha === "string" && baseline.sha.trim().length > 0
+          ? { kind: "commit", sha: baseline.sha }
+          : null;
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+export function getThreadDiffPreferences(sessionPath: string): ProjectDiffPreferences {
+  const db = getThreadStateDatabase();
+  const row = db
+    .prepare(
+      `
+        SELECT
+          diff_baseline_json AS diffBaselineJson,
+          diff_render_mode AS diffRenderMode
+        FROM threads
+        WHERE session_path = ?
+      `,
+    )
+    .get(sessionPath) as ThreadDiffPreferencesRow | undefined;
+  const renderMode = row?.diffRenderMode;
+
+  return {
+    baseline: parseDiffBaseline(row?.diffBaselineJson ?? null),
+    renderMode: renderMode === "stacked" || renderMode === "split" ? renderMode : null,
+  };
 }
 
 export function listProjectThreads(projectId: string): Thread[] {

--- a/desktop/thread-state-db/schema.cts
+++ b/desktop/thread-state-db/schema.cts
@@ -157,6 +157,8 @@ export function ensureThreadStateSchema(database: Database) {
       running INTEGER NOT NULL DEFAULT 0,
       pinned INTEGER NOT NULL DEFAULT 0,
       archived INTEGER NOT NULL DEFAULT 0,
+      diff_baseline_json TEXT,
+      diff_render_mode TEXT,
       last_modified_ms INTEGER NOT NULL,
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -231,6 +233,14 @@ export function ensureThreadStateSchema(database: Database) {
 
   if (!hasColumn(database, "threads", "running")) {
     database.exec("ALTER TABLE threads ADD COLUMN running INTEGER NOT NULL DEFAULT 0");
+  }
+
+  if (!hasColumn(database, "threads", "diff_baseline_json")) {
+    database.exec("ALTER TABLE threads ADD COLUMN diff_baseline_json TEXT");
+  }
+
+  if (!hasColumn(database, "threads", "diff_render_mode")) {
+    database.exec("ALTER TABLE threads ADD COLUMN diff_render_mode TEXT");
   }
 
   if (!hasColumn(database, "inbox_items", "last_user_prompt")) {

--- a/desktop/thread-state-db/thread-writes.cts
+++ b/desktop/thread-state-db/thread-writes.cts
@@ -1,3 +1,4 @@
+import type { ProjectDiffBaseline, ProjectDiffRenderMode } from "../../shared/desktop-contracts.ts";
 import { getThreadStateDatabase } from "./db.cts";
 import { runInTransaction } from "./write-transaction.cts";
 
@@ -10,6 +11,43 @@ export function setThreadRunningState(sessionPath: string, running: boolean) {
       WHERE session_path = ? AND running != ?
     `,
   ).run(running ? 1 : 0, sessionPath, running ? 1 : 0);
+}
+
+export function setThreadDiffPreferences(
+  sessionPath: string,
+  preferences: {
+    baseline?: ProjectDiffBaseline | null;
+    renderMode?: ProjectDiffRenderMode | null;
+  },
+): boolean {
+  const assignments: string[] = [];
+  const values: unknown[] = [];
+
+  if ("baseline" in preferences) {
+    assignments.push("diff_baseline_json = ?");
+    values.push(preferences.baseline ? JSON.stringify(preferences.baseline) : null);
+  }
+
+  if ("renderMode" in preferences) {
+    assignments.push("diff_render_mode = ?");
+    values.push(preferences.renderMode ?? null);
+  }
+
+  if (assignments.length === 0) {
+    return true;
+  }
+
+  const db = getThreadStateDatabase();
+  const result = db
+    .prepare(
+      `
+      UPDATE threads
+      SET ${assignments.join(", ")}, updated_at = CURRENT_TIMESTAMP
+      WHERE session_path = ?
+    `,
+    )
+    .run(...values, sessionPath) as { changes: number };
+  return result.changes > 0;
 }
 
 export function toggleThreadPinned(threadId: string) {

--- a/desktop/thread-state-db/types.cts
+++ b/desktop/thread-state-db/types.cts
@@ -74,6 +74,11 @@ export type ThreadPathRow = {
   sessionPath: string;
 };
 
+export type ThreadDiffPreferencesRow = {
+  diffBaselineJson: string | null;
+  diffRenderMode: string | null;
+};
+
 export type ThreadCwdRow = {
   cwd: string;
 };

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -8,6 +8,9 @@ import type {
   DictationModelId,
   GitOpsMode,
   PiSettings,
+  ProjectDiffBaseline,
+  ProjectDiffDefaultBaseline,
+  ProjectDiffRenderMode,
   ProjectDeletionMode,
   ProjectImportCandidate,
 } from "./desktop-data-contracts";
@@ -19,6 +22,8 @@ export type DesktopActionPayloadFields = {
   folders?: string[];
   imported?: boolean | null;
   gitOpsMode?: GitOpsMode | null;
+  diffBaseline?: ProjectDiffBaseline | null;
+  diffRenderMode?: ProjectDiffRenderMode | null;
   includeUnstaged?: boolean;
   key?: keyof AppSettings;
   piSettingsKey?: keyof PiSettings;
@@ -42,7 +47,7 @@ export type DesktopActionPayloadFields = {
   text?: string;
   threadId?: string;
   threadIds?: string[];
-  value?: string | number | boolean | null;
+  value?: string | number | boolean | ProjectDiffDefaultBaseline | null;
 };
 
 export type DesktopActionPayloadInput = {
@@ -65,6 +70,8 @@ export type DesktopSettingsUpdatePayload =
   | { key: "preferredProjectLocation"; value: string | null }
   | { key: "initializeGitOnProjectCreate"; value: boolean }
   | { key: "gitOpsDefaultMode"; value: GitOpsMode }
+  | { key: "gitDiffBaselineDefault"; value: ProjectDiffDefaultBaseline }
+  | { key: "gitDiffRenderModeDefault"; value: ProjectDiffRenderMode }
   | { key: "projectDeletionMode"; value: ProjectDeletionMode }
   | { key: "useAgentsSkillsPaths"; value: boolean }
   | { key: "piTuiTakeover"; value: boolean };
@@ -104,6 +111,12 @@ export type DesktopActionPayloadMap = {
     sessionPath?: string | null;
     repoUrl?: string | null;
     gitOpsMode?: GitOpsMode | null;
+  };
+  "workspace.diff-preferences": {
+    projectId?: string | null;
+    sessionPath?: string | null;
+    diffBaseline?: ProjectDiffBaseline | null;
+    diffRenderMode?: ProjectDiffRenderMode | null;
   };
   "composer.model": {
     projectId?: string | null;

--- a/shared/desktop-action-coverage.ts
+++ b/shared/desktop-action-coverage.ts
@@ -32,6 +32,7 @@ export const implementedDesktopActions = [
   "inbox.dismiss",
   "workspace.commit",
   "workspace.commit-options",
+  "workspace.diff-preferences",
   "settings.update",
   "pi-settings.update",
   "projects.import.scan",

--- a/shared/desktop-actions.ts
+++ b/shared/desktop-actions.ts
@@ -22,6 +22,7 @@ export const desktopActions = [
   "thread.pin",
   "workspace.commit",
   "workspace.commit-options",
+  "workspace.diff-preferences",
   "composer.model",
   "composer.thinking",
   "composer.send",

--- a/shared/desktop-project-git-contracts.ts
+++ b/shared/desktop-project-git-contracts.ts
@@ -1,5 +1,13 @@
 import type { GitOpsMode } from "./desktop-settings-contracts";
 
+export type ProjectDiffRenderMode = "stacked" | "split";
+export type ProjectDiffDefaultBaseline =
+  | { kind: "head" }
+  | { kind: "previous" }
+  | { kind: "yesterday" }
+  | { kind: "main-branch" }
+  | { kind: "dev-branch" };
+
 export type ProjectGitState = {
   projectId: string;
   isGitRepo: boolean;
@@ -23,6 +31,11 @@ export type ProjectDiffBaseline =
   | { kind: "main-branch" }
   | { kind: "dev-branch" }
   | { kind: "commit"; sha: string };
+
+export type ProjectDiffPreferences = {
+  baseline: ProjectDiffBaseline | null;
+  renderMode: ProjectDiffRenderMode | null;
+};
 
 export type ProjectDiffResolvedBaseline = {
   kind: ProjectDiffBaseline["kind"];

--- a/shared/desktop-settings-contracts.ts
+++ b/shared/desktop-settings-contracts.ts
@@ -4,6 +4,10 @@ import type {
   ComposerThinkingLevel,
 } from "./desktop-composer-contracts";
 import type { DictationModelId } from "./desktop-dictation-contracts";
+import type {
+  ProjectDiffDefaultBaseline,
+  ProjectDiffRenderMode,
+} from "./desktop-project-git-contracts";
 import type { Project } from "./desktop-thread-contracts";
 
 export type ModelSelection = {
@@ -28,6 +32,8 @@ export type AppSettings = {
   preferredProjectLocation: string | null;
   initializeGitOnProjectCreate: boolean;
   gitOpsDefaultMode: GitOpsMode;
+  gitDiffBaselineDefault: ProjectDiffDefaultBaseline;
+  gitDiffRenderModeDefault: ProjectDiffRenderMode;
   projectDeletionMode: ProjectDeletionMode;
   useAgentsSkillsPaths: boolean;
   piTuiTakeover: boolean;

--- a/shared/desktop-thread-contracts.ts
+++ b/shared/desktop-thread-contracts.ts
@@ -1,3 +1,5 @@
+import type { ProjectDiffPreferences } from "./desktop-project-git-contracts";
+
 export type Thread = {
   id: string;
   title: string;
@@ -127,4 +129,5 @@ export type ThreadData = {
   previousMessageCount: number;
   isStreaming: boolean;
   isCompacting: boolean;
+  diffPreferences?: ProjectDiffPreferences;
 };

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -8,6 +8,9 @@ import type {
   DictationModelId,
   GitOpsMode,
   ModelSelection,
+  ProjectDiffBaseline,
+  ProjectDiffDefaultBaseline,
+  ProjectDiffRenderMode,
   ProjectDeletionMode,
 } from "./desktop-contracts";
 import { getPersistedSessionPath } from "./session-paths";
@@ -170,6 +173,77 @@ export function getGitOpsMode(
     : "invalid";
 }
 
+function isProjectDiffBaseline(value: unknown): value is ProjectDiffBaseline {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const baseline = value as Record<string, unknown>;
+  switch (baseline.kind) {
+    case "head":
+    case "previous":
+    case "yesterday":
+    case "main-branch":
+    case "dev-branch":
+      return true;
+    case "last-opened":
+      return typeof baseline.rev === "string" && baseline.rev.trim().length > 0;
+    case "commit":
+      return typeof baseline.sha === "string" && baseline.sha.trim().length > 0;
+    default:
+      return false;
+  }
+}
+
+export function getProjectDiffBaselinePreference(
+  payload: DesktopActionPayloadInput,
+): ProjectDiffBaseline | null | undefined | "invalid" {
+  if (!("diffBaseline" in payload) || payload.diffBaseline === undefined) {
+    return undefined;
+  }
+
+  if (payload.diffBaseline === null) {
+    return null;
+  }
+
+  return isProjectDiffBaseline(payload.diffBaseline) ? payload.diffBaseline : "invalid";
+}
+
+export function getProjectDiffRenderModePreference(
+  payload: DesktopActionPayloadInput,
+): ProjectDiffRenderMode | null | undefined | "invalid" {
+  if (!("diffRenderMode" in payload) || payload.diffRenderMode === undefined) {
+    return undefined;
+  }
+
+  if (payload.diffRenderMode === null) {
+    return null;
+  }
+
+  return payload.diffRenderMode === "stacked" || payload.diffRenderMode === "split"
+    ? payload.diffRenderMode
+    : "invalid";
+}
+
+export function getSettingsProjectDiffBaselineDefault(
+  payload: DesktopActionPayloadInput,
+): ProjectDiffDefaultBaseline | null {
+  return isProjectDiffBaseline(payload.value) &&
+    (payload.value.kind === "head" ||
+      payload.value.kind === "previous" ||
+      payload.value.kind === "yesterday" ||
+      payload.value.kind === "main-branch" ||
+      payload.value.kind === "dev-branch")
+    ? payload.value
+    : null;
+}
+
+export function getSettingsProjectDiffRenderModeDefault(
+  payload: DesktopActionPayloadInput,
+): ProjectDiffRenderMode | null {
+  return payload.value === "stacked" || payload.value === "split" ? payload.value : null;
+}
+
 export function getSettingsKey(payload: DesktopActionPayloadInput) {
   return payload.key === "gitCommitMessageModel" ||
     payload.key === "gitCommitMessageThinkingLevel" ||
@@ -184,6 +258,8 @@ export function getSettingsKey(payload: DesktopActionPayloadInput) {
     payload.key === "preferredProjectLocation" ||
     payload.key === "initializeGitOnProjectCreate" ||
     payload.key === "gitOpsDefaultMode" ||
+    payload.key === "gitDiffBaselineDefault" ||
+    payload.key === "gitDiffRenderModeDefault" ||
     payload.key === "projectDeletionMode" ||
     payload.key === "useAgentsSkillsPaths" ||
     payload.key === "piTuiTakeover"

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -3,7 +3,7 @@ import { getPersistedSessionPath, isLocalSessionPath } from "../../../shared/ses
 import { Sidebar } from "../components/sidebar/Sidebar";
 import { TerminalPanel } from "../components/workspace/TerminalPanel";
 import { defaultDiffBaseline } from "../components/workspace/composer/diff-baseline";
-import type { ProjectDiffBaseline } from "../desktop/types";
+import type { ProjectDiffBaseline, ProjectDiffRenderMode } from "../desktop/types";
 import { useAnimatedPresence } from "../hooks/useAnimatedPresence";
 import { AppShellOverlays } from "./AppShellOverlays";
 import { AppShellWorkspace } from "./AppShellWorkspace";
@@ -36,6 +36,45 @@ function isLocalToPersistedTakeoverTransition(
   );
 }
 
+function areDiffBaselinesEqual(left: ProjectDiffBaseline, right: ProjectDiffBaseline) {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+
+  if (left.kind === "commit" && right.kind === "commit") {
+    return left.sha === right.sha;
+  }
+
+  if (left.kind === "last-opened" && right.kind === "last-opened") {
+    return left.rev === right.rev;
+  }
+
+  return true;
+}
+
+function isSameDraftPromotion({
+  activeThreadId,
+  messageCount,
+  previousSessionPath,
+  previousThreadId,
+  nextSessionPath,
+}: {
+  activeThreadId: string | null;
+  messageCount: number | null;
+  previousSessionPath: string | null;
+  previousThreadId: string | null;
+  nextSessionPath: string | null;
+}) {
+  return (
+    isLocalSessionPath(previousSessionPath) &&
+    previousThreadId !== null &&
+    previousThreadId.startsWith("local-thread-") &&
+    activeThreadId !== null &&
+    getPersistedSessionPath(nextSessionPath) !== null &&
+    (messageCount === null || messageCount <= 1)
+  );
+}
+
 type AppShellLayoutProps = {
   controller: AppShellController;
 };
@@ -44,10 +83,29 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
   const controllerRef = useRef(controller);
   const [diffBaselineState, setDiffBaselineState] = useState<{
     projectId: string;
+    threadId: string | null;
+    sessionPath: string | null;
     baseline: ProjectDiffBaseline;
+    source: "init" | "override" | "default";
   }>({
     projectId: "",
+    threadId: null,
+    sessionPath: null,
     baseline: defaultDiffBaseline,
+    source: "init",
+  });
+  const [diffRenderModeState, setDiffRenderModeState] = useState<{
+    projectId: string;
+    threadId: string | null;
+    sessionPath: string | null;
+    renderMode: ProjectDiffRenderMode;
+    source: "init" | "override" | "default";
+  }>({
+    projectId: "",
+    threadId: null,
+    sessionPath: null,
+    renderMode: "stacked",
+    source: "init",
   });
   const {
     activeComposerState,
@@ -76,13 +134,27 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
     state.activeView === "thread" || state.activeView === "gitops"
       ? state.selectedSessionPath
       : null;
+  const activeThreadId =
+    state.activeView === "thread" || state.activeView === "gitops" ? state.selectedThreadId : null;
   const takeoverVisible = state.takeoverVisible;
   const terminalDrawerVisible = state.activeView === "thread" && state.terminalVisible;
   const terminalDrawerPresent = useAnimatedPresence(terminalDrawerVisible);
   const diffBaseline =
-    diffBaselineState.projectId === composerProjectId
+    diffBaselineState.projectId === composerProjectId &&
+    diffBaselineState.threadId === activeThreadId &&
+    diffBaselineState.sessionPath === terminalSessionPath
       ? diffBaselineState.baseline
-      : defaultDiffBaseline;
+      : (controller.activeThreadData?.diffPreferences?.baseline ??
+        controller.shellState?.appSettings.gitDiffBaselineDefault ??
+        defaultDiffBaseline);
+  const diffRenderMode =
+    diffRenderModeState.projectId === composerProjectId &&
+    diffRenderModeState.threadId === activeThreadId &&
+    diffRenderModeState.sessionPath === terminalSessionPath
+      ? diffRenderModeState.renderMode
+      : (controller.activeThreadData?.diffPreferences?.renderMode ??
+        controller.shellState?.appSettings.gitDiffRenderModeDefault ??
+        "stacked");
   const { mainSectionRef, takeoverPresent, workspaceContentClass } = useAppShellLayoutState({
     takeoverVisible,
   });
@@ -120,25 +192,150 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
 
   useEffect(() => {
     setDiffBaselineState((current) => {
-      if (current.projectId === composerProjectId && current.baseline.kind === "head") {
+      const nextBaseline =
+        controller.activeThreadData?.diffPreferences?.baseline ??
+        controller.shellState?.appSettings.gitDiffBaselineDefault ??
+        defaultDiffBaseline;
+      if (
+        current.projectId === composerProjectId &&
+        current.source === "override" &&
+        isSameDraftPromotion({
+          activeThreadId,
+          messageCount: controller.activeThreadData?.messages.length ?? null,
+          previousSessionPath: current.sessionPath,
+          previousThreadId: current.threadId,
+          nextSessionPath: terminalSessionPath,
+        })
+      ) {
+        const appDefault = controllerRef.current.shellState?.appSettings.gitDiffBaselineDefault;
+        const nextBaseline =
+          appDefault && areDiffBaselinesEqual(current.baseline, appDefault)
+            ? null
+            : current.baseline;
+        void controllerRef.current.handleAction("workspace.diff-preferences", {
+          diffBaseline: nextBaseline,
+        });
+        return {
+          ...current,
+          threadId: activeThreadId,
+          sessionPath: terminalSessionPath,
+        };
+      }
+
+      if (
+        current.projectId === composerProjectId &&
+        current.threadId === activeThreadId &&
+        current.sessionPath === terminalSessionPath &&
+        (current.source === "override" || areDiffBaselinesEqual(current.baseline, nextBaseline))
+      ) {
         return current;
       }
 
       return {
         projectId: composerProjectId,
-        baseline: defaultDiffBaseline,
+        threadId: activeThreadId,
+        sessionPath: terminalSessionPath,
+        baseline: nextBaseline,
+        source: "init",
       };
     });
-  }, [composerProjectId]);
+  }, [
+    activeThreadId,
+    composerProjectId,
+    controller.activeThreadData,
+    controller.shellState,
+    terminalSessionPath,
+  ]);
+
+  useEffect(() => {
+    setDiffRenderModeState((current) => {
+      const nextRenderMode =
+        controller.activeThreadData?.diffPreferences?.renderMode ??
+        controller.shellState?.appSettings.gitDiffRenderModeDefault ??
+        "stacked";
+      if (
+        current.projectId === composerProjectId &&
+        current.source === "override" &&
+        isSameDraftPromotion({
+          activeThreadId,
+          messageCount: controller.activeThreadData?.messages.length ?? null,
+          previousSessionPath: current.sessionPath,
+          previousThreadId: current.threadId,
+          nextSessionPath: terminalSessionPath,
+        })
+      ) {
+        const appDefault = controllerRef.current.shellState?.appSettings.gitDiffRenderModeDefault;
+        const nextRenderMode = appDefault === current.renderMode ? null : current.renderMode;
+        void controllerRef.current.handleAction("workspace.diff-preferences", {
+          diffRenderMode: nextRenderMode,
+        });
+        return {
+          ...current,
+          threadId: activeThreadId,
+          sessionPath: terminalSessionPath,
+        };
+      }
+
+      if (
+        current.projectId === composerProjectId &&
+        current.threadId === activeThreadId &&
+        current.sessionPath === terminalSessionPath &&
+        (current.source === "override" || current.renderMode === nextRenderMode)
+      ) {
+        return current;
+      }
+
+      return {
+        projectId: composerProjectId,
+        threadId: activeThreadId,
+        sessionPath: terminalSessionPath,
+        renderMode: nextRenderMode,
+        source: "init",
+      };
+    });
+  }, [
+    activeThreadId,
+    composerProjectId,
+    controller.activeThreadData,
+    controller.shellState,
+    terminalSessionPath,
+  ]);
 
   const handleSetDiffBaseline = useCallback(
     (baseline: ProjectDiffBaseline) => {
+      const appDefault = controllerRef.current.shellState?.appSettings.gitDiffBaselineDefault;
+      const nextBaseline =
+        appDefault && areDiffBaselinesEqual(baseline, appDefault) ? null : baseline;
       setDiffBaselineState({
         projectId: composerProjectId,
+        threadId: activeThreadId,
+        sessionPath: terminalSessionPath,
         baseline,
+        source: nextBaseline ? "override" : "default",
+      });
+      void controllerRef.current.handleAction("workspace.diff-preferences", {
+        diffBaseline: nextBaseline,
       });
     },
-    [composerProjectId],
+    [activeThreadId, composerProjectId, terminalSessionPath],
+  );
+
+  const handleSetDiffRenderMode = useCallback(
+    (renderMode: ProjectDiffRenderMode) => {
+      const appDefault = controllerRef.current.shellState?.appSettings.gitDiffRenderModeDefault;
+      const nextRenderMode = appDefault === renderMode ? null : renderMode;
+      setDiffRenderModeState({
+        projectId: composerProjectId,
+        threadId: activeThreadId,
+        sessionPath: terminalSessionPath,
+        renderMode,
+        source: nextRenderMode ? "override" : "default",
+      });
+      void controllerRef.current.handleAction("workspace.diff-preferences", {
+        diffRenderMode: nextRenderMode,
+      });
+    },
+    [activeThreadId, composerProjectId, terminalSessionPath],
   );
 
   const handleOpenGitOpsFromTakeover = useCallback(async () => {
@@ -172,6 +369,8 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 preferredProjectLocation: null,
                 initializeGitOnProjectCreate: false,
                 gitOpsDefaultMode: "commit",
+                gitDiffBaselineDefault: { kind: "head" },
+                gitDiffRenderModeDefault: "stacked",
                 projectDeletionMode: "pi-only",
                 useAgentsSkillsPaths: false,
                 piTuiTakeover: false,
@@ -230,10 +429,12 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 composerProjectId={composerProjectId}
                 currentProjectName={currentProjectName}
                 diffBaseline={diffBaseline}
+                diffRenderMode={diffRenderMode}
                 terminalDrawerVisible={terminalDrawerVisible}
                 terminalSessionPath={terminalSessionPath}
                 workspaceContentClass={workspaceContentClass}
                 onSetDiffBaseline={handleSetDiffBaseline}
+                onSetDiffRenderMode={handleSetDiffRenderMode}
               />
             </div>
 

--- a/src/app/app-shell/AppShellWorkspace.tsx
+++ b/src/app/app-shell/AppShellWorkspace.tsx
@@ -1,4 +1,4 @@
-import type { ProjectDiffBaseline } from "../desktop/types";
+import type { ProjectDiffBaseline, ProjectDiffRenderMode } from "../desktop/types";
 import { CodeWorkspaceView } from "../features/code/CodeWorkspaceView";
 import { mainPanelClass } from "../ui/classes";
 import { MainView } from "../views/MainView";
@@ -11,10 +11,12 @@ type AppShellWorkspaceProps = {
   composerProjectId: string;
   currentProjectName: string;
   diffBaseline: ProjectDiffBaseline;
+  diffRenderMode: ProjectDiffRenderMode;
   terminalDrawerVisible: boolean;
   terminalSessionPath: string | null;
   workspaceContentClass: string;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
+  onSetDiffRenderMode: (renderMode: ProjectDiffRenderMode) => void;
 };
 
 export function AppShellWorkspace({
@@ -24,10 +26,12 @@ export function AppShellWorkspace({
   composerProjectId,
   currentProjectName,
   diffBaseline,
+  diffRenderMode,
   terminalDrawerVisible,
   terminalSessionPath,
   workspaceContentClass,
   onSetDiffBaseline,
+  onSetDiffRenderMode,
 }: AppShellWorkspaceProps) {
   const { state } = controller;
 
@@ -49,10 +53,12 @@ export function AppShellWorkspace({
       composerProjectId={composerProjectId}
       currentProjectName={currentProjectName}
       diffBaseline={diffBaseline}
+      diffRenderMode={diffRenderMode}
       terminalDrawerVisible={terminalDrawerVisible}
       terminalSessionPath={terminalSessionPath}
       workspaceContentClass={workspaceContentClass}
       onSetDiffBaseline={onSetDiffBaseline}
+      onSetDiffRenderMode={onSetDiffRenderMode}
     />
   );
 }

--- a/src/app/app-shell/controller-action-helpers.ts
+++ b/src/app/app-shell/controller-action-helpers.ts
@@ -21,7 +21,8 @@ export function buildContextualActionPayload({
     action === "composer.stop" ||
     action === "composer.thinking" ||
     action === "workspace.commit" ||
-    action === "workspace.commit-options"
+    action === "workspace.commit-options" ||
+    action === "workspace.diff-preferences"
     ? {
         projectId: composerProjectId,
         sessionPath:

--- a/src/app/app-shell/controller-optimistic-updates.ts
+++ b/src/app/app-shell/controller-optimistic-updates.ts
@@ -1,6 +1,11 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { DesktopAction } from "../desktop/actions";
-import type { ComposerThinkingLevel, PiSettings, ShellState } from "../desktop/types";
+import type {
+  ComposerThinkingLevel,
+  PiSettings,
+  ProjectDiffDefaultBaseline,
+  ShellState,
+} from "../desktop/types";
 import { desktopQueryKeys } from "../query/desktop-query";
 import {
   type ActionPayload,
@@ -32,6 +37,8 @@ export function getOptimisticallyUpdatedShellState(
     payload.key !== "preferredProjectLocation" &&
     payload.key !== "initializeGitOnProjectCreate" &&
     payload.key !== "gitOpsDefaultMode" &&
+    payload.key !== "gitDiffBaselineDefault" &&
+    payload.key !== "gitDiffRenderModeDefault" &&
     payload.key !== "projectDeletionMode" &&
     payload.key !== "useAgentsSkillsPaths" &&
     payload.key !== "piTuiTakeover"
@@ -142,6 +149,26 @@ export function getOptimisticallyUpdatedShellState(
       ? payload.value
       : currentState.appSettings.gitOpsDefaultMode;
 
+  const nextGitDiffBaselineDefault =
+    payload.key === "gitDiffBaselineDefault" && payload.value && typeof payload.value === "object"
+      ? (() => {
+          const baseline = payload.value as { kind?: unknown };
+          return baseline.kind === "head" ||
+            baseline.kind === "previous" ||
+            baseline.kind === "yesterday" ||
+            baseline.kind === "main-branch" ||
+            baseline.kind === "dev-branch"
+            ? ({ kind: baseline.kind } as ProjectDiffDefaultBaseline)
+            : currentState.appSettings.gitDiffBaselineDefault;
+        })()
+      : currentState.appSettings.gitDiffBaselineDefault;
+
+  const nextGitDiffRenderModeDefault =
+    payload.key === "gitDiffRenderModeDefault" &&
+    (payload.value === "stacked" || payload.value === "split")
+      ? payload.value
+      : currentState.appSettings.gitDiffRenderModeDefault;
+
   const nextUseAgentsSkillsPaths =
     payload.key === "useAgentsSkillsPaths" && typeof payload.value === "boolean"
       ? payload.value
@@ -169,6 +196,8 @@ export function getOptimisticallyUpdatedShellState(
       preferredProjectLocation: nextPreferredProjectLocation,
       initializeGitOnProjectCreate: nextInitializeGitOnProjectCreate,
       gitOpsDefaultMode: nextGitOpsDefaultMode,
+      gitDiffBaselineDefault: nextGitDiffBaselineDefault,
+      gitDiffRenderModeDefault: nextGitDiffRenderModeDefault,
       projectDeletionMode: nextProjectDeletionMode,
       useAgentsSkillsPaths: nextUseAgentsSkillsPaths,
       piTuiTakeover: nextPiTuiTakeover,

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -5,7 +5,10 @@ import type {
   ArchivedThread,
   ComposerState,
   DesktopActionResult,
+  ProjectDiffBaseline,
+  ProjectDiffRenderMode,
   ProjectGitState,
+  ThreadData,
 } from "../desktop/types";
 import { desktopQueryKeys } from "../query/desktop-query";
 import type { WorkspaceAction, WorkspaceState } from "../state/workspace";
@@ -47,6 +50,7 @@ type RunPostDesktopActionEffectsInput = {
   refreshShellState: () => Promise<unknown>;
   setArchivedThreads: (threads: ArchivedThread[]) => void;
   setComposerState: (state: ComposerState | null) => void;
+  setLiveThreadData: (updater: (state: ThreadData | null) => ThreadData | null) => void;
   setProjectGitState: (state: ProjectGitState | null) => void;
   queryClient: QueryClient;
 };
@@ -65,6 +69,7 @@ export async function runPostDesktopActionEffects({
   refreshShellState,
   setArchivedThreads,
   setComposerState,
+  setLiveThreadData,
   setProjectGitState,
   queryClient,
 }: RunPostDesktopActionEffectsInput) {
@@ -293,6 +298,52 @@ export async function runPostDesktopActionEffects({
     }
 
     await refreshShellState();
+  }
+
+  if (action === "workspace.diff-preferences" && !hasActionError(actionResult)) {
+    const sessionPath =
+      typeof contextualPayload.sessionPath === "string" ? contextualPayload.sessionPath : null;
+    if (sessionPath) {
+      const hasBaseline = "diffBaseline" in contextualPayload;
+      const hasRenderMode = "diffRenderMode" in contextualPayload;
+      const nextBaseline = (contextualPayload.diffBaseline ?? null) as ProjectDiffBaseline | null;
+      const nextRenderMode = (contextualPayload.diffRenderMode ??
+        null) as ProjectDiffRenderMode | null;
+      queryClient.setQueryData(desktopQueryKeys.thread(sessionPath), (current: unknown) => {
+        const currentThread = current as ThreadData | null | undefined;
+        if (!currentThread) {
+          return currentThread;
+        }
+
+        return {
+          ...currentThread,
+          diffPreferences: {
+            baseline: hasBaseline
+              ? nextBaseline
+              : (currentThread.diffPreferences?.baseline ?? null),
+            renderMode: hasRenderMode
+              ? nextRenderMode
+              : (currentThread.diffPreferences?.renderMode ?? null),
+          },
+        };
+      });
+      setLiveThreadData((current) =>
+        current?.sessionPath === sessionPath
+          ? {
+              ...current,
+              diffPreferences: {
+                baseline: hasBaseline ? nextBaseline : (current.diffPreferences?.baseline ?? null),
+                renderMode: hasRenderMode
+                  ? nextRenderMode
+                  : (current.diffPreferences?.renderMode ?? null),
+              },
+            }
+          : current,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: desktopQueryKeys.threadPrefix(sessionPath),
+      });
+    }
   }
 
   if (action === "workspace.commit") {

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -118,6 +118,7 @@ export function useAppShellController() {
     selectedSessionPath: state.selectedSessionPath,
     setArchivedThreads,
     setComposerState,
+    setLiveThreadData,
     setProjectGitState,
     showToast,
     workspaceState: state,

--- a/src/app/app-shell/useDesktopActionHandlers.ts
+++ b/src/app/app-shell/useDesktopActionHandlers.ts
@@ -9,6 +9,7 @@ import type {
   DesktopActionInvoker,
   DesktopActionResult,
   ProjectGitState,
+  ThreadData,
 } from "../desktop/types";
 import type { WorkspaceAction, WorkspaceState } from "../state/workspace";
 import type { View } from "../types";
@@ -40,6 +41,7 @@ type UseDesktopActionHandlersArgs = {
   selectedSessionPath: string | null;
   setArchivedThreads: Dispatch<SetStateAction<ArchivedThread[]>>;
   setComposerState: Dispatch<SetStateAction<ComposerState | null>>;
+  setLiveThreadData: Dispatch<SetStateAction<ThreadData | null>>;
   setProjectGitState: Dispatch<SetStateAction<ProjectGitState | null>>;
   showToast: (message: string) => void;
   workspaceState: WorkspaceState;
@@ -64,7 +66,8 @@ function shouldShowGlobalActionError(action: DesktopAction) {
     action === "composer.send" ||
     action === "composer.stop" ||
     action === "workspace.commit" ||
-    action === "workspace.commit-options"
+    action === "workspace.commit-options" ||
+    action === "workspace.diff-preferences"
   );
 }
 
@@ -81,6 +84,7 @@ export function useDesktopActionHandlers({
   selectedSessionPath,
   setArchivedThreads,
   setComposerState,
+  setLiveThreadData,
   setProjectGitState,
   showToast,
   workspaceState,
@@ -118,6 +122,7 @@ export function useDesktopActionHandlers({
         refreshShellState,
         setArchivedThreads,
         setComposerState,
+        setLiveThreadData,
         setProjectGitState,
         queryClient,
       });
@@ -142,6 +147,7 @@ export function useDesktopActionHandlers({
       selectedSessionPath,
       setArchivedThreads,
       setComposerState,
+      setLiveThreadData,
       setProjectGitState,
       showToast,
       workspaceState,

--- a/src/app/app-shell/useDesktopEventSync.ts
+++ b/src/app/app-shell/useDesktopEventSync.ts
@@ -104,7 +104,22 @@ export function useDesktopEventSync({
         return;
       }
 
-      queryClient.setQueryData(desktopQueryKeys.thread(event.sessionPath), event.thread);
+      let threadWithPreferences = event.thread;
+      let hadCachedThread = false;
+      queryClient.setQueryData(desktopQueryKeys.thread(event.sessionPath), (current: unknown) => {
+        const currentThread = current as ThreadData | null | undefined;
+        hadCachedThread = Boolean(currentThread);
+        threadWithPreferences = {
+          ...event.thread,
+          diffPreferences: event.thread.diffPreferences ?? currentThread?.diffPreferences,
+        };
+        return threadWithPreferences;
+      });
+      if (!event.thread.diffPreferences && !hadCachedThread) {
+        void queryClient.invalidateQueries({
+          queryKey: desktopQueryKeys.threadPrefix(event.sessionPath),
+        });
+      }
 
       const isVisibleThreadUpdate = event.sessionPath === visibleSessionPath;
       const isCompactionThreadUpdate =
@@ -112,7 +127,10 @@ export function useDesktopEventSync({
 
       setLiveThreadData((current) =>
         isVisibleThreadUpdate || current?.sessionPath === event.sessionPath
-          ? event.thread
+          ? {
+              ...threadWithPreferences,
+              diffPreferences: threadWithPreferences.diffPreferences ?? current?.diffPreferences,
+            }
           : current,
       );
 

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -7,6 +7,7 @@ import type {
   ComposerThinkingLevel,
   DesktopActionInvoker,
   ProjectDiffBaseline,
+  ProjectDiffRenderMode,
   ProjectGitState,
 } from "../../desktop/types";
 import type { View } from "../../types";
@@ -33,13 +34,13 @@ export type ComposerProps = {
   dictationMaxDurationSeconds: number;
   favoriteFolders: string[];
   showDictationButton: boolean;
-  diffRenderMode: "stacked" | "split";
+  diffRenderMode: ProjectDiffRenderMode;
   diffComments: SavedDiffComment[];
   diffCommentCount: number;
   diffCommentsSending: boolean;
   diffCommentError: string | null;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
-  onSetDiffRenderMode: (mode: "stacked" | "split") => void;
+  onSetDiffRenderMode: (mode: ProjectDiffRenderMode) => void;
   onSendDiffComments: (message?: string | null) => void;
   onSelectDiffComment: (filePath: string, commentId: string) => void;
   promptResetKey: number;

--- a/src/app/components/workspace/GitOpsComposerPanel.tsx
+++ b/src/app/components/workspace/GitOpsComposerPanel.tsx
@@ -3,6 +3,7 @@ import type {
   DesktopActionInvoker,
   AppSettings,
   ProjectDiffBaseline,
+  ProjectDiffRenderMode,
   ProjectGitState,
 } from "../../desktop/types";
 import { ComposerGitOpsSurface } from "./composer/ComposerGitOpsSurface";
@@ -17,14 +18,14 @@ type GitOpsComposerPanelProps = {
   showDictationButton: boolean;
   appSettings: AppSettings;
   diffBaseline: ProjectDiffBaseline;
-  diffRenderMode: "stacked" | "split";
+  diffRenderMode: ProjectDiffRenderMode;
   diffComments: SavedDiffComment[];
   diffCommentCount: number;
   diffCommentsSending: boolean;
   diffCommentError: string | null;
   diffLoadError: string | null;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
-  onSetDiffRenderMode: (mode: "stacked" | "split") => void;
+  onSetDiffRenderMode: (mode: ProjectDiffRenderMode) => void;
   onSendDiffComments: (message?: string | null) => void;
   onSelectDiffComment: (filePath: string, commentId: string) => void;
   onAction: DesktopActionInvoker;

--- a/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
@@ -1,6 +1,11 @@
 import { ArrowLeft, Columns2, Rows3, Settings } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
-import type { GitOpsMode, ProjectDiffBaseline, ProjectGitState } from "../../../desktop/types";
+import type {
+  GitOpsMode,
+  ProjectDiffBaseline,
+  ProjectDiffRenderMode,
+  ProjectGitState,
+} from "../../../desktop/types";
 import {
   compactIconButtonClass,
   diffPanelIconButtonClass,
@@ -14,14 +19,14 @@ import { PlainToggle } from "./PlainToggle";
 type ComposerGitOpsFooterProps = {
   composerPanelRef: RefObject<HTMLDivElement | null>;
   diffBaseline: ProjectDiffBaseline;
-  diffRenderMode: "stacked" | "split";
+  diffRenderMode: ProjectDiffRenderMode;
   hasOrigin: boolean;
   includeUnstaged: boolean;
   isGitRepo: boolean;
   onSaveOrigin: () => void;
   onBack: () => void;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
-  onSetDiffRenderMode: (mode: "stacked" | "split") => void;
+  onSetDiffRenderMode: (mode: ProjectDiffRenderMode) => void;
   onSetRepoUrl: (repoUrl: string) => void;
   onToggleIncludeUnstaged: () => void;
   onTogglePreview: () => void;

--- a/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
@@ -3,6 +3,7 @@ import type {
   DesktopActionInvoker,
   AppSettings,
   ProjectDiffBaseline,
+  ProjectDiffRenderMode,
   ProjectGitState,
 } from "../../../desktop/types";
 import { getFeatureStatusDataAttributes } from "../../../features/feature-status";
@@ -27,14 +28,14 @@ type ComposerGitOpsSurfaceProps = {
   showDictationButton: boolean;
   appSettings: AppSettings;
   diffBaseline: ProjectDiffBaseline;
-  diffRenderMode: "stacked" | "split";
+  diffRenderMode: ProjectDiffRenderMode;
   diffComments: SavedDiffComment[];
   diffCommentCount: number;
   diffCommentsSending: boolean;
   diffCommentError: string | null;
   diffLoadError: string | null;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
-  onSetDiffRenderMode: (mode: "stacked" | "split") => void;
+  onSetDiffRenderMode: (mode: ProjectDiffRenderMode) => void;
   onSendDiffComments: (message?: string | null) => void;
   onSelectDiffComment: (filePath: string, commentId: string) => void;
   onAction: DesktopActionInvoker;

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -46,6 +46,8 @@ export type {
   ProjectDeletionMode,
   ProjectCommitEntry,
   ProjectDiffBaseline,
+  ProjectDiffDefaultBaseline,
+  ProjectDiffRenderMode,
   ProjectDiffResolvedBaseline,
   ProjectDiffResult,
   ProjectDiffStatsResult,

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -5,7 +5,7 @@ import { Composer } from "../../components/workspace/Composer";
 import { DiffPanel } from "../../components/workspace/DiffPanel";
 import { GitOpsComposerPanel } from "../../components/workspace/GitOpsComposerPanel";
 import { QueuedPromptsCard } from "../../components/workspace/composer/QueuedPromptsCard";
-import type { ProjectDiffBaseline } from "../../desktop/types";
+import type { ProjectDiffBaseline, ProjectDiffRenderMode } from "../../desktop/types";
 import { useDesktopDiff } from "../../hooks/useDesktopDiff";
 import { mainPanelClass } from "../../ui/classes";
 import { CodeWorkspaceMainView } from "./CodeWorkspaceMainView";
@@ -20,10 +20,12 @@ type CodeWorkspaceViewProps = {
   composerProjectId: string;
   currentProjectName: string;
   diffBaseline: ProjectDiffBaseline;
+  diffRenderMode: ProjectDiffRenderMode;
   terminalDrawerVisible: boolean;
   terminalSessionPath: string | null;
   workspaceContentClass: string;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
+  onSetDiffRenderMode: (renderMode: ProjectDiffRenderMode) => void;
 };
 
 const TERMINAL_DRAWER_OFFSET = "min(28rem, calc(100% - 2.5rem))";
@@ -35,14 +37,15 @@ export function CodeWorkspaceView({
   composerProjectId,
   currentProjectName,
   diffBaseline,
+  diffRenderMode,
   terminalDrawerVisible,
   terminalSessionPath,
   workspaceContentClass,
   onSetDiffBaseline,
+  onSetDiffRenderMode,
 }: CodeWorkspaceViewProps) {
   const [composerPromptResetKey, setComposerPromptResetKey] = useState(0);
   const [composerLayoutVersion, setComposerLayoutVersion] = useState(0);
-  const [diffRenderMode, setDiffRenderMode] = useState<"stacked" | "split">("stacked");
   const footerRef = useRef<HTMLElement>(null);
   const mainViewRef = useRef<HTMLElement>(null);
   const {
@@ -147,6 +150,8 @@ export function CodeWorkspaceView({
                     preferredProjectLocation: null,
                     initializeGitOnProjectCreate: false,
                     gitOpsDefaultMode: "commit",
+                    gitDiffBaselineDefault: { kind: "head" },
+                    gitDiffRenderModeDefault: "stacked",
                     projectDeletionMode: "pi-only",
                     useAgentsSkillsPaths: false,
                     piTuiTakeover: false,
@@ -217,6 +222,8 @@ export function CodeWorkspaceView({
                         preferredProjectLocation: null,
                         initializeGitOnProjectCreate: false,
                         gitOpsDefaultMode: "commit",
+                        gitDiffBaselineDefault: { kind: "head" },
+                        gitDiffRenderModeDefault: "stacked",
                         projectDeletionMode: "pi-only",
                         useAgentsSkillsPaths: false,
                         piTuiTakeover: false,
@@ -230,7 +237,7 @@ export function CodeWorkspaceView({
                     diffCommentError={diffCommentError}
                     diffLoadError={diffLoadError}
                     onSetDiffBaseline={onSetDiffBaseline}
-                    onSetDiffRenderMode={setDiffRenderMode}
+                    onSetDiffRenderMode={onSetDiffRenderMode}
                     onSendDiffComments={(message) => {
                       void handleSendDiffComments(message);
                     }}
@@ -288,7 +295,7 @@ export function CodeWorkspaceView({
                       diffCommentsSending={diffCommentsSending}
                       diffCommentError={diffCommentError}
                       onSetDiffBaseline={onSetDiffBaseline}
-                      onSetDiffRenderMode={setDiffRenderMode}
+                      onSetDiffRenderMode={onSetDiffRenderMode}
                       onSendDiffComments={(message) => {
                         void handleSendDiffComments(message);
                       }}

--- a/src/app/views/settings/settingsDescriptors.tsx
+++ b/src/app/views/settings/settingsDescriptors.tsx
@@ -612,6 +612,72 @@ export function buildSettingsDescriptors({
       ),
     },
     {
+      id: "projects.git-diff-baseline-default",
+      category: "projects",
+      title: "Diff comparison default",
+      description: "Default baseline for the files and lines changed summary.",
+      keywords: "git diff baseline comparison files lines default",
+      render: () => (
+        <div className="grid grid-cols-3 gap-1 rounded-2xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)] xl:grid-cols-5">
+          {[
+            [{ kind: "head" }, "Last"],
+            [{ kind: "previous" }, "Prev"],
+            [{ kind: "dev-branch" }, "Dev"],
+            [{ kind: "main-branch" }, "Main"],
+            [{ kind: "yesterday" }, "Yesterday"],
+          ].map(([value, label]) => {
+            const baseline = value as AppSettings["gitDiffBaselineDefault"];
+            return (
+              <button
+                key={baseline.kind}
+                type="button"
+                className={cn(
+                  "rounded-xl px-3 py-1 transition-colors active:scale-[0.96]",
+                  appSettings.gitDiffBaselineDefault.kind === baseline.kind &&
+                    "bg-[rgba(255,255,255,0.18)] text-[color:var(--text)] shadow-[inset_0_0_0_1px_rgba(183,186,245,0.5)]",
+                )}
+                onClick={() => controller.setGitDiffBaselineDefault(baseline)}
+              >
+                {label as string}
+              </button>
+            );
+          })}
+        </div>
+      ),
+    },
+    {
+      id: "projects.git-diff-render-default",
+      category: "projects",
+      title: "Diff view default",
+      description: "Default layout for the GitOps diff panel.",
+      keywords: "git diff layout stacked split default",
+      render: () => (
+        <div className="grid grid-cols-2 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)]">
+          {[
+            ["stacked", "Unified"],
+            ["split", "Split"],
+          ].map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              className={cn(
+                "rounded-full px-3 py-1 transition-colors active:scale-[0.96]",
+                appSettings.gitDiffRenderModeDefault === value &&
+                  "bg-[rgba(255,255,255,0.18)] text-[color:var(--text)] shadow-[inset_0_0_0_1px_rgba(183,186,245,0.5)]",
+              )}
+              onClick={() =>
+                controller.setGitDiffRenderModeDefault(
+                  value as AppSettings["gitDiffRenderModeDefault"],
+                )
+              }
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      ),
+    },
+    {
       id: "projects.deletion-mode",
       category: "projects",
       title: "Project deletion cleanup",

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -234,6 +234,16 @@ export function useSettingsController({
         key: "gitOpsDefaultMode",
         value,
       }),
+    setGitDiffBaselineDefault: (value: AppSettings["gitDiffBaselineDefault"]) =>
+      void onAction("settings.update", {
+        key: "gitDiffBaselineDefault",
+        value,
+      }),
+    setGitDiffRenderModeDefault: (value: AppSettings["gitDiffRenderModeDefault"]) =>
+      void onAction("settings.update", {
+        key: "gitDiffRenderModeDefault",
+        value,
+      }),
     updatePiSetting: <Key extends keyof PiSettings>(key: Key, value: PiSettings[Key]) =>
       void onAction("pi-settings.update", {
         piSettingsKey: key,

--- a/src/test/controller-post-action-effects.test.ts
+++ b/src/test/controller-post-action-effects.test.ts
@@ -29,6 +29,8 @@ function buildShellState(): ShellState {
       preferredProjectLocation: null,
       initializeGitOnProjectCreate: false,
       gitOpsDefaultMode: "commit",
+      gitDiffBaselineDefault: { kind: "head" },
+      gitDiffRenderModeDefault: "stacked",
       projectDeletionMode: "pi-only",
       useAgentsSkillsPaths: false,
       piTuiTakeover: false,
@@ -130,6 +132,20 @@ describe("controller post action effects", () => {
         value: "commit-push",
       }),
     ).toMatchObject({ appSettings: { gitOpsDefaultMode: "commit-push" } });
+
+    expect(
+      getOptimisticallyUpdatedShellState(state, {
+        key: "gitDiffBaselineDefault",
+        value: { kind: "previous" },
+      }),
+    ).toMatchObject({ appSettings: { gitDiffBaselineDefault: { kind: "previous" } } });
+
+    expect(
+      getOptimisticallyUpdatedShellState(state, {
+        key: "gitDiffRenderModeDefault",
+        value: "split",
+      }),
+    ).toMatchObject({ appSettings: { gitDiffRenderModeDefault: "split" } });
 
     expect(
       getOptimisticallyUpdatedShellState(state, {


### PR DESCRIPTION
## Summary
- Add global Git diff defaults for comparison baseline and diff render mode.
- Persist per-session diff baseline/render-mode overrides across app restarts.
- Share the same persisted preferences across normal composer, GitOps composer, and Pi TUI takeover mini composer.
- Keep live thread updates/cache refreshes from dropping saved diff preferences.

## Validation
- pre-commit hooks passed: lint, typecheck, vitest
- tests: 32 files / 142 tests passed