### PR TITLE
Fix background review focus steal

### DIFF
--- a/src/app/app-shell/desktop-event-sync.ts
+++ b/src/app/app-shell/desktop-event-sync.ts
@@ -1,4 +1,4 @@
-import { getPersistedSessionPath } from "../../../shared/session-paths";
+import { getLocalDraftProjectId, getPersistedSessionPath } from "../../../shared/session-paths";
 import type { DesktopEvent } from "../desktop/types";
 import { desktopQueryKeys } from "../query/desktop-query";
 import type { WorkspaceState } from "../state/workspace";
@@ -10,7 +10,7 @@ type QueryClientLike = {
 
 export type DesktopEventSelectionState = Pick<
   WorkspaceState,
-  "activeView" | "selectedSessionPath" | "selectedInboxSessionPath"
+  "activeView" | "selectedProjectId" | "selectedSessionPath" | "selectedInboxSessionPath"
 >;
 
 export function getVisibleDesktopSessionPath(workspaceState: DesktopEventSelectionState) {
@@ -21,16 +21,29 @@ export function getVisibleDesktopSessionPath(workspaceState: DesktopEventSelecti
       : null;
 }
 
-export function shouldAutoOpenStartedThread(
-  reason: Extract<DesktopEvent, { type: "thread-update" }>["reason"],
-  workspaceState: DesktopEventSelectionState,
-) {
+export function shouldAutoOpenStartedThread({
+  reason,
+  projectId,
+  workspaceState,
+}: {
+  reason: Extract<DesktopEvent, { type: "thread-update" }>["reason"];
+  projectId: string;
+  workspaceState: DesktopEventSelectionState;
+}) {
+  if (reason !== "start" || projectId !== workspaceState.selectedProjectId) {
+    return false;
+  }
+
   const visibleSessionPath = getVisibleDesktopSessionPath(workspaceState);
+  const localDraftProjectId = getLocalDraftProjectId(workspaceState.selectedSessionPath);
+
+  if (localDraftProjectId) {
+    return false;
+  }
 
   return (
-    reason === "start" &&
-    (workspaceState.activeView === "code" ||
-      (workspaceState.activeView === "thread" && visibleSessionPath === null))
+    workspaceState.activeView === "code" ||
+    (workspaceState.activeView === "thread" && visibleSessionPath === null)
   );
 }
 

--- a/src/app/app-shell/useDesktopEventSync.ts
+++ b/src/app/app-shell/useDesktopEventSync.ts
@@ -47,6 +47,7 @@ export function useDesktopEventSync({
     composerProjectId,
     workspaceState: {
       activeView: workspaceState.activeView,
+      selectedProjectId: workspaceState.selectedProjectId,
       selectedSessionPath: workspaceState.selectedSessionPath,
       selectedInboxSessionPath: workspaceState.selectedInboxSessionPath,
     } satisfies DesktopEventSelectionState,
@@ -57,6 +58,7 @@ export function useDesktopEventSync({
       composerProjectId,
       workspaceState: {
         activeView: workspaceState.activeView,
+        selectedProjectId: workspaceState.selectedProjectId,
         selectedSessionPath: workspaceState.selectedSessionPath,
         selectedInboxSessionPath: workspaceState.selectedInboxSessionPath,
       },
@@ -64,6 +66,7 @@ export function useDesktopEventSync({
   }, [
     composerProjectId,
     workspaceState.activeView,
+    workspaceState.selectedProjectId,
     workspaceState.selectedInboxSessionPath,
     workspaceState.selectedSessionPath,
   ]);
@@ -166,7 +169,13 @@ export function useDesktopEventSync({
         );
       }
 
-      if (shouldAutoOpenStartedThread(event.reason, latestWorkspaceState)) {
+      if (
+        shouldAutoOpenStartedThread({
+          reason: event.reason,
+          projectId: event.projectId,
+          workspaceState: latestWorkspaceState,
+        })
+      ) {
         dispatch({
           type: "open-thread",
           projectId: event.projectId,

--- a/src/test/desktop-event-sync.test.ts
+++ b/src/test/desktop-event-sync.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { createLocalThreadDraft } from "../../shared/session-paths";
+import {
+  getVisibleDesktopSessionPath,
+  shouldAutoOpenStartedThread,
+  type DesktopEventSelectionState,
+} from "../app/app-shell/desktop-event-sync";
+
+function selectionState(
+  overrides: Partial<DesktopEventSelectionState> = {},
+): DesktopEventSelectionState {
+  return {
+    activeView: "code",
+    selectedProjectId: "/repo/project-a",
+    selectedSessionPath: null,
+    selectedInboxSessionPath: null,
+    ...overrides,
+  };
+}
+
+describe("desktop event selection helpers", () => {
+  it("does not treat a local draft thread as a visible persisted session", () => {
+    const draft = createLocalThreadDraft("/repo/project-b", "draft");
+
+    expect(
+      getVisibleDesktopSessionPath(
+        selectionState({
+          activeView: "thread",
+          selectedProjectId: draft.projectId,
+          selectedSessionPath: draft.sessionPath,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not auto-open a started background thread over a local draft in another project", () => {
+    const draft = createLocalThreadDraft("/repo/project-b", "draft");
+
+    expect(
+      shouldAutoOpenStartedThread({
+        reason: "start",
+        projectId: "/repo/project-a",
+        workspaceState: selectionState({
+          activeView: "thread",
+          selectedProjectId: draft.projectId,
+          selectedSessionPath: draft.sessionPath,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-open over a local draft even when the background thread is in the same project", () => {
+    const draft = createLocalThreadDraft("/repo/project-a", "draft");
+
+    expect(
+      shouldAutoOpenStartedThread({
+        reason: "start",
+        projectId: draft.projectId,
+        workspaceState: selectionState({
+          activeView: "thread",
+          selectedProjectId: draft.projectId,
+          selectedSessionPath: draft.sessionPath,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-open a started background thread over an empty thread view in another project", () => {
+    expect(
+      shouldAutoOpenStartedThread({
+        reason: "start",
+        projectId: "/repo/project-a",
+        workspaceState: selectionState({
+          activeView: "thread",
+          selectedProjectId: "/repo/project-b",
+          selectedSessionPath: null,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps same-project auto-open behavior for empty thread and code views", () => {
+    expect(
+      shouldAutoOpenStartedThread({
+        reason: "start",
+        projectId: "/repo/project-a",
+        workspaceState: selectionState({ activeView: "thread", selectedSessionPath: null }),
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoOpenStartedThread({
+        reason: "start",
+        projectId: "/repo/project-a",
+        workspaceState: selectionState({ activeView: "code" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not auto-open non-start updates or when a persisted session is visible", () => {
+    expect(
+      shouldAutoOpenStartedThread({
+        reason: "end",
+        projectId: "/repo/project-a",
+        workspaceState: selectionState({ activeView: "thread", selectedSessionPath: null }),
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldAutoOpenStartedThread({
+        reason: "start",
+        projectId: "/repo/project-a",
+        workspaceState: selectionState({
+          activeView: "thread",
+          selectedSessionPath: "/sessions/project-a.jsonl",
+        }),
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- prevents background thread-start events from auto-opening over the user's current project/session
- treats local draft/new-composer sessions as active user intent, so background runtime updates cannot steal navigation
- adds focused coverage for cross-project and local-draft auto-open policy

## Notes
The existing auto-open path treated local draft sessions as having no visible persisted session. That made background runtime thread updates eligible to dispatch `open-thread` while the user was composing elsewhere. This tightens that policy to the selected project and blocks auto-open while a local draft is active.

## Validation
- `bunx biome check --organize-imports-enabled=false src/app/app-shell/desktop-event-sync.ts src/app/app-shell/useDesktopEventSync.ts src/test/desktop-event-sync.test.ts`

Closes #162
