### PR TITLE
Upgrade terminal renderer to Ghostty

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,8 +19,10 @@
         "@tanstack/react-pacer": "^0.21.1",
         "@tanstack/react-query": "^5.96.1",
         "@tanstack/react-virtual": "^3.13.23",
-        "@wterm/dom": "0.2.1",
-        "@wterm/react": "0.2.1",
+        "@wterm/core": "0.3.0",
+        "@wterm/dom": "0.3.0",
+        "@wterm/ghostty": "0.3.0",
+        "@wterm/react": "0.3.0",
         "better-sqlite3": "^12.2.0",
         "clip-filepaths": "^0.3.0",
         "esbuild": "0.27.7",
@@ -58,8 +60,8 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1036.0",
     "@aws-sdk/core": "^3.974.5",
     "@aws-sdk/xml-builder": "^3.972.19",
-    "@wterm/core": "0.2.1",
-    "@wterm/dom": "0.2.1",
+    "@wterm/core": "0.3.0",
+    "@wterm/dom": "0.3.0",
     "uuid": "^14.0.0",
   },
   "packages": {
@@ -913,11 +915,13 @@
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
-    "@wterm/core": ["@wterm/core@0.2.1", "", {}, "sha512-g+xrTei6qovjH0QI/HFyAyV2TCAuH/d3FJl2Vh/aObDX6FqA8PjwkafBwESSOaEvSeUQhU5d37ELtUSWMZP46A=="],
+    "@wterm/core": ["@wterm/core@0.3.0", "", {}, "sha512-aQ73QBP+eyA3kcn31mA7DmAi7qmEsQijZdmvgwxtSjCi2248EAOZgtkGDpjlspfrxyVxQbUl/IF+gCVcXt4nZQ=="],
 
-    "@wterm/dom": ["@wterm/dom@0.2.1", "", { "dependencies": { "@wterm/core": "0.2.1" } }, "sha512-ojJqz6oJku/rxBOObLdq+Jd7gNwrCtx1jY11hP/x2/kcLLaEvbIsAmrjuVBxgTyFxBcBq0Ru6TdFbDdfMBH+vw=="],
+    "@wterm/dom": ["@wterm/dom@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ=="],
 
-    "@wterm/react": ["@wterm/react@0.2.1", "", { "peerDependencies": { "@wterm/dom": "0.2.1", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-pZEIcMvsSd/tmMM8aXqO/EseRNq25MPEH0cG+A0nS1BCBuhC3tY8GQKJ4mUHlYS1FdYcsIRF6lHeuV0o/o12pg=="],
+    "@wterm/ghostty": ["@wterm/ghostty@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-TDjEmUSRD7IaFxq31P7+I3Inkp5mHCfBfO6LYj3/vbLbWOkOZOKPhjAcZ36AYFHe9Q0HLCFvLWmrxIO3aGCjDA=="],
+
+    "@wterm/react": ["@wterm/react@0.3.0", "", { "peerDependencies": { "@wterm/dom": "0.3.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-1rua/roQGCIGkNxjs9TVq+EkXJ0n2IK6aCoaGIQJpvzuHv7iU9/lngG3i1SCpX6deOOO/wpfhtjDTI+z9XF0aA=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 

--- a/package.json
+++ b/package.json
@@ -61,8 +61,10 @@
     "@tanstack/react-pacer": "^0.21.1",
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-virtual": "^3.13.23",
-    "@wterm/dom": "0.2.1",
-    "@wterm/react": "0.2.1",
+    "@wterm/core": "0.3.0",
+    "@wterm/dom": "0.3.0",
+    "@wterm/ghostty": "0.3.0",
+    "@wterm/react": "0.3.0",
     "better-sqlite3": "^12.2.0",
     "clip-filepaths": "^0.3.0",
     "esbuild": "0.27.7",
@@ -98,8 +100,8 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1036.0",
     "@aws-sdk/core": "^3.974.5",
     "@aws-sdk/xml-builder": "^3.972.19",
-    "@wterm/core": "0.2.1",
-    "@wterm/dom": "0.2.1",
+    "@wterm/core": "0.3.0",
+    "@wterm/dom": "0.3.0",
     "uuid": "^14.0.0"
   }
 }

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -1,4 +1,5 @@
-import { Terminal, type TerminalHandle, type WTerm } from "@wterm/react";
+import { GhosttyCore } from "@wterm/ghostty";
+import { Terminal, type TerminalCore, type TerminalHandle, type WTerm } from "@wterm/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getPersistedSessionPath } from "../../../../../shared/session-paths";
 import type { TerminalEvent } from "../../../desktop/types";
@@ -62,8 +63,10 @@ export function TerminalViewport({
   backgroundCssVar = "--terminal-bg",
   className,
 }: TerminalViewportProps) {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
   const terminalHandleRef = useRef<TerminalHandle | null>(null);
   const terminalInstanceRef = useRef<WTerm | null>(null);
+  const terminalResizeFrameRef = useRef<number | null>(null);
   const pendingScrollFrameRef = useRef<number | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const attachFailedRef = useRef(false);
@@ -75,6 +78,7 @@ export function TerminalViewport({
   const lastSentSizeRef = useRef<{ sessionId: string; cols: number; rows: number } | null>(null);
   const [terminalReadyRevision, setTerminalReadyRevision] = useState(0);
   const [terminalInitError, setTerminalInitError] = useState<string | null>(null);
+  const [terminalCore, setTerminalCore] = useState<TerminalCore | null>(null);
   const effectiveLaunchMode = launchMode;
   if (effectiveLaunchMode === "pi-session" && piSessionPathRef.current === null) {
     piSessionPathRef.current = { value: sessionPath };
@@ -126,6 +130,9 @@ export function TerminalViewport({
 
   useEffect(
     () => () => {
+      if (terminalResizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(terminalResizeFrameRef.current);
+      }
       if (pendingScrollFrameRef.current !== null) {
         window.cancelAnimationFrame(pendingScrollFrameRef.current);
       }
@@ -180,6 +187,30 @@ export function TerminalViewport({
     setTerminalInitError(message);
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    setTerminalCore(null);
+    setTerminalInitError(null);
+
+    void GhosttyCore.load().then(
+      (core) => {
+        if (!cancelled) {
+          setTerminalCore(core);
+        }
+      },
+      (error: unknown) => {
+        if (!cancelled) {
+          const message = error instanceof Error ? error.message : "Unable to initialize terminal.";
+          setTerminalInitError(message);
+        }
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const handleTerminalResize = useCallback((cols: number, rows: number) => {
     const nextCols = normalizeTerminalDimension(cols, lastKnownSizeRef.current.cols);
     const nextRows = normalizeTerminalDimension(rows, lastKnownSizeRef.current.rows);
@@ -230,6 +261,72 @@ export function TerminalViewport({
     },
     [writeToTerminal],
   );
+
+  const resizeTerminalToContainer = useCallback(() => {
+    const terminal = terminalInstanceRef.current;
+    const terminalElement = terminal?.element;
+    if (!terminal || !terminalElement) {
+      return;
+    }
+
+    const shouldStickToBottom = isTerminalElementNearBottom(terminalElement);
+    const measuredSize = measureTerminalSize(terminal);
+    if (!measuredSize) {
+      return;
+    }
+
+    const cols = normalizeTerminalDimension(measuredSize.cols, lastKnownSizeRef.current.cols);
+    const rows = normalizeTerminalDimension(measuredSize.rows, lastKnownSizeRef.current.rows);
+    if (!isUsableTerminalSize(cols, rows)) {
+      return;
+    }
+
+    if (terminal.cols !== cols || terminal.rows !== rows) {
+      terminal.resize(cols, rows);
+    }
+    handleTerminalResize(cols, rows);
+
+    if (shouldStickToBottom) {
+      scheduleTerminalScrollToBottom();
+    }
+  }, [handleTerminalResize, scheduleTerminalScrollToBottom]);
+
+  const scheduleTerminalResizeToContainer = useCallback(() => {
+    if (terminalResizeFrameRef.current !== null) {
+      window.cancelAnimationFrame(terminalResizeFrameRef.current);
+    }
+
+    terminalResizeFrameRef.current = window.requestAnimationFrame(() => {
+      terminalResizeFrameRef.current = null;
+      resizeTerminalToContainer();
+    });
+  }, [resizeTerminalToContainer]);
+
+  useEffect(() => {
+    if (terminalReadyRevision === 0) {
+      return;
+    }
+
+    const viewportElement = viewportRef.current;
+    if (!viewportElement || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      scheduleTerminalResizeToContainer();
+    });
+
+    observer.observe(viewportElement);
+    scheduleTerminalResizeToContainer();
+
+    return () => {
+      observer.disconnect();
+      if (terminalResizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(terminalResizeFrameRef.current);
+        terminalResizeFrameRef.current = null;
+      }
+    };
+  }, [scheduleTerminalResizeToContainer, terminalReadyRevision]);
 
   useEffect(() => {
     if (terminalReadyRevision === 0) {
@@ -482,23 +579,31 @@ export function TerminalViewport({
 
   return (
     <div
+      ref={viewportRef}
       style={viewportStyle}
       className={cn(
         "terminal-viewport relative h-full min-h-[220px] min-w-0 w-full flex-1 overflow-hidden rounded-[12px] bg-[color:var(--terminal-surface)] text-[color:var(--text)]",
         className,
       )}
     >
-      <Terminal
-        ref={terminalHandleRef}
-        autoResize
-        cursorBlink
-        onReady={handleTerminalReady}
-        onError={handleTerminalError}
-        onResize={handleTerminalResize}
-        onData={handleTerminalData}
-        className="h-full w-full"
-        style={{ height: "100%", width: "100%", ...terminalStyle }}
-      />
+      {terminalCore ? (
+        <Terminal
+          ref={terminalHandleRef}
+          core={terminalCore}
+          cursorBlink
+          onReady={handleTerminalReady}
+          onError={handleTerminalError}
+          onResize={handleTerminalResize}
+          onData={handleTerminalData}
+          className="h-full w-full"
+          style={{ height: "100%", width: "100%", ...terminalStyle }}
+        />
+      ) : null}
+      {!terminalCore && !terminalInitError ? (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-start bg-[color:var(--terminal-surface)] px-4 py-3 text-[12px] leading-5 text-[color:var(--muted)]">
+          <span>[terminal] Loading Ghostty renderer…</span>
+        </div>
+      ) : null}
       {terminalInitError ? (
         <div className="pointer-events-none absolute inset-0 z-10 flex items-start bg-[color:var(--terminal-surface)]/92 px-4 py-3 text-[12px] leading-5 text-[color:var(--text)]">
           <span>[terminal] {terminalInitError}</span>

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -590,6 +590,7 @@ export function TerminalViewport({
         <Terminal
           ref={terminalHandleRef}
           core={terminalCore}
+          autoResize
           cursorBlink
           onReady={handleTerminalReady}
           onError={handleTerminalError}

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -51,6 +51,27 @@ type TerminalViewportProps = {
   className?: string;
 };
 
+async function loadUsableGhosttyCore() {
+  const probe = await GhosttyCore.load({ scrollbackLimit: 100 });
+  probe.init(20, 5);
+  for (let line = 1; line <= 8; line += 1) {
+    probe.writeString(`ghostty-scrollback-probe-${line}\r\n`);
+  }
+
+  const scrollbackCount = probe.getScrollbackCount();
+  const hasReadableScrollback =
+    scrollbackCount === 0 ||
+    Array.from({ length: scrollbackCount }, (_, offset) => probe.getScrollbackLineLen(offset)).some(
+      (lineLength) => lineLength > 0,
+    );
+
+  if (!hasReadableScrollback) {
+    return null;
+  }
+
+  return GhosttyCore.load();
+}
+
 export function TerminalViewport({
   projectId,
   sessionPath,
@@ -78,7 +99,7 @@ export function TerminalViewport({
   const lastSentSizeRef = useRef<{ sessionId: string; cols: number; rows: number } | null>(null);
   const [terminalReadyRevision, setTerminalReadyRevision] = useState(0);
   const [terminalInitError, setTerminalInitError] = useState<string | null>(null);
-  const [terminalCore, setTerminalCore] = useState<TerminalCore | null>(null);
+  const [terminalCore, setTerminalCore] = useState<TerminalCore | null | undefined>(undefined);
   const effectiveLaunchMode = launchMode;
   if (effectiveLaunchMode === "pi-session" && piSessionPathRef.current === null) {
     piSessionPathRef.current = { value: sessionPath };
@@ -189,10 +210,10 @@ export function TerminalViewport({
 
   useEffect(() => {
     let cancelled = false;
-    setTerminalCore(null);
+    setTerminalCore(undefined);
     setTerminalInitError(null);
 
-    void GhosttyCore.load().then(
+    void loadUsableGhosttyCore().then(
       (core) => {
         if (!cancelled) {
           setTerminalCore(core);
@@ -586,10 +607,10 @@ export function TerminalViewport({
         className,
       )}
     >
-      {terminalCore ? (
+      {terminalCore !== undefined ? (
         <Terminal
           ref={terminalHandleRef}
-          core={terminalCore}
+          core={terminalCore ?? undefined}
           autoResize
           cursorBlink
           onReady={handleTerminalReady}
@@ -600,7 +621,7 @@ export function TerminalViewport({
           style={{ height: "100%", width: "100%", ...terminalStyle }}
         />
       ) : null}
-      {!terminalCore && !terminalInitError ? (
+      {terminalCore === undefined && !terminalInitError ? (
         <div className="pointer-events-none absolute inset-0 z-10 flex items-start bg-[color:var(--terminal-surface)] px-4 py-3 text-[12px] leading-5 text-[color:var(--muted)]">
           <span>[terminal] Loading Ghostty renderer…</span>
         </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,23 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
+
+function stripGhosttyPackageSourcemaps(): Plugin {
+  return {
+    name: "strip-ghostty-package-sourcemaps",
+    enforce: "pre",
+    transform(code, id) {
+      if (!id.includes("/node_modules/@wterm/ghostty/dist/") || !id.endsWith(".js")) {
+        return null;
+      }
+
+      return {
+        code: code.replace(/\n?\/\/# sourceMappingURL=.*\.js\.map\s*$/u, ""),
+        map: null,
+      };
+    },
+  };
+}
 
 export default defineConfig({
   base: "./",
@@ -8,7 +25,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ["@wterm/ghostty"],
   },
-  plugins: [react(), tailwindcss()],
+  plugins: [stripGhosttyPackageSourcemaps(), react(), tailwindcss()],
   worker: {
     format: "es",
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   base: "./",
+  assetsInclude: ["**/*.wasm"],
+  optimizeDeps: {
+    exclude: ["@wterm/ghostty"],
+  },
   plugins: [react(), tailwindcss()],
   worker: {
     format: "es",


### PR DESCRIPTION
## Summary
- Upgrade the embedded WTerm stack to 0.3.0 and switch the terminal renderer to the Ghostty/libghostty WASM core.
- Add explicit container resize observation so terminal cols/rows are recalculated on both shrink and growth, then forwarded to the PTY backend.
- Preserve bottom stickiness during writes and viewport resize only when the user was already near the bottom.

## Details
- Keeps the existing `node-pty` backend and desktop IPC path intact; Ghostty replaces only the frontend WTerm emulation core.
- Excludes `@wterm/ghostty` from Vite dependency prebundling and includes WASM assets so the package-local Ghostty WASM URL remains loadable.
- Shows a lightweight loading state while the Ghostty core initializes and reuses the existing terminal error overlay on load/init failure.

## Validation
- Commit hooks ran lint, web/desktop/electron/scripts typechecks, and the Vitest suite successfully.
- Push hooks ran lint and all typecheck targets successfully.

Closes #159
Refs #83
