### PR TITLE
Polish composer popout controls

### DIFF
--- a/src/app/components/common/Tooltip.tsx
+++ b/src/app/components/common/Tooltip.tsx
@@ -72,7 +72,7 @@ export function Tooltip({
   return (
     <span
       ref={anchorRef}
-      className={cn("relative inline-flex min-w-0", className)}
+      className={cn("tooltip-anchor", className)}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
       onFocus={() => setOpen(true)}
@@ -86,18 +86,10 @@ export function Tooltip({
               id={tooltipId}
               role="tooltip"
               data-open={open ? "true" : "false"}
+              data-placement={placement}
+              data-ready={positionReady ? "true" : "false"}
               style={{ left: `${position.left}px`, top: `${position.top}px` }}
-              className={cn(
-                "pointer-events-none fixed z-[120] w-max max-w-[360px] rounded-[10px] border border-[color:var(--border-strong)] bg-[rgba(45,48,64,0.98)] px-2.5 py-1.5 text-[11.5px] leading-4 text-[color:var(--text)] shadow-[0_12px_30px_rgba(0,0,0,0.24)] whitespace-normal break-all transition-[opacity,transform] duration-150 ease-out",
-                placement === "right" ? "-translate-y-1/2" : "-translate-x-1/2 -translate-y-full",
-                open && positionReady && placement === "right" && "opacity-100 translate-x-[2px]",
-                open && positionReady && placement === "top" && "opacity-100 translate-y-[-2px]",
-                (!open || !positionReady) &&
-                  placement === "right" &&
-                  "opacity-0 translate-x-[-4px]",
-                (!open || !positionReady) && placement === "top" && "opacity-0 translate-y-[4px]",
-                contentClassName,
-              )}
+              className={cn("tooltip-content", contentClassName)}
             >
               {content}
             </span>,

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -65,18 +65,12 @@ export function Composer(props: ComposerProps) {
   const composerPanelRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div
-      ref={composerPanelRef}
-      className="grid gap-0 overflow-visible rounded-[20px] border border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
-      aria-label="Composer panel"
-    >
-      <ComposerPromptSurface
-        {...props}
-        composerPanelRef={composerPanelRef}
-        mainViewRef={props.mainViewRef}
-        workspaceFooterRef={props.workspaceFooterRef}
-        onOpenGitOps={props.onOpenGitOpsView}
-      />
-    </div>
+    <ComposerPromptSurface
+      {...props}
+      composerPanelRef={composerPanelRef}
+      mainViewRef={props.mainViewRef}
+      workspaceFooterRef={props.workspaceFooterRef}
+      onOpenGitOps={props.onOpenGitOpsView}
+    />
   );
 }

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -5,11 +5,17 @@ import {
   type FeatureStatusId,
   getFeatureStatusDataAttributes,
 } from "../../features/feature-status";
-import { compactCardClass, compactIconButtonClass } from "../../ui/classes";
+import { compactIconButtonClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
 import { HowcodeLogoMark } from "../common/HowcodeLogoMark";
 import { ToolbarButton } from "../common/ToolbarButton";
 import { ComposerDiffBaselineSelector } from "./composer/ComposerDiffBaselineSelector";
+import {
+  WorkspaceBranchChip,
+  workspaceFooterRowClass,
+  workspaceFooterTextClass,
+  workspaceFooterTrailingGroupClass,
+} from "./footer/WorkspaceFooterPrimitives";
 import { getGitOpsEntryButtonClass } from "./composer/git-ops";
 import { TerminalViewport } from "./terminal/TerminalViewport";
 
@@ -67,20 +73,22 @@ export const TerminalPanel = memo(function TerminalPanel({
         />
         <div className="relative z-[80] overflow-visible rounded-b-[20px] border-x border-b border-[color:var(--border)] bg-[rgba(39,42,57,0.94)] shadow-[var(--shadow)]">
           <div className="h-px bg-[rgba(169,178,215,0.07)]" />
-          <div className="flex items-center gap-1.5 rounded-b-[20px] px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+          <div className={cn(workspaceFooterRowClass, "rounded-b-[20px]")}>
             <ToolbarButton
               label="Desktop"
               tooltip="Howcode Desktop"
               icon={<HowcodeLogoMark className="h-[14px] w-[14px]" />}
+              className={workspaceFooterTextClass}
               onClick={onClose}
             />
             <ToolbarButton
               label="Terminal"
               tooltip="Shell terminal"
               icon={<SquareTerminal size={14} />}
+              className={workspaceFooterTextClass}
               onClick={onOpenDrawerTerminal}
             />
-            <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+            <div className={workspaceFooterTrailingGroupClass}>
               {projectGitState?.isGitRepo && diffBaseline && onSetDiffBaseline ? (
                 <ComposerDiffBaselineSelector
                   composerPanelRef={panelRef}
@@ -91,15 +99,7 @@ export const TerminalPanel = memo(function TerminalPanel({
                 />
               ) : null}
               {projectGitState?.isGitRepo ? (
-                <div
-                  className={cn(
-                    compactCardClass,
-                    "inline-flex max-w-[12rem] px-2.5 py-1 text-[12px] text-[color:var(--muted)]",
-                  )}
-                  title={projectGitState.branch ?? "Detached"}
-                >
-                  <span className="truncate">{projectGitState.branch ?? "Detached"}</span>
-                </div>
+                <WorkspaceBranchChip branch={projectGitState.branch} />
               ) : null}
               <button
                 type="button"

--- a/src/app/components/workspace/composer/AGENTS.md
+++ b/src/app/components/workspace/composer/AGENTS.md
@@ -1,0 +1,10 @@
+# Composer workspace guidance
+
+- Footer visual changes usually span multiple hosts:
+  - `ComposerFooter.tsx` for the normal prompt composer.
+  - `ComposerGitOpsFooter.tsx` for git-ops composer mode.
+  - `../TerminalPanel.tsx` for Pi-TUI takeover footer chrome.
+  - `ComposerDiffBaselineSelector.tsx` for the shared diff baseline/stat control.
+- Shared footer row/chip/text primitives live in `../footer/WorkspaceFooterPrimitives.tsx`; do not recreate local composer-only copies.
+- The `.composer-footer-text` CSS rule lives in `src/styles/primitives.css`; use it when text must match across toolbar buttons, branch chips, and diff stats.
+- Do not replace shared tooltip styling with native `title`; use `Tooltip` so placement and hover behavior remain consistent.

--- a/src/app/components/workspace/composer/ComposerDictationControls.tsx
+++ b/src/app/components/workspace/composer/ComposerDictationControls.tsx
@@ -12,6 +12,7 @@ type ComposerDictationControlsProps = {
   dictationMissingModel: boolean;
   dictationSupported: boolean;
   dictationTranscribing: boolean;
+  placement?: "inline" | "trailing";
   onAction: DesktopActionInvoker;
   onOpenSettingsView: () => void;
   showDictationButton: boolean;
@@ -23,6 +24,7 @@ export function ComposerDictationControls({
   dictationMissingModel,
   dictationSupported,
   dictationTranscribing,
+  placement = "inline",
   onAction,
   onOpenSettingsView,
   showDictationButton,
@@ -46,7 +48,7 @@ export function ComposerDictationControls({
   }, [dictationMissingModel, showDictationButton]);
 
   return showDictationButton ? (
-    <div className="relative">
+    <div className={cn("relative", placement === "trailing" && "h-6 w-6 shrink-0")}>
       {dictationPromptPresent ? (
         <div
           ref={dictationPromptRef}
@@ -109,13 +111,15 @@ export function ComposerDictationControls({
           setDictationPromptOpen(result === "setup-required");
         }}
         className={cn(
-          iconButtonClass,
+          placement === "trailing"
+            ? "inline-flex h-6 w-6 items-center justify-center rounded-full border border-transparent bg-transparent text-[color:var(--muted-2)] opacity-45 transition-colors hover:bg-[rgba(255,255,255,0.035)] hover:text-[color:var(--muted)] hover:opacity-70"
+            : iconButtonClass,
           dictationActive &&
-            "border-[rgba(255,110,110,0.3)] bg-[rgba(255,94,94,0.12)] text-[#ffd1d1]",
+            "border-[rgba(255,110,110,0.3)] bg-[rgba(255,94,94,0.12)] text-[#ffd1d1] opacity-100",
           dictationTranscribing &&
-            "border-[rgba(183,186,245,0.3)] bg-[rgba(183,186,245,0.12)] text-[color:var(--text)]",
+            "border-[rgba(183,186,245,0.3)] bg-[rgba(183,186,245,0.12)] text-[color:var(--text)] opacity-100",
           dictationPromptOpen &&
-            "border-[rgba(183,186,245,0.24)] bg-[rgba(183,186,245,0.08)] text-[color:var(--text)]",
+            "border-[rgba(183,186,245,0.24)] bg-[rgba(183,186,245,0.08)] text-[color:var(--text)] opacity-100",
         )}
         aria-label={
           dictationActive

--- a/src/app/components/workspace/composer/ComposerDiffBaselineSelector.tsx
+++ b/src/app/components/workspace/composer/ComposerDiffBaselineSelector.tsx
@@ -249,7 +249,7 @@ export function ComposerDiffBaselineSelector({
         aria-expanded={open}
         aria-controls={open ? panelId : undefined}
         className={cn(
-          "group relative inline-flex h-7 min-w-[9.5rem] items-center justify-end overflow-hidden rounded-lg px-2 text-right text-[12px] leading-none text-[color:var(--muted)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]",
+          "composer-footer-text group relative inline-flex h-7 min-w-[9.5rem] items-center justify-end overflow-hidden rounded-lg px-2 text-right text-[color:var(--muted)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]",
           open && "text-[color:var(--text)]",
         )}
         onClick={() => setOpen((current) => !current)}
@@ -282,7 +282,7 @@ export function ComposerDiffBaselineSelector({
         </span>
         <span
           className={cn(
-            "pointer-events-none absolute inset-0 flex h-full items-center justify-end truncate px-2 text-[12px] leading-none text-[color:var(--text)] transition-opacity duration-150 ease-out",
+            "composer-footer-text pointer-events-none absolute inset-0 flex h-full items-center justify-end truncate px-2 text-[color:var(--text)] transition-opacity duration-150 ease-out",
             open ? "opacity-100" : "opacity-0 group-hover:opacity-100",
           )}
         >

--- a/src/app/components/workspace/composer/ComposerFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerFooter.tsx
@@ -7,12 +7,18 @@ import type {
   ProjectDiffBaseline,
   ProjectGitState,
 } from "../../../desktop/types";
-import { compactCardClass, compactIconButtonClass } from "../../../ui/classes";
+import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { PiLogoMark } from "../../common/PiLogoMark";
 import { ToolbarButton } from "../../common/ToolbarButton";
 import { ComposerContextMeter } from "./ComposerContextMeter";
 import { ComposerDiffBaselineSelector } from "./ComposerDiffBaselineSelector";
+import {
+  WorkspaceBranchChip,
+  workspaceFooterRowClass,
+  workspaceFooterTextClass,
+  workspaceFooterTrailingGroupClass,
+} from "../footer/WorkspaceFooterPrimitives";
 import { ComposerModelPopover } from "./ComposerModelPopover";
 import { getGitOpsEntryButtonClass } from "./git-ops";
 
@@ -76,18 +82,22 @@ export function ComposerFooter({
       : "clean";
 
   return (
-    <div className="flex items-center gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+    <div className={workspaceFooterRowClass}>
       <ToolbarButton
         label="TUI"
         tooltip="Pi-TUI takeover"
         icon={<PiLogoMark className="h-[14px] w-[14px]" />}
+        className={workspaceFooterTextClass}
         onClick={onOpenTakeoverTerminal}
       />
       <ToolbarButton
         label="Terminal"
         icon={<Terminal size={14} />}
         onClick={onToggleTerminal}
-        className={cn(terminalVisible && "bg-[rgba(255,255,255,0.04)] text-[color:var(--text)]")}
+        className={cn(
+          workspaceFooterTextClass,
+          terminalVisible && "bg-[rgba(255,255,255,0.04)] text-[color:var(--text)]",
+        )}
       />
       <div className="relative inline-flex h-7 items-center">
         <ToolbarButton
@@ -95,7 +105,7 @@ export function ComposerFooter({
           label="Agent"
           tooltip="Model settings"
           icon={<Bot size={14} />}
-          className="pr-8"
+          className={cn(workspaceFooterTextClass, "pr-8")}
           onClick={() => onSetOpenMenu((current) => (current === "model" ? null : "model"))}
           aria-haspopup="menu"
           aria-expanded={modelMenuOpen}
@@ -122,7 +132,7 @@ export function ComposerFooter({
           />
         ) : null}
       </div>
-      <div className="ml-auto flex min-h-7 items-center gap-1.5 max-md:flex-wrap">
+      <div className={workspaceFooterTrailingGroupClass}>
         {projectGitState?.isGitRepo ? (
           <ComposerDiffBaselineSelector
             composerPanelRef={composerPanelRef}
@@ -133,15 +143,7 @@ export function ComposerFooter({
           />
         ) : null}
         {projectGitState?.isGitRepo ? (
-          <div
-            className={cn(
-              compactCardClass,
-              "inline-flex h-7 max-w-[12rem] items-center px-2.5 py-0 text-[12px] leading-none text-[color:var(--muted)]",
-            )}
-            title={projectGitState.branch ?? "Detached"}
-          >
-            <span className="truncate">{projectGitState.branch ?? "Detached"}</span>
-          </div>
+          <WorkspaceBranchChip branch={projectGitState.branch} />
         ) : null}
         <button
           type="button"

--- a/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsFooter.tsx
@@ -14,6 +14,10 @@ import {
 } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { ComposerDiffBaselineSelector } from "./ComposerDiffBaselineSelector";
+import {
+  workspaceFooterRowClass,
+  workspaceFooterTrailingGroupClass,
+} from "../footer/WorkspaceFooterPrimitives";
 import { PlainToggle } from "./PlainToggle";
 
 type ComposerGitOpsFooterProps = {
@@ -114,7 +118,7 @@ export function ComposerGitOpsFooter({
   }, [optionsOpen]);
 
   return (
-    <div className="flex items-center gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
+    <div className={workspaceFooterRowClass}>
       {isGitRepo ? (
         <div className="inline-flex items-center gap-1.5">
           <div ref={optionsRef} className="relative inline-flex">
@@ -222,7 +226,7 @@ export function ComposerGitOpsFooter({
         </div>
       ) : null}
 
-      <div className="ml-auto flex items-center gap-2 max-md:flex-wrap">
+      <div className={workspaceFooterTrailingGroupClass}>
         {isGitRepo ? (
           <ComposerDiffBaselineSelector
             composerPanelRef={composerPanelRef}

--- a/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
@@ -104,7 +104,7 @@ export function ComposerPromptInputPanel({
           onToggleFile={togglePendingPickerAttachment}
         />
       ) : null}
-      <div className="grid content-end px-4 py-3">
+      <div className="grid content-end px-4 pt-4 pb-1">
         <div className="flex items-end justify-between gap-2">
           <div className="flex min-w-0 flex-1 items-end gap-2">
             <div className="min-w-0 flex-1">

--- a/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Paperclip, Send, Square, X } from "lucide-react";
+import { Loader2, Send, Square } from "lucide-react";
 import type { ClipboardEvent, RefObject } from "react";
 import { getPathForFileQuery } from "../../../query/desktop-query";
 import { compactIconButtonClass } from "../../../ui/classes";
@@ -19,9 +19,7 @@ import type { ComposerAttachment, DesktopActionInvoker } from "../../../desktop/
 
 type ComposerPromptInputPanelProps = {
   attachments: ComposerAttachment[];
-  attachmentButtonLabel: string;
   canSend: boolean;
-  clearAttachments: () => void;
   clearError: () => void;
   dictationActive: boolean;
   dictationMissingModel: boolean;
@@ -32,7 +30,6 @@ type ComposerPromptInputPanelProps = {
   extensionRunning: boolean;
   favoriteFolders: string[];
   isSending: boolean;
-  pickerButtonRef: RefObject<HTMLButtonElement | null>;
   pickerLoading: boolean;
   pickerOpen: boolean;
   pickerPanelRef: RefObject<HTMLDivElement | null>;
@@ -55,7 +52,6 @@ type ComposerPromptInputPanelProps = {
   onOpenSettingsView: () => void;
   openPickerDirectory: Parameters<typeof ComposerFilePicker>[0]["onOpenDirectory"];
   openPickerRoot: Parameters<typeof ComposerFilePicker>[0]["onOpenRoot"];
-  pickAttachments: () => void;
   removeAttachment: (path: string) => void;
   setDraft: (value: string) => void;
   stop: () => Promise<void>;
@@ -65,9 +61,7 @@ type ComposerPromptInputPanelProps = {
 
 export function ComposerPromptInputPanel({
   attachments,
-  attachmentButtonLabel,
   canSend,
-  clearAttachments,
   clearError,
   dictationActive,
   dictationMissingModel,
@@ -78,7 +72,6 @@ export function ComposerPromptInputPanel({
   extensionRunning,
   favoriteFolders,
   isSending,
-  pickerButtonRef,
   pickerLoading,
   pickerOpen,
   pickerPanelRef,
@@ -98,7 +91,6 @@ export function ComposerPromptInputPanel({
   onOpenSettingsView,
   openPickerDirectory,
   openPickerRoot,
-  pickAttachments,
   removeAttachment,
   setDraft,
   stop,
@@ -126,46 +118,6 @@ export function ComposerPromptInputPanel({
       <div className="grid content-end px-4 py-3">
         <div className="flex items-end justify-between gap-2">
           <div className="flex min-w-0 flex-1 items-end gap-2">
-            <div className="inline-flex h-6 shrink-0 items-center gap-1.5">
-              <button
-                ref={pickerButtonRef}
-                type="button"
-                className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md"
-                onClick={() => {
-                  if (slashCommands.open) {
-                    slashCommands.dismiss({ clearDraft: true });
-                  }
-                  pickAttachments();
-                }}
-                aria-label={attachmentButtonLabel}
-                data-tooltip={attachmentButtonLabel}
-              >
-                <span className={cn(compactIconButtonClass, "shrink-0")}>
-                  <Paperclip size={16} />
-                </span>
-
-                {attachments.length > 0 ? (
-                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
-                    {attachments.length}
-                  </span>
-                ) : null}
-              </button>
-
-              {attachments.length > 0 ? (
-                <>
-                  <button
-                    type="button"
-                    className={cn(compactIconButtonClass, "h-5 w-5 shrink-0")}
-                    onClick={clearAttachments}
-                    aria-label="Clear attachments"
-                    data-tooltip="Clear attachments"
-                  >
-                    <X size={12} />
-                  </button>
-                </>
-              ) : null}
-            </div>
-
             <div className="min-w-0 flex-1">
               {slashCommands.open ? (
                 <div

--- a/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
@@ -104,7 +104,7 @@ export function ComposerPromptInputPanel({
           onToggleFile={togglePendingPickerAttachment}
         />
       ) : null}
-      <div className="grid content-end px-4 pt-4 pb-1">
+      <div className="grid content-end pr-4 pl-[1.1rem] pt-4 pb-1">
         <div className="flex items-end justify-between gap-2">
           <div className="flex min-w-0 flex-1 items-end gap-2">
             <div className="min-w-0 flex-1">

--- a/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
@@ -1,7 +1,6 @@
-import { Loader2, Send, Square } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import type { ClipboardEvent, RefObject } from "react";
 import { getPathForFileQuery } from "../../../query/desktop-query";
-import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { ComposerDictationControls } from "./ComposerDictationControls";
 import { ComposerFilePicker } from "./ComposerFilePicker";
@@ -19,7 +18,6 @@ import type { ComposerAttachment, DesktopActionInvoker } from "../../../desktop/
 
 type ComposerPromptInputPanelProps = {
   attachments: ComposerAttachment[];
-  canSend: boolean;
   clearError: () => void;
   dictationActive: boolean;
   dictationMissingModel: boolean;
@@ -29,17 +27,14 @@ type ComposerPromptInputPanelProps = {
   errorMessage: string | null;
   extensionRunning: boolean;
   favoriteFolders: string[];
-  isSending: boolean;
   pickerLoading: boolean;
   pickerOpen: boolean;
   pickerPanelRef: RefObject<HTMLDivElement | null>;
   pickerState: Parameters<typeof ComposerFilePicker>[0]["picker"];
   placeholderText: string;
   projectId: string;
-  sessionPath: string | null;
   slashCommandPanelRef: RefObject<HTMLDivElement | null>;
   slashCommands: ComposerSlashCommands;
-  composerIsStreaming: boolean;
   showDictationButton: boolean;
   attachPickerAttachments: Parameters<typeof ComposerFilePicker>[0]["onAttachAttachments"];
   cancelDictation: () => Promise<void>;
@@ -54,14 +49,12 @@ type ComposerPromptInputPanelProps = {
   openPickerRoot: Parameters<typeof ComposerFilePicker>[0]["onOpenRoot"];
   removeAttachment: (path: string) => void;
   setDraft: (value: string) => void;
-  stop: () => Promise<void>;
   toggleDictation: Parameters<typeof ComposerDictationControls>[0]["toggleDictation"];
   togglePendingPickerAttachment: Parameters<typeof ComposerFilePicker>[0]["onToggleFile"];
 };
 
 export function ComposerPromptInputPanel({
   attachments,
-  canSend,
   clearError,
   dictationActive,
   dictationMissingModel,
@@ -71,17 +64,14 @@ export function ComposerPromptInputPanel({
   errorMessage,
   extensionRunning,
   favoriteFolders,
-  isSending,
   pickerLoading,
   pickerOpen,
   pickerPanelRef,
   pickerState,
   placeholderText,
   projectId,
-  sessionPath,
   slashCommandPanelRef,
   slashCommands,
-  composerIsStreaming,
   showDictationButton,
   attachPickerAttachments,
   cancelDictation,
@@ -93,7 +83,6 @@ export function ComposerPromptInputPanel({
   openPickerRoot,
   removeAttachment,
   setDraft,
-  stop,
   toggleDictation,
   togglePendingPickerAttachment,
 }: ComposerPromptInputPanelProps) {
@@ -230,54 +219,31 @@ export function ComposerPromptInputPanel({
                 placeholderTone={errorMessage ? "error" : "muted"}
                 statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                 reservedLineCount={1}
+                trailingAdornment={
+                  <ComposerDictationControls
+                    dictationActive={dictationActive}
+                    dictationMissingModel={dictationMissingModel}
+                    dictationSupported={dictationSupported}
+                    dictationTranscribing={dictationTranscribing}
+                    placement="trailing"
+                    onAction={onAction}
+                    onOpenSettingsView={onOpenSettingsView}
+                    showDictationButton={showDictationButton}
+                    toggleDictation={toggleDictation}
+                  />
+                }
                 onHeightChange={onLayoutChange}
               />
             </div>
           </div>
 
           <div className="inline-flex h-8 items-center justify-end gap-2">
-            <ComposerDictationControls
-              dictationActive={dictationActive}
-              dictationMissingModel={dictationMissingModel}
-              dictationSupported={dictationSupported}
-              dictationTranscribing={dictationTranscribing}
-              onAction={onAction}
-              onOpenSettingsView={onOpenSettingsView}
-              showDictationButton={showDictationButton}
-              toggleDictation={toggleDictation}
-            />
-            <button
-              type="button"
-              className={cn(
-                compactIconButtonClass,
-                "h-6 w-6 shrink-0 rounded-full bg-[rgba(229,111,111,0.18)] text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.28)] hover:text-[#ffd1d1] disabled:cursor-not-allowed disabled:opacity-45",
-              )}
-              onClick={() => void stop()}
-              disabled={(!composerIsStreaming && !extensionRunning) || isSending || !sessionPath}
-              aria-label="Stop Pi"
-              data-tooltip="Stop Pi"
-            >
-              <Square size={11} fill="currentColor" />
-            </button>
             {extensionRunning ? (
               <div className="inline-flex h-6 items-center gap-1.5 rounded-full border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.045)] px-2.5 text-[12px] text-[color:var(--muted)]">
                 <Loader2 size={12} className="animate-spin" />
                 <span>Pi extension running</span>
               </div>
             ) : null}
-            <button
-              type="button"
-              className={cn(
-                compactIconButtonClass,
-                "h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.46)] text-[color:var(--workspace)] hover:bg-[rgba(146,153,184,0.56)] hover:text-[color:var(--workspace)] disabled:cursor-not-allowed disabled:opacity-45",
-              )}
-              onClick={slashCommands.submit}
-              disabled={!canSend}
-              aria-label="Send"
-              data-tooltip="Send"
-            >
-              <Send size={14} />
-            </button>
           </div>
         </div>
       </div>

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -1,4 +1,4 @@
-import { Paperclip, X } from "lucide-react";
+import { Paperclip, Square, X } from "lucide-react";
 import { type RefObject, useEffect, useRef } from "react";
 import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
@@ -53,7 +53,6 @@ export function ComposerPromptSurface({
   const {
     attachments,
     cancelDictation,
-    canSend,
     clearAttachments,
     clearError,
     draft,
@@ -253,12 +252,13 @@ export function ComposerPromptSurface({
   const placeholderText =
     errorMessage ??
     (activeView === "thread"
-      ? "Ask for follow-up changes"
-      : "Ask Pi anything, @ to add files, / for commands, $ for skills");
+      ? "Hover to type · Enter sends · Shift+Enter for a new line"
+      : "Hover to type · / commands · @ files · Enter sends");
   const attachmentButtonLabel = attachments.length > 0 ? "Manage attachments" : "Add attachment";
+  const canStopComposer = (composerIsStreaming || extensionRunning) && !isSending && !!sessionPath;
 
   return (
-    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-end gap-2 overflow-visible">
+    <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2 overflow-visible">
       <div className="mb-[3.55rem] inline-flex h-8 shrink-0 items-center gap-1.5 text-[color:var(--muted)]">
         <button
           ref={pickerButtonRef}
@@ -309,7 +309,6 @@ export function ComposerPromptSurface({
               still mirrors the git-ops composer shell while attachments live beside it. */}
           <ComposerPromptInputPanel
             attachments={attachments}
-            canSend={canSend}
             clearError={clearError}
             dictationActive={dictationActive}
             dictationMissingModel={dictationMissingModel}
@@ -319,17 +318,14 @@ export function ComposerPromptSurface({
             errorMessage={errorMessage}
             extensionRunning={extensionRunning}
             favoriteFolders={favoriteFolders}
-            isSending={isSending}
             pickerLoading={pickerLoading}
             pickerOpen={pickerOpen}
             pickerPanelRef={pickerPanelRef}
             pickerState={pickerState}
             placeholderText={placeholderText}
             projectId={projectId}
-            sessionPath={sessionPath}
             slashCommandPanelRef={slashCommandPanelRef}
             slashCommands={slashCommands}
-            composerIsStreaming={composerIsStreaming}
             showDictationButton={showDictationButton}
             attachPickerAttachments={attachPickerAttachments}
             cancelDictation={cancelDictation}
@@ -341,7 +337,6 @@ export function ComposerPromptSurface({
             openPickerRoot={openPickerRoot}
             removeAttachment={removeAttachment}
             setDraft={setDraft}
-            stop={stop}
             toggleDictation={toggleDictation}
             togglePendingPickerAttachment={togglePendingPickerAttachment}
           />
@@ -398,6 +393,25 @@ export function ComposerPromptSurface({
           thinkingLevel={thinkingLevel}
           thinkingLevelLabels={thinkingLevelLabels}
         />
+      </div>
+
+      <div className="mb-[3.55rem] inline-flex h-8 shrink-0 items-center justify-end text-[color:var(--muted)]">
+        <button
+          type="button"
+          className={cn(
+            compactIconButtonClass,
+            "h-7 w-7 shrink-0 rounded-full text-[#ffb4b4] hover:bg-[rgba(229,111,111,0.2)] hover:text-[#ffd1d1]",
+            canStopComposer
+              ? "bg-[rgba(229,111,111,0.14)] opacity-80"
+              : "bg-transparent opacity-25 hover:opacity-45",
+          )}
+          onClick={() => void stop()}
+          disabled={!canStopComposer}
+          aria-label="Stop Pi"
+          data-tooltip="Stop Pi"
+        >
+          <Square size={11} fill="currentColor" />
+        </button>
       </div>
     </div>
   );

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -259,42 +259,46 @@ export function ComposerPromptSurface({
 
   return (
     <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2 overflow-visible">
-      <div className="mb-[3.55rem] inline-flex h-8 shrink-0 items-center gap-1.5 text-[color:var(--muted)]">
-        <button
-          ref={pickerButtonRef}
-          type="button"
-          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full"
-          onClick={() => {
-            if (slashCommands.open) {
-              slashCommands.dismiss({ clearDraft: true });
-            }
-            pickAttachments();
-          }}
-          aria-label={attachmentButtonLabel}
-          data-tooltip={attachmentButtonLabel}
-        >
-          <span className={cn(compactIconButtonClass, "h-7 w-7 shrink-0 rounded-full")}>
-            <Paperclip size={15} />
-          </span>
+      <div className="relative mb-[3.55rem] h-8 w-8 shrink-0 text-[color:var(--muted)]">
+        <div className="absolute bottom-0 left-0 flex w-7 flex-col-reverse items-center gap-1">
+          <button
+            ref={pickerButtonRef}
+            type="button"
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+            onClick={() => {
+              if (slashCommands.open) {
+                slashCommands.dismiss({ clearDraft: true });
+              }
+              pickAttachments();
+            }}
+            aria-label={attachmentButtonLabel}
+            data-tooltip={attachmentButtonLabel}
+          >
+            <span className={cn(compactIconButtonClass, "h-7 w-7 shrink-0 rounded-full")}>
+              <Paperclip size={15} />
+            </span>
+          </button>
 
           {attachments.length > 0 ? (
-            <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
-              {attachments.length}
-            </span>
+            <>
+              <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
+                {attachments.length}
+              </span>
+              <button
+                type="button"
+                className={cn(
+                  compactIconButtonClass,
+                  "h-5 w-5 rounded-full opacity-70 hover:opacity-100",
+                )}
+                onClick={clearAttachments}
+                aria-label="Clear attachments"
+                data-tooltip="Clear attachments"
+              >
+                <X size={11} />
+              </button>
+            </>
           ) : null}
-        </button>
-
-        {attachments.length > 0 ? (
-          <button
-            type="button"
-            className={cn(compactIconButtonClass, "h-6 w-6 shrink-0 rounded-full")}
-            onClick={clearAttachments}
-            aria-label="Clear attachments"
-            data-tooltip="Clear attachments"
-          >
-            <X size={12} />
-          </button>
-        ) : null}
+        </div>
       </div>
 
       <div

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -259,7 +259,7 @@ export function ComposerPromptSurface({
 
   return (
     <div className="grid grid-cols-[auto_minmax(0,1fr)] items-end gap-2 overflow-visible">
-      <div className="mb-2.5 inline-flex h-8 shrink-0 items-center gap-1.5 text-[color:var(--muted)]">
+      <div className="mb-[3.55rem] inline-flex h-8 shrink-0 items-center gap-1.5 text-[color:var(--muted)]">
         <button
           ref={pickerButtonRef}
           type="button"

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -1,4 +1,7 @@
+import { Paperclip, X } from "lucide-react";
 import { type RefObject, useEffect, useRef } from "react";
+import { compactIconButtonClass } from "../../../ui/classes";
+import { cn } from "../../../utils/cn";
 import type { ComposerProps } from "../Composer";
 import { ComposerFooter } from "./ComposerFooter";
 import { ComposerPromptInputPanel } from "./ComposerPromptInputPanel";
@@ -255,107 +258,147 @@ export function ComposerPromptSurface({
   const attachmentButtonLabel = attachments.length > 0 ? "Manage attachments" : "Add attachment";
 
   return (
-    <div className="grid gap-0">
-      {/* Let the prompt column size itself to one line by default, then grow upward naturally as
-          the textarea expands. */}
-      <div className="relative">
-        {/* The prompt surface keeps add-attachment, attachment count, prompt text, and trailing
-            controls in one shared block so it still mirrors the git-ops composer shell. */}
-        <ComposerPromptInputPanel
-          attachments={attachments}
-          attachmentButtonLabel={attachmentButtonLabel}
-          canSend={canSend}
-          clearAttachments={clearAttachments}
-          clearError={clearError}
-          dictationActive={dictationActive}
-          dictationMissingModel={dictationMissingModel}
-          dictationSupported={dictationSupported}
-          dictationTranscribing={dictationTranscribing}
-          draft={draft}
-          errorMessage={errorMessage}
-          extensionRunning={extensionRunning}
-          favoriteFolders={favoriteFolders}
-          isSending={isSending}
-          pickerButtonRef={pickerButtonRef}
-          pickerLoading={pickerLoading}
-          pickerOpen={pickerOpen}
-          pickerPanelRef={pickerPanelRef}
-          pickerState={pickerState}
-          placeholderText={placeholderText}
-          projectId={projectId}
-          sessionPath={sessionPath}
-          slashCommandPanelRef={slashCommandPanelRef}
-          slashCommands={slashCommands}
-          composerIsStreaming={composerIsStreaming}
-          showDictationButton={showDictationButton}
-          attachPickerAttachments={attachPickerAttachments}
-          cancelDictation={cancelDictation}
-          handlePaste={handlePaste}
-          onAction={onAction}
-          onLayoutChange={onLayoutChange}
-          onOpenSettingsView={onOpenSettingsView}
-          openPickerDirectory={openPickerDirectory}
-          openPickerRoot={openPickerRoot}
-          pickAttachments={pickAttachments}
-          removeAttachment={removeAttachment}
-          setDraft={setDraft}
-          stop={stop}
-          toggleDictation={toggleDictation}
-          togglePendingPickerAttachment={togglePendingPickerAttachment}
-        />
+    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-end gap-2 overflow-visible">
+      <div className="mb-2.5 inline-flex h-8 shrink-0 items-center gap-1.5 text-[color:var(--muted)]">
+        <button
+          ref={pickerButtonRef}
+          type="button"
+          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full"
+          onClick={() => {
+            if (slashCommands.open) {
+              slashCommands.dismiss({ clearDraft: true });
+            }
+            pickAttachments();
+          }}
+          aria-label={attachmentButtonLabel}
+          data-tooltip={attachmentButtonLabel}
+        >
+          <span className={cn(compactIconButtonClass, "h-7 w-7 shrink-0 rounded-full")}>
+            <Paperclip size={15} />
+          </span>
+
+          {attachments.length > 0 ? (
+            <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
+              {attachments.length}
+            </span>
+          ) : null}
+        </button>
+
+        {attachments.length > 0 ? (
+          <button
+            type="button"
+            className={cn(compactIconButtonClass, "h-6 w-6 shrink-0 rounded-full")}
+            onClick={clearAttachments}
+            aria-label="Clear attachments"
+            data-tooltip="Clear attachments"
+          >
+            <X size={12} />
+          </button>
+        ) : null}
       </div>
 
-      {errorMessage ? (
-        <output className="sr-only" aria-live="polite">
-          {errorMessage}
-        </output>
-      ) : null}
+      <div
+        ref={composerPanelRef}
+        className="grid gap-0 overflow-visible rounded-[20px] border border-[rgba(169,178,215,0.06)] bg-[#272a39] shadow-none"
+        aria-label="Composer panel"
+      >
+        {/* Let the prompt column size itself to one line by default, then grow upward naturally as
+            the textarea expands. */}
+        <div className="relative">
+          {/* The prompt surface keeps prompt text and trailing controls in one shared block so it
+              still mirrors the git-ops composer shell while attachments live beside it. */}
+          <ComposerPromptInputPanel
+            attachments={attachments}
+            canSend={canSend}
+            clearError={clearError}
+            dictationActive={dictationActive}
+            dictationMissingModel={dictationMissingModel}
+            dictationSupported={dictationSupported}
+            dictationTranscribing={dictationTranscribing}
+            draft={draft}
+            errorMessage={errorMessage}
+            extensionRunning={extensionRunning}
+            favoriteFolders={favoriteFolders}
+            isSending={isSending}
+            pickerLoading={pickerLoading}
+            pickerOpen={pickerOpen}
+            pickerPanelRef={pickerPanelRef}
+            pickerState={pickerState}
+            placeholderText={placeholderText}
+            projectId={projectId}
+            sessionPath={sessionPath}
+            slashCommandPanelRef={slashCommandPanelRef}
+            slashCommands={slashCommands}
+            composerIsStreaming={composerIsStreaming}
+            showDictationButton={showDictationButton}
+            attachPickerAttachments={attachPickerAttachments}
+            cancelDictation={cancelDictation}
+            handlePaste={handlePaste}
+            onAction={onAction}
+            onLayoutChange={onLayoutChange}
+            onOpenSettingsView={onOpenSettingsView}
+            openPickerDirectory={openPickerDirectory}
+            openPickerRoot={openPickerRoot}
+            removeAttachment={removeAttachment}
+            setDraft={setDraft}
+            stop={stop}
+            toggleDictation={toggleDictation}
+            togglePendingPickerAttachment={togglePendingPickerAttachment}
+          />
+        </div>
 
-      <div className="h-px bg-[rgba(169,178,215,0.07)]" />
+        {errorMessage ? (
+          <output className="sr-only" aria-live="polite">
+            {errorMessage}
+          </output>
+        ) : null}
 
-      <ComposerFooter
-        availableModels={availableModels}
-        availableThinkingLevels={availableThinkingLevels}
-        composerPanelRef={composerPanelRef}
-        diffBaseline={diffBaseline}
-        model={model}
-        contextUsage={contextUsage}
-        compactDisabled={isStreaming || isCompacting || !sessionPath}
-        isCompacting={isCompacting}
-        modelButtonRef={modelButtonRef}
-        modelMenuOpen={modelMenuOpen}
-        modelMenuRef={modelMenuRef}
-        onOpenGitOps={onOpenGitOps}
-        onOpenTakeoverTerminal={onOpenTakeoverTerminal}
-        onSelectBaseline={onSetDiffBaseline}
-        onSelectModel={(availableModel) => {
-          void runComposerAction(
-            "composer.model",
-            {
-              provider: availableModel.provider,
-              modelId: availableModel.id,
+        <div className="h-px bg-[rgba(169,178,215,0.07)]" />
+
+        <ComposerFooter
+          availableModels={availableModels}
+          availableThinkingLevels={availableThinkingLevels}
+          composerPanelRef={composerPanelRef}
+          diffBaseline={diffBaseline}
+          model={model}
+          contextUsage={contextUsage}
+          compactDisabled={isStreaming || isCompacting || !sessionPath}
+          isCompacting={isCompacting}
+          modelButtonRef={modelButtonRef}
+          modelMenuOpen={modelMenuOpen}
+          modelMenuRef={modelMenuRef}
+          onOpenGitOps={onOpenGitOps}
+          onOpenTakeoverTerminal={onOpenTakeoverTerminal}
+          onSelectBaseline={onSetDiffBaseline}
+          onSelectModel={(availableModel) => {
+            void runComposerAction(
+              "composer.model",
+              {
+                provider: availableModel.provider,
+                modelId: availableModel.id,
+                projectId,
+                sessionPath,
+              },
+              { closeMenu: false },
+            );
+          }}
+          onSelectThinkingLevel={(level) => {
+            void runComposerAction("composer.thinking", {
+              level,
               projectId,
               sessionPath,
-            },
-            { closeMenu: false },
-          );
-        }}
-        onSelectThinkingLevel={(level) => {
-          void runComposerAction("composer.thinking", {
-            level,
-            projectId,
-            sessionPath,
-          });
-        }}
-        onCompact={() => void compact()}
-        onSetOpenMenu={setOpenMenu}
-        onToggleTerminal={onToggleTerminal}
-        projectGitState={projectGitState}
-        projectId={projectId}
-        terminalVisible={terminalVisible}
-        thinkingLevel={thinkingLevel}
-        thinkingLevelLabels={thinkingLevelLabels}
-      />
+            });
+          }}
+          onCompact={() => void compact()}
+          onSetOpenMenu={setOpenMenu}
+          onToggleTerminal={onToggleTerminal}
+          projectGitState={projectGitState}
+          projectId={projectId}
+          terminalVisible={terminalVisible}
+          thinkingLevel={thinkingLevel}
+          thinkingLevelLabels={thinkingLevelLabels}
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -110,6 +110,7 @@ export function ComposerPromptSurface({
   });
   const dictationTranscribing = dictationInterimText.length > 0;
   const slashCommandPanelRef = useRef<HTMLDivElement>(null);
+  const stopButtonBoundaryRef = useRef<HTMLDivElement>(null);
   const slashCommands = useComposerSlashCommands({
     draft,
     projectId,
@@ -133,7 +134,8 @@ export function ComposerPromptSurface({
       if (
         !target ||
         slashCommandPanelRef.current?.contains(target) ||
-        composerPanelRef.current?.contains(target)
+        composerPanelRef.current?.contains(target) ||
+        stopButtonBoundaryRef.current?.contains(target)
       ) {
         return;
       }
@@ -399,7 +401,10 @@ export function ComposerPromptSurface({
         />
       </div>
 
-      <div className="mb-[3.55rem] inline-flex h-8 shrink-0 items-center justify-end text-[color:var(--muted)]">
+      <div
+        ref={stopButtonBoundaryRef}
+        className="mb-[3.55rem] inline-flex h-8 shrink-0 items-center justify-end text-[color:var(--muted)]"
+      >
         <button
           type="button"
           className={cn(

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -260,7 +260,7 @@ export function ComposerPromptSurface({
   const canStopComposer = (composerIsStreaming || extensionRunning) && !isSending && !!sessionPath;
 
   return (
-    <div className="relative left-1/2 grid w-[calc(100%+5rem)] -translate-x-1/2 grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible max-[900px]:w-full max-[900px]:translate-x-0 max-[900px]:left-0">
+    <div className="relative left-1/2 grid w-[calc(100%+5rem)] -translate-x-1/2 grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible">
       <div className="relative mb-[3.55rem] h-8 w-8 shrink-0 text-[color:var(--muted)]">
         <div className="absolute bottom-0 left-0 flex w-7 flex-col-reverse items-center gap-1">
           <button

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -258,7 +258,7 @@ export function ComposerPromptSurface({
   const canStopComposer = (composerIsStreaming || extensionRunning) && !isSending && !!sessionPath;
 
   return (
-    <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-2 overflow-visible">
+    <div className="relative left-1/2 grid w-[calc(100%+5rem)] -translate-x-1/2 grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible max-[900px]:w-full max-[900px]:translate-x-0 max-[900px]:left-0">
       <div className="relative mb-[3.55rem] h-8 w-8 shrink-0 text-[color:var(--muted)]">
         <div className="absolute bottom-0 left-0 flex w-7 flex-col-reverse items-center gap-1">
           <button

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -60,6 +60,7 @@ export function ComposerTextField({
     left: number;
     top: number;
   } | null>(null);
+  const [trailingContainerHeight, setTrailingContainerHeight] = useState<number | null>(null);
   const lineHeightRef = useRef(20);
 
   const focusTextareaAtEnd = () => {
@@ -116,6 +117,7 @@ export function ComposerTextField({
   useLayoutEffect(() => {
     if (!trailingAdornment) {
       setTrailingAdornmentPosition(null);
+      setTrailingContainerHeight(null);
       return;
     }
 
@@ -128,6 +130,7 @@ export function ComposerTextField({
       const computedStyle = window.getComputedStyle(textarea);
       const mirror = document.createElement("div");
       const marker = document.createElement("span");
+      const lineHeight = Number.parseFloat(computedStyle.lineHeight) || lineHeightRef.current;
 
       mirror.style.position = "absolute";
       mirror.style.visibility = "hidden";
@@ -155,16 +158,22 @@ export function ComposerTextField({
       const markerRect = marker.getBoundingClientRect();
       document.body.removeChild(mirror);
 
-      const nextLeft = Math.min(
-        Math.max(0, markerRect.left - mirrorRect.left + 6),
-        Math.max(0, textarea.clientWidth - 24),
-      );
-      const nextTop = Math.max(0, markerRect.top - mirrorRect.top - 1.5);
+      const markerLeft = Math.max(0, markerRect.left - mirrorRect.left);
+      const markerTop = Math.max(0, markerRect.top - mirrorRect.top);
+      const adornmentWidth = 24;
+      const adornmentGap = 6;
+      const shouldWrapAdornment = markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth;
+      const nextLeft = shouldWrapAdornment ? 0 : markerLeft + adornmentGap;
+      const nextTop = Math.max(0, markerTop + (shouldWrapAdornment ? lineHeight : 0) - 1.5);
+      const nextContainerHeight = Math.max(textarea.scrollHeight, nextTop + lineHeight);
 
       setTrailingAdornmentPosition((current) =>
         current?.left === nextLeft && current.top === nextTop
           ? current
           : { left: nextLeft, top: nextTop },
+      );
+      setTrailingContainerHeight((current) =>
+        current === nextContainerHeight ? current : nextContainerHeight,
       );
     };
 
@@ -210,7 +219,7 @@ export function ComposerTextField({
       ) : null}
       <div
         className="relative min-w-0"
-        style={trailingAdornment ? { paddingRight: "1.75rem" } : undefined}
+        style={trailingContainerHeight ? { minHeight: `${trailingContainerHeight}px` } : undefined}
       >
         <textarea
           ref={textareaRef}

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -1,4 +1,12 @@
-import { type ClipboardEvent, type KeyboardEvent, useEffect, useRef, useState } from "react";
+import {
+  type ClipboardEvent,
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { cn } from "../../../utils/cn";
 
 type ComposerTextFieldProps = {
@@ -12,6 +20,7 @@ type ComposerTextFieldProps = {
   ariaControls?: string;
   ariaExpanded?: boolean;
   reservedLineCount?: number;
+  trailingAdornment?: ReactNode;
   onHeightChange?: (height: number) => void;
   onChange: (value: string) => void;
   onInput?: () => void;
@@ -33,6 +42,7 @@ export function ComposerTextField({
   ariaControls,
   ariaExpanded,
   reservedLineCount = 4,
+  trailingAdornment = null,
   onHeightChange,
   onChange,
   onInput,
@@ -46,6 +56,10 @@ export function ComposerTextField({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const lastReportedHeightRef = useRef<number | null>(null);
   const [reservedHeight, setReservedHeight] = useState<number | null>(null);
+  const [trailingAdornmentPosition, setTrailingAdornmentPosition] = useState<{
+    left: number;
+    top: number;
+  } | null>(null);
 
   const focusTextareaAtEnd = () => {
     const textarea = textareaRef.current;
@@ -97,6 +111,67 @@ export function ComposerTextField({
     onHeightChange?.(height);
   });
 
+  useLayoutEffect(() => {
+    if (!trailingAdornment) {
+      setTrailingAdornmentPosition(null);
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const measureTrailingAdornmentPosition = () => {
+      const computedStyle = window.getComputedStyle(textarea);
+      const mirror = document.createElement("div");
+      const marker = document.createElement("span");
+      const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 20;
+
+      mirror.style.position = "absolute";
+      mirror.style.visibility = "hidden";
+      mirror.style.pointerEvents = "none";
+      mirror.style.whiteSpace = "pre-wrap";
+      mirror.style.overflowWrap = "break-word";
+      mirror.style.wordBreak = "break-word";
+      mirror.style.boxSizing = computedStyle.boxSizing;
+      mirror.style.width = `${textarea.clientWidth}px`;
+      mirror.style.font = computedStyle.font;
+      mirror.style.fontFamily = computedStyle.fontFamily;
+      mirror.style.fontSize = computedStyle.fontSize;
+      mirror.style.fontWeight = computedStyle.fontWeight;
+      mirror.style.letterSpacing = computedStyle.letterSpacing;
+      mirror.style.lineHeight = computedStyle.lineHeight;
+      mirror.style.padding = computedStyle.padding;
+      mirror.style.border = computedStyle.border;
+
+      mirror.textContent = textarea.value || textarea.placeholder || "";
+      marker.textContent = "\u200b";
+      mirror.appendChild(marker);
+      document.body.appendChild(mirror);
+
+      const mirrorRect = mirror.getBoundingClientRect();
+      const markerRect = marker.getBoundingClientRect();
+      document.body.removeChild(mirror);
+
+      const nextLeft = Math.min(
+        Math.max(0, markerRect.left - mirrorRect.left + 6),
+        Math.max(0, textarea.clientWidth - 24),
+      );
+      const nextTop = Math.max(0, markerRect.top - mirrorRect.top + lineHeight / 2 - 12);
+
+      setTrailingAdornmentPosition((current) =>
+        current?.left === nextLeft && current.top === nextTop
+          ? current
+          : { left: nextLeft, top: nextTop },
+      );
+    };
+
+    measureTrailingAdornmentPosition();
+    window.addEventListener("resize", measureTrailingAdornmentPosition);
+    return () => window.removeEventListener("resize", measureTrailingAdornmentPosition);
+  });
+
   return (
     <div
       ref={wrapperRef}
@@ -132,29 +207,42 @@ export function ComposerTextField({
           {statusMessage}
         </div>
       ) : null}
-      <textarea
-        ref={textareaRef}
-        rows={1}
-        className={cn(
-          "m-0 w-full min-h-6 resize-none overflow-hidden bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none",
-          placeholderTone === "error"
-            ? "placeholder:text-[#f2a7a7]"
-            : "placeholder:text-[color:var(--muted-2)]",
-        )}
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        onInput={onInput}
-        onKeyDown={onKeyDown}
-        onPaste={onPaste}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        aria-label={ariaLabel}
-        aria-activedescendant={ariaActiveDescendant}
-        aria-autocomplete={ariaControls ? "list" : undefined}
-        aria-controls={ariaControls}
-        aria-expanded={ariaExpanded}
-        placeholder={placeholder}
-      />
+      <div className="relative min-w-0">
+        <textarea
+          ref={textareaRef}
+          rows={1}
+          className={cn(
+            "m-0 w-full min-h-6 resize-none overflow-hidden bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none",
+            placeholderTone === "error"
+              ? "placeholder:text-[#f2a7a7]"
+              : "placeholder:text-[color:var(--muted-2)]",
+          )}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onInput={onInput}
+          onKeyDown={onKeyDown}
+          onPaste={onPaste}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          aria-label={ariaLabel}
+          aria-activedescendant={ariaActiveDescendant}
+          aria-autocomplete={ariaControls ? "list" : undefined}
+          aria-controls={ariaControls}
+          aria-expanded={ariaExpanded}
+          placeholder={placeholder}
+        />
+        {trailingAdornment && trailingAdornmentPosition ? (
+          <span
+            className="absolute z-10 inline-flex"
+            style={{
+              left: `${trailingAdornmentPosition.left}px`,
+              top: `${trailingAdornmentPosition.top}px`,
+            }}
+          >
+            {trailingAdornment}
+          </span>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -60,6 +60,7 @@ export function ComposerTextField({
     left: number;
     top: number;
   } | null>(null);
+  const lineHeightRef = useRef(20);
 
   const focusTextareaAtEnd = () => {
     const textarea = textareaRef.current;
@@ -80,6 +81,7 @@ export function ComposerTextField({
 
     const computedStyle = window.getComputedStyle(textarea);
     const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 20;
+    lineHeightRef.current = lineHeight;
     const reservedHeight = Math.ceil(lineHeight * reservedLineCount);
     setReservedHeight((current) => (current === reservedHeight ? current : reservedHeight));
 
@@ -126,7 +128,6 @@ export function ComposerTextField({
       const computedStyle = window.getComputedStyle(textarea);
       const mirror = document.createElement("div");
       const marker = document.createElement("span");
-      const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 20;
 
       mirror.style.position = "absolute";
       mirror.style.visibility = "hidden";
@@ -158,7 +159,7 @@ export function ComposerTextField({
         Math.max(0, markerRect.left - mirrorRect.left + 6),
         Math.max(0, textarea.clientWidth - 24),
       );
-      const nextTop = Math.max(0, markerRect.top - mirrorRect.top + lineHeight / 2 - 12);
+      const nextTop = Math.max(0, markerRect.top - mirrorRect.top - 1.5);
 
       setTrailingAdornmentPosition((current) =>
         current?.left === nextLeft && current.top === nextTop
@@ -207,7 +208,10 @@ export function ComposerTextField({
           {statusMessage}
         </div>
       ) : null}
-      <div className="relative min-w-0">
+      <div
+        className="relative min-w-0"
+        style={trailingAdornment ? { paddingRight: "1.75rem" } : undefined}
+      >
         <textarea
           ref={textareaRef}
           rows={1}
@@ -233,10 +237,11 @@ export function ComposerTextField({
         />
         {trailingAdornment && trailingAdornmentPosition ? (
           <span
-            className="absolute z-10 inline-flex"
+            className="absolute z-10 inline-flex items-center"
             style={{
               left: `${trailingAdornmentPosition.left}px`,
               top: `${trailingAdornmentPosition.top}px`,
+              height: `${lineHeightRef.current}px`,
             }}
           >
             {trailingAdornment}

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -149,7 +149,7 @@ export function ComposerTextField({
       mirror.style.padding = computedStyle.padding;
       mirror.style.border = computedStyle.border;
 
-      mirror.textContent = textarea.value || textarea.placeholder || "";
+      mirror.textContent = value || placeholder || "";
       marker.textContent = "\u200b";
       mirror.appendChild(marker);
       document.body.appendChild(mirror);
@@ -180,7 +180,7 @@ export function ComposerTextField({
     measureTrailingAdornmentPosition();
     window.addEventListener("resize", measureTrailingAdornmentPosition);
     return () => window.removeEventListener("resize", measureTrailingAdornmentPosition);
-  });
+  }, [placeholder, trailingAdornment, value]);
 
   return (
     <div

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -149,7 +149,7 @@ export function ComposerTextField({
       mirror.style.padding = computedStyle.padding;
       mirror.style.border = computedStyle.border;
 
-      mirror.textContent = value || "";
+      mirror.textContent = value || placeholder || "";
       marker.textContent = "\u200b";
       mirror.appendChild(marker);
       document.body.appendChild(mirror);
@@ -180,7 +180,7 @@ export function ComposerTextField({
     measureTrailingAdornmentPosition();
     window.addEventListener("resize", measureTrailingAdornmentPosition);
     return () => window.removeEventListener("resize", measureTrailingAdornmentPosition);
-  }, [trailingAdornment, value]);
+  }, [placeholder, trailingAdornment, value]);
 
   return (
     <div

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -149,7 +149,7 @@ export function ComposerTextField({
       mirror.style.padding = computedStyle.padding;
       mirror.style.border = computedStyle.border;
 
-      mirror.textContent = value || placeholder || "";
+      mirror.textContent = value || "";
       marker.textContent = "\u200b";
       mirror.appendChild(marker);
       document.body.appendChild(mirror);
@@ -180,7 +180,7 @@ export function ComposerTextField({
     measureTrailingAdornmentPosition();
     window.addEventListener("resize", measureTrailingAdornmentPosition);
     return () => window.removeEventListener("resize", measureTrailingAdornmentPosition);
-  }, [placeholder, trailingAdornment, value]);
+  }, [trailingAdornment, value]);
 
   return (
     <div

--- a/src/app/components/workspace/footer/AGENTS.md
+++ b/src/app/components/workspace/footer/AGENTS.md
@@ -1,0 +1,6 @@
+# Workspace footer guidance
+
+- This folder owns shared bottom chrome for workspace surfaces, not composer-specific behavior.
+- Use these primitives for footer rows in the prompt composer, git-ops composer, and Pi-TUI takeover terminal instead of copying class strings.
+- Keep composer-only state/actions in `../composer/**`; keep shared visual primitives here.
+- If changing branch chips, diff stats, toolbar footer text, or footer spacing, check all hosts that import `WorkspaceFooterPrimitives.tsx`.

--- a/src/app/components/workspace/footer/WorkspaceFooterPrimitives.tsx
+++ b/src/app/components/workspace/footer/WorkspaceFooterPrimitives.tsx
@@ -1,0 +1,35 @@
+import { cn } from "../../../utils/cn";
+import { Tooltip } from "../../common/Tooltip";
+
+// Keep workspace bottom chrome visually in sync across the prompt composer,
+// git-ops composer, and Pi-TUI takeover terminal footer.
+export const workspaceFooterRowClass =
+  "flex items-center gap-1.5 pr-2.5 pl-2.5 py-2 text-[color:var(--muted)] max-md:flex-wrap";
+
+export const workspaceFooterTrailingGroupClass =
+  "ml-auto flex min-h-7 items-center gap-1.5 max-md:flex-wrap";
+
+export const workspaceFooterTextClass = "composer-footer-text";
+
+type WorkspaceBranchChipProps = {
+  branch: string | null | undefined;
+  className?: string;
+};
+
+export function WorkspaceBranchChip({ branch, className }: WorkspaceBranchChipProps) {
+  const label = branch ?? "Detached";
+
+  return (
+    <Tooltip content={label}>
+      <div
+        className={cn(
+          workspaceFooterTextClass,
+          "inline-flex h-7 max-w-[12rem] items-center rounded-lg border border-transparent px-2.5 py-0 text-[color:var(--muted)] transition-colors duration-150 hover:border-[color:var(--border)] hover:bg-[rgba(255,255,255,0.02)] hover:text-[color:var(--text)]",
+          className,
+        )}
+      >
+        <span className="truncate">{label}</span>
+      </div>
+    </Tooltip>
+  );
+}

--- a/src/app/components/workspace/thread/ThreadTimeline.tsx
+++ b/src/app/components/workspace/thread/ThreadTimeline.tsx
@@ -21,7 +21,7 @@ type ThreadTimelineProps = {
 };
 
 const timelineQuickActionButtonClass =
-  "pointer-events-auto shrink-0 rounded-full bg-[rgba(146,153,184,0.22)] hover:bg-[rgba(146,153,184,0.32)] disabled:cursor-not-allowed disabled:opacity-45";
+  "pointer-events-auto h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.22)] hover:bg-[rgba(146,153,184,0.32)] disabled:cursor-not-allowed disabled:opacity-45";
 
 export function ThreadTimeline({
   messages,
@@ -283,7 +283,11 @@ export function ThreadTimeline({
 
   return (
     <div className={`${chatViewportClass} relative`}>
-      <div ref={containerRef} className={chatScrollableAreaClass} onScroll={handleScroll}>
+      <div
+        ref={containerRef}
+        className={cn(chatScrollableAreaClass, "ml-[2.95rem] mr-[2.05rem]")}
+        onScroll={handleScroll}
+      >
         <div
           ref={contentRef}
           className={`mx-auto w-full min-w-0 ${CHAT_TEXT_MAX_WIDTH_CLASS} overflow-x-hidden px-4 pt-4 pb-4`}
@@ -302,7 +306,7 @@ export function ThreadTimeline({
           </div>
         </div>
       ) : null}
-      <div className="pointer-events-none absolute right-4 bottom-4 z-10 flex flex-col items-center gap-1.5">
+      <div className="pointer-events-none absolute right-0 bottom-4 z-10 flex w-7 flex-col items-center gap-1.5">
         <button
           type="button"
           className={cn(compactIconButtonClass, timelineQuickActionButtonClass)}

--- a/src/app/components/workspace/thread/thread-layout.ts
+++ b/src/app/components/workspace/thread/thread-layout.ts
@@ -1,4 +1,4 @@
-import { WORKSPACE_CONTENT_MAX_WIDTH_CLASS } from "../../../ui/layout";
+import { WORKSPACE_CHROME_MAX_WIDTH_CLASS } from "../../../ui/layout";
 
 export const CHAT_STICKY_BOTTOM_THRESHOLD_PX = 24;
 export const CHAT_ROW_GAP_PX = 16;
@@ -9,8 +9,8 @@ export const CHAT_COLLAPSED_ROW_HEIGHT_PX = 56;
 export const CHAT_DIFF_TREE_INDENT_BASE_PX = 8;
 export const CHAT_DIFF_TREE_INDENT_STEP_PX = 16;
 
-export const chatViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} overflow-visible`;
-export const chatHiddenViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} overflow-hidden`;
+export const chatViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CHROME_MAX_WIDTH_CLASS} overflow-visible`;
+export const chatHiddenViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CHROME_MAX_WIDTH_CLASS} overflow-hidden`;
 export const chatScrollableAreaClass =
   "min-h-0 w-full overflow-y-scroll overflow-x-visible [overflow-anchor:none] [scrollbar-gutter:stable]";
 export const chatEmptyStateClass =

--- a/src/app/components/workspace/thread/thread-layout.ts
+++ b/src/app/components/workspace/thread/thread-layout.ts
@@ -12,7 +12,7 @@ export const CHAT_DIFF_TREE_INDENT_STEP_PX = 16;
 export const chatViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} overflow-visible`;
 export const chatHiddenViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} overflow-hidden`;
 export const chatScrollableAreaClass =
-  "min-h-0 overflow-y-scroll overflow-x-visible [overflow-anchor:none] [scrollbar-gutter:stable]";
+  "min-h-0 w-full overflow-y-scroll overflow-x-visible [overflow-anchor:none] [scrollbar-gutter:stable]";
 export const chatEmptyStateClass =
   "min-h-0 w-full overflow-y-scroll overflow-x-hidden px-4 pt-8 text-[color:var(--muted)] [scrollbar-gutter:stable]";
 export const chatTimelinePaddingClass = "px-4 pt-4 pb-8";

--- a/src/app/components/workspace/thread/thread-layout.ts
+++ b/src/app/components/workspace/thread/thread-layout.ts
@@ -12,7 +12,7 @@ export const CHAT_DIFF_TREE_INDENT_STEP_PX = 16;
 export const chatViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} overflow-visible`;
 export const chatHiddenViewportClass = `mx-auto flex h-full w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} overflow-hidden`;
 export const chatScrollableAreaClass =
-  "min-h-0 w-full overflow-y-scroll overflow-x-visible [overflow-anchor:none] [scrollbar-gutter:stable]";
+  "min-h-0 overflow-y-scroll overflow-x-visible [overflow-anchor:none] [scrollbar-gutter:stable]";
 export const chatEmptyStateClass =
   "min-h-0 w-full overflow-y-scroll overflow-x-hidden px-4 pt-8 text-[color:var(--muted)] [scrollbar-gutter:stable]";
 export const chatTimelinePaddingClass = "px-4 pt-4 pb-8";

--- a/src/app/ui/layout.ts
+++ b/src/app/ui/layout.ts
@@ -1,2 +1,3 @@
 export const WORKSPACE_CONTENT_MAX_WIDTH_CLASS = "max-w-[800px]";
+export const WORKSPACE_CHROME_MAX_WIDTH_CLASS = "max-w-[880px]";
 export const CHAT_TEXT_MAX_WIDTH_CLASS = "max-w-[744px]";

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -109,3 +109,52 @@ button[data-tooltip]:disabled::after,
 button[data-tooltip][aria-disabled="true"]::after {
   display: none;
 }
+
+.tooltip-anchor {
+  position: relative;
+  display: inline-flex;
+  min-width: 0;
+}
+
+.tooltip-content {
+  pointer-events: none;
+  position: fixed;
+  z-index: 120;
+  width: max-content;
+  max-width: 360px;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: rgba(45, 48, 64, 0.98);
+  padding: 6px 10px;
+  color: var(--text);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
+  font-size: 11.5px;
+  line-height: 16px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  opacity: 0;
+  transition: opacity 150ms ease-out, transform 150ms ease-out;
+}
+
+.tooltip-content[data-placement="top"] {
+  transform: translate(-50%, calc(-100% + 4px));
+}
+
+.tooltip-content[data-placement="top"][data-open="true"][data-ready="true"] {
+  transform: translate(-50%, calc(-100% - 2px));
+  opacity: 1;
+}
+
+.tooltip-content[data-placement="right"] {
+  transform: translate(-4px, -50%);
+}
+
+.tooltip-content[data-placement="right"][data-open="true"][data-ready="true"] {
+  transform: translate(2px, -50%);
+  opacity: 1;
+}
+
+.composer-footer-text {
+  font-size: 12px;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- Pop composer attachment, stop, and dictation controls out of the prompt surface while keeping the main composer at its original width.
- Remove the send button and polish composer footer alignment, spacing, branch chip chrome, diff stats typography, and quick action alignment.
- Move shared workspace footer chrome into `workspace/footer` primitives and document the cross-surface ownership for future agent navigation.

## Details
- Adds inline trailing dictation positioning in the prompt input.
- Adds proper CSS-backed tooltip primitives instead of embedding all tooltip presentation in component class strings.
- Shares footer row, text, and branch chip primitives across the normal composer, git-ops footer, and Pi-TUI takeover footer.
- Keeps the popped side controls outside the restored 800px composer panel width.

## Validation
- Commit hook ran Biome, typecheck, and Vitest successfully.
- Push hook ran Biome and typecheck successfully.
