### PR TITLE
Add GitOps changed files tree

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@mariozechner/pi-tui": "0.70.6",
         "@mdxeditor/editor": "^3.55.0",
         "@pierre/diffs": "^1.1.0-beta.16",
+        "@pierre/trees": "1.0.0-beta.3",
         "@tanstack/react-pacer": "^0.21.1",
         "@tanstack/react-query": "^5.96.1",
         "@tanstack/react-virtual": "^3.13.23",
@@ -512,6 +513,8 @@
     "@pierre/diffs": ["@pierre/diffs@1.1.15", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-Gj863E+aSpc0H3C4cH0fQTaF/tP9yYfhnilR7/dS72qq8thqNpR3fo3jURHRtRKz6KJJ10anxcurHP7b3ZUQkw=="],
 
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
+
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.3", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -1806,6 +1809,10 @@
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "postject": ["postject@1.0.0-alpha.6", "", { "dependencies": { "commander": "^9.4.0" }, "bin": { "postject": "dist/cli.js" } }, "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A=="],
+
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 

--- a/desktop/app-settings/keys.cts
+++ b/desktop/app-settings/keys.cts
@@ -17,6 +17,7 @@ export const initializeGitOnProjectCreateKey = "initializeGitOnProjectCreate";
 export const gitOpsDefaultModeKey = "gitOpsDefaultMode";
 export const gitDiffBaselineDefaultKey = "gitDiffBaselineDefault";
 export const gitDiffRenderModeDefaultKey = "gitDiffRenderModeDefault";
+export const gitDiffFileTreeDefaultVisibleKey = "gitDiffFileTreeDefaultVisible";
 export const projectDeletionModeKey = "projectDeletionMode";
 export const useAgentsSkillsPathsKey = "useAgentsSkillsPaths";
 export const piTuiTakeoverKey = "piTuiTakeover";

--- a/desktop/app-settings/readers.cts
+++ b/desktop/app-settings/readers.cts
@@ -16,6 +16,7 @@ import {
   gitCommitMessageModelKey,
   gitCommitMessageThinkingLevelKey,
   gitDiffBaselineDefaultKey,
+  gitDiffFileTreeDefaultVisibleKey,
   gitDiffRenderModeDefaultKey,
   gitOpsDefaultModeKey,
   initializeGitOnProjectCreateKey,
@@ -190,6 +191,15 @@ export function loadAppSettings(): AppSettings {
       `,
     )
     .get(gitDiffBaselineDefaultKey) as PreferenceRow | undefined;
+  const gitDiffFileTreeDefaultVisibleRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(gitDiffFileTreeDefaultVisibleKey) as PreferenceRow | undefined;
   const gitDiffRenderModeDefaultRow = db
     .prepare(
       `
@@ -276,6 +286,8 @@ export function loadAppSettings(): AppSettings {
     ) ?? { kind: "head" },
     gitDiffRenderModeDefault:
       parseGitDiffRenderModePreference(gitDiffRenderModeDefaultRow?.valueJson) ?? "stacked",
+    gitDiffFileTreeDefaultVisible:
+      parseBooleanPreference(gitDiffFileTreeDefaultVisibleRow?.valueJson) ?? true,
     projectDeletionMode:
       parseProjectDeletionModePreference(projectDeletionModeRow?.valueJson) ?? "pi-only",
     useAgentsSkillsPaths: parseBooleanPreference(useAgentsSkillsPathsRow?.valueJson) ?? false,

--- a/desktop/app-settings/writers.cts
+++ b/desktop/app-settings/writers.cts
@@ -25,6 +25,7 @@ import {
   gitCommitMessageModelKey,
   gitCommitMessageThinkingLevelKey,
   gitDiffBaselineDefaultKey,
+  gitDiffFileTreeDefaultVisibleKey,
   gitDiffRenderModeDefaultKey,
   gitOpsDefaultModeKey,
   initializeGitOnProjectCreateKey,
@@ -222,6 +223,15 @@ export function setGitDiffRenderModeDefault(mode: ProjectDiffRenderMode) {
   }
 
   writeAppPreference(gitDiffRenderModeDefaultKey, JSON.stringify(mode));
+}
+
+export function setGitDiffFileTreeDefaultVisible(visible: boolean) {
+  if (visible) {
+    deleteAppPreference(gitDiffFileTreeDefaultVisibleKey);
+    return;
+  }
+
+  writeAppPreference(gitDiffFileTreeDefaultVisibleKey, JSON.stringify(false));
 }
 
 export function setProjectDeletionMode(mode: ProjectDeletionMode) {

--- a/desktop/pi-threads/settings-actions.cts
+++ b/desktop/pi-threads/settings-actions.cts
@@ -31,6 +31,7 @@ import {
   setGitCommitMessageModelSelection,
   setGitCommitMessageThinkingLevel,
   setGitDiffBaselineDefault,
+  setGitDiffFileTreeDefaultVisible,
   setGitDiffRenderModeDefault,
   setGitOpsDefaultMode,
   setInitializeGitOnProjectCreate,
@@ -161,6 +162,14 @@ export async function handleSettingsDesktopAction(
     const value = getSettingsProjectDiffBaselineDefault(payload);
     if (value) {
       setGitDiffBaselineDefault(value);
+    }
+    return handledAction();
+  }
+
+  if (key === "gitDiffFileTreeDefaultVisible") {
+    const value = getSettingsBooleanValue(payload);
+    if (value !== null) {
+      setGitDiffFileTreeDefaultVisible(value);
     }
     return handledAction();
   }

--- a/desktop/project-git/worktree-snapshot.cts
+++ b/desktop/project-git/worktree-snapshot.cts
@@ -14,21 +14,33 @@ export type WorktreeSnapshot = {
 
 export type WorktreeStats = Omit<WorktreeSnapshot, "patch">;
 
-function parseShortStat(output: string) {
-  const insertionsMatch = output.match(/(\d+)\s+insertions?\(\+\)/);
-  const deletionsMatch = output.match(/(\d+)\s+deletions?\(-\)/);
+function parseNumStat(output: string) {
+  let fileCount = 0;
+  let insertions = 0;
+  let deletions = 0;
 
-  return {
-    insertions: insertionsMatch ? Number.parseInt(insertionsMatch[1], 10) : 0,
-    deletions: deletionsMatch ? Number.parseInt(deletionsMatch[1], 10) : 0,
-  };
-}
+  for (const line of output.split("\n")) {
+    const trimmedLine = line.trim();
+    if (trimmedLine.length === 0) {
+      continue;
+    }
 
-function countNonEmptyLines(output: string) {
-  return output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean).length;
+    fileCount += 1;
+
+    const [rawInsertions, rawDeletions] = trimmedLine.split("\t");
+    const parsedInsertions = Number.parseInt(rawInsertions ?? "", 10);
+    const parsedDeletions = Number.parseInt(rawDeletions ?? "", 10);
+
+    if (!Number.isNaN(parsedInsertions)) {
+      insertions += parsedInsertions;
+    }
+
+    if (!Number.isNaN(parsedDeletions)) {
+      deletions += parsedDeletions;
+    }
+  }
+
+  return { fileCount, insertions, deletions };
 }
 
 async function withStagedWorktree<T>(
@@ -121,49 +133,27 @@ export async function loadWorktreeStats(
       "--",
     ];
 
-    const [shortStatOutput, diffStatOutput, nameStatusOutput, numStatOutput] = await Promise.all([
-      runGitWithOptions(projectId, diffArguments(["--shortstat"]), {
+    const numStatOutput = await runGitWithOptions(
+      projectId,
+      diffArguments(["--numstat", "--find-renames"]),
+      {
         env: context?.env,
         timeout: 20_000,
         maxBuffer: 1024 * 1024 * 4,
-      }).then(
-        ({ stdout }) => stdout.trim(),
-        () => "",
-      ),
-      runGitWithOptions(projectId, diffArguments(["--stat=200,200", "--find-renames"]), {
-        env: context?.env,
-        timeout: 20_000,
-        maxBuffer: 1024 * 1024 * 4,
-      }).then(
-        ({ stdout }) => stdout.trim(),
-        () => "",
-      ),
-      runGitWithOptions(projectId, diffArguments(["--name-status", "--find-renames"]), {
-        env: context?.env,
-        timeout: 20_000,
-        maxBuffer: 1024 * 1024 * 4,
-      }).then(
-        ({ stdout }) => stdout.trim(),
-        () => "",
-      ),
-      runGitWithOptions(projectId, diffArguments(["--numstat", "--find-renames"]), {
-        env: context?.env,
-        timeout: 20_000,
-        maxBuffer: 1024 * 1024 * 4,
-      }).then(
-        ({ stdout }) => stdout.trim(),
-        () => "",
-      ),
-    ]);
+      },
+    ).then(
+      ({ stdout }) => stdout.trim(),
+      () => "",
+    );
 
-    const shortStat = parseShortStat(shortStatOutput);
+    const numStat = parseNumStat(numStatOutput);
 
     return {
-      fileCount: Math.max(countNonEmptyLines(nameStatusOutput), countNonEmptyLines(numStatOutput)),
-      insertions: shortStat.insertions,
-      deletions: shortStat.deletions,
-      diffStat: diffStatOutput,
-      nameStatus: nameStatusOutput,
+      fileCount: numStat.fileCount,
+      insertions: numStat.insertions,
+      deletions: numStat.deletions,
+      diffStat: "",
+      nameStatus: "",
       numStat: numStatOutput,
     };
   };

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@mariozechner/pi-tui": "0.70.6",
     "@mdxeditor/editor": "^3.55.0",
     "@pierre/diffs": "^1.1.0-beta.16",
+    "@pierre/trees": "1.0.0-beta.3",
     "@tanstack/react-pacer": "^0.21.1",
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-virtual": "^3.13.23",

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -83,6 +83,7 @@ export type DesktopSettingsUpdatePayload =
   | { key: "gitOpsDefaultMode"; value: GitOpsMode }
   | { key: "gitDiffBaselineDefault"; value: ProjectDiffDefaultBaseline }
   | { key: "gitDiffRenderModeDefault"; value: ProjectDiffRenderMode }
+  | { key: "gitDiffFileTreeDefaultVisible"; value: boolean }
   | { key: "projectDeletionMode"; value: ProjectDeletionMode }
   | { key: "useAgentsSkillsPaths"; value: boolean }
   | { key: "piTuiTakeover"; value: boolean };

--- a/shared/desktop-settings-contracts.ts
+++ b/shared/desktop-settings-contracts.ts
@@ -38,6 +38,7 @@ export type AppSettings = {
   gitOpsDefaultMode: GitOpsMode;
   gitDiffBaselineDefault: ProjectDiffDefaultBaseline;
   gitDiffRenderModeDefault: ProjectDiffRenderMode;
+  gitDiffFileTreeDefaultVisible: boolean;
   projectDeletionMode: ProjectDeletionMode;
   useAgentsSkillsPaths: boolean;
   piTuiTakeover: boolean;

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -269,6 +269,7 @@ export function getSettingsKey(payload: DesktopActionPayloadInput) {
     payload.key === "gitOpsDefaultMode" ||
     payload.key === "gitDiffBaselineDefault" ||
     payload.key === "gitDiffRenderModeDefault" ||
+    payload.key === "gitDiffFileTreeDefaultVisible" ||
     payload.key === "projectDeletionMode" ||
     payload.key === "useAgentsSkillsPaths" ||
     payload.key === "piTuiTakeover"

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -382,6 +382,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                   gitOpsDefaultMode: "commit",
                   gitDiffBaselineDefault: { kind: "head" },
                   gitDiffRenderModeDefault: "stacked",
+                  gitDiffFileTreeDefaultVisible: true,
                   projectDeletionMode: "pi-only",
                   useAgentsSkillsPaths: false,
                   piTuiTakeover: false,

--- a/src/app/app-shell/controller-optimistic-updates.ts
+++ b/src/app/app-shell/controller-optimistic-updates.ts
@@ -43,6 +43,7 @@ export function getOptimisticallyUpdatedShellState(
     payload.key !== "gitOpsDefaultMode" &&
     payload.key !== "gitDiffBaselineDefault" &&
     payload.key !== "gitDiffRenderModeDefault" &&
+    payload.key !== "gitDiffFileTreeDefaultVisible" &&
     payload.key !== "projectDeletionMode" &&
     payload.key !== "useAgentsSkillsPaths" &&
     payload.key !== "piTuiTakeover"
@@ -209,6 +210,11 @@ export function getOptimisticallyUpdatedShellState(
       ? payload.value
       : currentState.appSettings.gitDiffRenderModeDefault;
 
+  const nextGitDiffFileTreeDefaultVisible =
+    payload.key === "gitDiffFileTreeDefaultVisible" && typeof payload.value === "boolean"
+      ? payload.value
+      : currentState.appSettings.gitDiffFileTreeDefaultVisible;
+
   const nextUseAgentsSkillsPaths =
     payload.key === "useAgentsSkillsPaths" && typeof payload.value === "boolean"
       ? payload.value
@@ -242,6 +248,7 @@ export function getOptimisticallyUpdatedShellState(
       gitOpsDefaultMode: nextGitOpsDefaultMode,
       gitDiffBaselineDefault: nextGitDiffBaselineDefault,
       gitDiffRenderModeDefault: nextGitDiffRenderModeDefault,
+      gitDiffFileTreeDefaultVisible: nextGitDiffFileTreeDefaultVisible,
       projectDeletionMode: nextProjectDeletionMode,
       useAgentsSkillsPaths: nextUseAgentsSkillsPaths,
       piTuiTakeover: nextPiTuiTakeover,

--- a/src/app/components/workspace/DiffPanel.tsx
+++ b/src/app/components/workspace/DiffPanel.tsx
@@ -11,6 +11,7 @@ type DiffPanelProps = {
   selectedCommentJumpKey: number;
   diffRenderMode: "stacked" | "split";
   layoutMode?: "split" | "overlay" | "main";
+  showFileTree?: boolean;
 };
 
 export function DiffPanel({
@@ -22,6 +23,7 @@ export function DiffPanel({
   selectedCommentJumpKey,
   diffRenderMode,
   layoutMode = "split",
+  showFileTree = true,
 }: DiffPanelProps) {
   return (
     <DiffWorkerPoolProvider>
@@ -34,6 +36,7 @@ export function DiffPanel({
         selectedCommentJumpKey={selectedCommentJumpKey}
         diffRenderMode={diffRenderMode}
         layoutMode={layoutMode}
+        showFileTree={showFileTree}
       />
     </DiffWorkerPoolProvider>
   );

--- a/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
+++ b/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
@@ -118,7 +118,10 @@ export function DiffChangedFilesTree({
   useEffect(() => {
     model.resetPaths(paths, { initialExpandedPaths: paths });
     model.setGitStatus(gitStatus);
-  }, [gitStatus, model, paths]);
+    if (search.value.trim().length > 0) {
+      model.setSearch(search.value);
+    }
+  }, [gitStatus, model, paths, search.value]);
 
   const hasSelection = selectedPaths.length > 0;
   const statusLabel = hasSelection

--- a/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
+++ b/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
@@ -47,6 +47,7 @@ const TREE_UNSAFE_CSS = `
 type DiffChangedFilesTreeProps = {
   files: FileDiffMetadata[];
   selectedPaths: readonly string[];
+  focusedFileCount: number;
   onSelectedPathsChange: (paths: readonly string[]) => void;
 };
 
@@ -77,6 +78,7 @@ const treeHostStyle = {
 export function DiffChangedFilesTree({
   files,
   selectedPaths,
+  focusedFileCount,
   onSelectedPathsChange,
 }: DiffChangedFilesTreeProps) {
   const paths = useMemo(() => files.map(resolveFileDiffPath).filter(Boolean), [files]);
@@ -114,18 +116,24 @@ export function DiffChangedFilesTree({
   });
 
   const search = useFileTreeSearch(model);
+  const searchValueRef = useRef(search.value);
+  searchValueRef.current = search.value;
 
   useEffect(() => {
     model.resetPaths(paths, { initialExpandedPaths: paths });
     model.setGitStatus(gitStatus);
-    if (search.value.trim().length > 0) {
-      model.setSearch(search.value);
+    if (searchValueRef.current.trim().length > 0) {
+      model.setSearch(searchValueRef.current);
     }
-  }, [gitStatus, model, paths, search.value]);
+  }, [gitStatus, model, paths]);
+
+  useEffect(() => {
+    model.setSearch(search.value);
+  }, [model, search.value]);
 
   const hasSelection = selectedPaths.length > 0;
   const statusLabel = hasSelection
-    ? `${selectedPaths.length}/${paths.length} selected`
+    ? `${focusedFileCount}/${paths.length} selected`
     : `${paths.length} changed`;
   const clearSelection = () => {
     for (const path of model.getSelectedPaths()) {

--- a/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
+++ b/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
@@ -26,7 +26,7 @@ const TREE_UNSAFE_CSS = `
     --trees-item-margin-x-override: 0px;
     --trees-item-padding-x-override: 0.625rem;
     --trees-scrollbar-thumb-override: rgba(169, 178, 215, 0.24);
-    --trees-scrollbar-gutter-override: 0px;
+    --trees-scrollbar-gutter-override: 6px;
     background: transparent;
     font-family: var(--font-sans, "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif);
   }
@@ -70,7 +70,7 @@ const treeHostStyle = {
   "--trees-level-gap-override": "0px",
   "--trees-item-margin-x-override": "0px",
   "--trees-item-padding-x-override": "0.625rem",
-  "--trees-scrollbar-gutter-override": "0px",
+  "--trees-scrollbar-gutter-override": "6px",
   backgroundColor: "var(--workspace)",
 } as CSSProperties;
 
@@ -168,7 +168,7 @@ export function DiffChangedFilesTree({
         </label>
         <FileTree
           model={model}
-          className={cn("min-h-0 flex-1")}
+          className={cn("-mr-[6px] min-h-0 w-[calc(100%+6px)] flex-1")}
           style={treeHostStyle}
           aria-label="Changed files"
         />

--- a/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
+++ b/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
@@ -1,0 +1,178 @@
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import type { GitStatusEntry } from "@pierre/trees";
+import { FileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
+import { FilterX, Search } from "lucide-react";
+import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import { cn } from "../../../utils/cn";
+import { getFileChangeCounts, resolveFileDiffPath } from "./diff-panel-content.helpers";
+
+const TREE_UNSAFE_CSS = `
+  :host {
+    color-scheme: dark;
+    --trees-fg-override: var(--text);
+    --trees-muted-fg-override: var(--muted);
+    --trees-bg-override: var(--workspace);
+    --trees-bg-muted-override: rgba(169, 178, 215, 0.075);
+    --trees-border-color-override: rgba(169, 178, 215, 0.11);
+    --trees-search-bg-override: rgba(10, 12, 18, 0.44);
+    --trees-search-fg-override: var(--text);
+    --trees-selected-bg-override: rgba(168, 177, 255, 0.16);
+    --trees-selected-fg-override: var(--text);
+    --trees-focused-bg-override: rgba(169, 178, 215, 0.08);
+    --trees-hover-bg-override: rgba(169, 178, 215, 0.08);
+    --trees-border-radius-override: 9px;
+    --trees-padding-inline-override: 0px;
+    --trees-level-gap-override: 0px;
+    --trees-item-margin-x-override: 0px;
+    --trees-item-padding-x-override: 0.625rem;
+    --trees-scrollbar-thumb-override: rgba(169, 178, 215, 0.24);
+    --trees-scrollbar-gutter-override: 0px;
+    background: transparent;
+    font-family: var(--font-sans, "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif);
+  }
+  [data-file-tree-virtualized-list='true'],
+  [data-file-tree-sticky-overlay-content='true'] {
+    background: transparent;
+  }
+  button[data-type='item'] {
+    border-radius: 10px;
+    min-width: 0;
+  }
+  [data-row-decoration] {
+    font-variant-numeric: tabular-nums;
+    color: var(--muted);
+  }
+`;
+
+type DiffChangedFilesTreeProps = {
+  files: FileDiffMetadata[];
+  selectedPaths: readonly string[];
+  onSelectedPathsChange: (paths: readonly string[]) => void;
+};
+
+function getGitStatus(file: FileDiffMetadata): GitStatusEntry["status"] {
+  switch (file.type) {
+    case "new":
+      return "added";
+    case "deleted":
+      return "deleted";
+    case "rename-pure":
+    case "rename-changed":
+      return "renamed";
+    default:
+      return "modified";
+  }
+}
+
+const treeHostStyle = {
+  "--trees-bg-override": "var(--workspace)",
+  "--trees-padding-inline-override": "0px",
+  "--trees-level-gap-override": "0px",
+  "--trees-item-margin-x-override": "0px",
+  "--trees-item-padding-x-override": "0.625rem",
+  "--trees-scrollbar-gutter-override": "0px",
+  backgroundColor: "var(--workspace)",
+} as CSSProperties;
+
+export function DiffChangedFilesTree({
+  files,
+  selectedPaths,
+  onSelectedPathsChange,
+}: DiffChangedFilesTreeProps) {
+  const paths = useMemo(() => files.map(resolveFileDiffPath).filter(Boolean), [files]);
+  const gitStatus = useMemo<GitStatusEntry[]>(
+    () => files.map((file) => ({ path: resolveFileDiffPath(file), status: getGitStatus(file) })),
+    [files],
+  );
+  const fileStatsByPath = useMemo(() => {
+    const stats = new Map<string, string>();
+    for (const file of files) {
+      const { additions, deletions } = getFileChangeCounts(file);
+      stats.set(resolveFileDiffPath(file), `+${additions} −${deletions}`);
+    }
+    return stats;
+  }, [files]);
+
+  const fileStatsByPathRef = useRef(fileStatsByPath);
+  fileStatsByPathRef.current = fileStatsByPath;
+
+  const { model } = useFileTree({
+    density: "compact",
+    fileTreeSearchMode: "hide-non-matches",
+    flattenEmptyDirectories: true,
+    gitStatus,
+    initialExpansion: "open",
+    initialSelectedPaths: selectedPaths,
+    onSelectionChange: onSelectedPathsChange,
+    paths,
+    search: false,
+    unsafeCSS: TREE_UNSAFE_CSS,
+    renderRowDecoration: ({ item }) => {
+      const text = fileStatsByPathRef.current.get(item.path);
+      return text ? { text, title: text } : null;
+    },
+  });
+
+  const search = useFileTreeSearch(model);
+
+  useEffect(() => {
+    model.resetPaths(paths, { initialExpandedPaths: paths });
+    model.setGitStatus(gitStatus);
+  }, [gitStatus, model, paths]);
+
+  const hasSelection = selectedPaths.length > 0;
+  const statusLabel = hasSelection
+    ? `${selectedPaths.length}/${paths.length} selected`
+    : `${paths.length} changed`;
+  const clearSelection = () => {
+    for (const path of model.getSelectedPaths()) {
+      model.getItem(path)?.deselect();
+    }
+    onSelectedPathsChange([]);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 w-[min(28rem,calc(100%-2.5rem))] shrink-0 flex-col border-l border-[color:var(--border)] bg-[color:var(--workspace)]">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-[color:var(--border)] px-2.5">
+        <div className="min-w-0 flex-1 truncate pl-2.5 text-[12px] font-medium text-[color:var(--text)]">
+          Changed
+        </div>
+        <div className="shrink-0 text-[11px] font-medium tabular-nums text-[color:var(--muted)]">
+          {statusLabel}
+        </div>
+        {hasSelection ? (
+          <button
+            type="button"
+            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[color:var(--muted)] transition hover:bg-[rgba(169,178,215,0.08)] hover:text-[color:var(--text)]"
+            onClick={clearSelection}
+            aria-label="Clear file focus"
+            data-tooltip="Clear file focus"
+          >
+            <FilterX size={13} />
+          </button>
+        ) : null}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col bg-[color:var(--workspace)] px-2.5 pt-2 pb-2">
+        <label
+          className="flex min-h-8 shrink-0 items-center gap-2 rounded-[10px] border border-transparent bg-transparent px-2.5 text-[13px] text-[color:var(--muted)] transition-colors hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)] focus-within:bg-[rgba(255,255,255,0.05)] focus-within:text-[color:var(--text)]"
+          data-active={search.value.trim().length > 0 ? "true" : "false"}
+        >
+          <Search size={14} className="shrink-0 text-[color:var(--muted)]" />
+          <input
+            value={search.value}
+            onChange={(event) => search.setValue(event.target.value)}
+            placeholder="Search"
+            className="min-w-0 flex-1 bg-transparent p-0 text-[13px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
+            aria-label="Search changed files"
+          />
+        </label>
+        <FileTree
+          model={model}
+          className={cn("min-h-0 flex-1")}
+          style={treeHostStyle}
+          aria-label="Changed files"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
+++ b/src/app/components/workspace/diff/DiffChangedFilesTree.tsx
@@ -132,7 +132,7 @@ export function DiffChangedFilesTree({
   };
 
   return (
-    <div className="flex h-full min-h-0 w-[min(28rem,calc(100%-2.5rem))] shrink-0 flex-col border-l border-[color:var(--border)] bg-[color:var(--workspace)]">
+    <div className="flex h-full min-h-0 w-full flex-col border-l border-[color:var(--border)] bg-[color:var(--workspace)]">
       <div className="flex h-10 shrink-0 items-center gap-2 border-b border-[color:var(--border)] px-2.5">
         <div className="min-w-0 flex-1 truncate pl-2.5 text-[12px] font-medium text-[color:var(--text)]">
           Changed

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -268,6 +268,7 @@ export function DiffPanelContent({
                     <DiffChangedFilesTree
                       files={renderableFiles}
                       selectedPaths={focusedFilePaths}
+                      focusedFileCount={hasFocusedFiles ? visibleRenderableFiles.length : 0}
                       onSelectedPathsChange={setFocusedFilePaths}
                     />
                   ) : null}

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -8,6 +8,7 @@ import { cn } from "../../../utils/cn";
 import { getDiffBaselinePrefix, getResolvedDiffBaselineLabel } from "../composer/diff-baseline";
 import { DiffCommentAnnotationCard } from "./DiffCommentAnnotationCard";
 import { DiffPanelEmptyState } from "./DiffPanelEmptyState";
+import { DiffChangedFilesTree } from "./DiffChangedFilesTree";
 import { DiffPanelFileList } from "./DiffPanelFileList";
 import {
   DIFF_FILE_ESTIMATED_FILE_GAP,
@@ -17,6 +18,7 @@ import {
   estimateFileDiffHeight,
   getRenderablePatch,
   orderRenderableFiles,
+  resolveFileDiffPath,
 } from "./diff-panel-content.helpers";
 import { useDiffCommentDrafting } from "./useDiffCommentDrafting";
 import { useDiffPanelCommentState } from "./useDiffPanelCommentState";
@@ -44,6 +46,7 @@ export function DiffPanelContent({
   layoutMode = "split",
 }: DiffPanelContentProps) {
   const [collapsedFiles, setCollapsedFiles] = useState<Record<string, boolean>>({});
+  const [focusedFilePaths, setFocusedFilePaths] = useState<readonly string[]>([]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const draftCardRef = useRef<HTMLDivElement | null>(null);
   const { diff, isLoading, error } = useDesktopDiff(projectId, baseline, isGitRepo);
@@ -62,6 +65,26 @@ export function DiffPanelContent({
         : [],
     [renderablePatch],
   );
+  const selectedFilePathSet = useMemo(() => new Set(focusedFilePaths), [focusedFilePaths]);
+  const hasFocusedFiles = focusedFilePaths.length > 0;
+  const visibleRenderableFiles = useMemo(() => {
+    if (!hasFocusedFiles) {
+      return renderableFiles;
+    }
+
+    const isVisiblePath = (filePath: string) =>
+      selectedFilePathSet.has(filePath) ||
+      focusedFilePaths.some((selectedPath) => filePath.startsWith(`${selectedPath}/`));
+    const selectedFileStillVisible = selectedFilePath ? isVisiblePath(selectedFilePath) : true;
+
+    return renderableFiles.filter((fileDiff) => {
+      const filePath = resolveFileDiffPath(fileDiff);
+      return (
+        isVisiblePath(filePath) || (!selectedFileStillVisible && filePath === selectedFilePath)
+      );
+    });
+  }, [focusedFilePaths, hasFocusedFiles, renderableFiles, selectedFilePath, selectedFilePathSet]);
+
   const {
     annotationCountByFile,
     commentAnnotationsByFile,
@@ -94,7 +117,7 @@ export function DiffPanelContent({
 
   const estimatedFileHeights = useMemo(
     () =>
-      renderableFiles.map((fileDiff) => {
+      visibleRenderableFiles.map((fileDiff) => {
         const fileKey = buildFileDiffRenderKey(fileDiff);
         return estimateFileDiffHeight({
           fileDiff,
@@ -103,16 +126,16 @@ export function DiffPanelContent({
           annotationCount: annotationCountByFile.get(fileKey) ?? 0,
         });
       }),
-    [annotationCountByFile, collapsedFiles, diffRenderMode, renderableFiles],
+    [annotationCountByFile, collapsedFiles, diffRenderMode, visibleRenderableFiles],
   );
 
   const getVirtualItemKey = useCallback(
-    (index: number) => buildFileDiffRenderKey(renderableFiles[index] as FileDiffMetadata),
-    [renderableFiles],
+    (index: number) => buildFileDiffRenderKey(visibleRenderableFiles[index] as FileDiffMetadata),
+    [visibleRenderableFiles],
   );
 
   const fileListVirtualizer = useVirtualizer({
-    count: renderableFiles.length,
+    count: visibleRenderableFiles.length,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: (index) =>
       estimatedFileHeights[index] ??
@@ -145,7 +168,7 @@ export function DiffPanelContent({
     draftCardRef,
     draftTarget,
     fileListVirtualizer,
-    renderableFiles,
+    renderableFiles: visibleRenderableFiles,
     savedComments,
     scrollContainerRef,
     selectedCommentId,
@@ -183,26 +206,33 @@ export function DiffPanelContent({
                 </div>
               </div>
             ) : renderablePatch.kind === "files" ? (
-              <div
-                ref={scrollContainerRef}
-                className="h-full min-h-0 overflow-auto [overflow-anchor:none]"
-              >
-                <DiffPanelFileList
-                  collapsedFiles={collapsedFiles}
-                  commentAnnotationsByFile={commentAnnotationsByFile}
-                  diffRenderMode={diffRenderMode}
-                  draftSelectedLines={draftSelectedLines}
-                  getFileInteractionHandlers={getFileInteractionHandlers}
-                  getSelectedLinesForFile={getSelectedLinesForFile}
-                  handleFilePointerDownCapture={handleFilePointerDownCapture}
-                  measureElement={fileListVirtualizer.measureElement}
-                  onOpenDraftComment={openDraftComment}
-                  onToggleFileCollapsed={toggleFileCollapsed}
-                  projectId={projectId}
-                  renderCommentAnnotation={renderCommentAnnotation}
-                  renderableFiles={renderableFiles}
-                  totalSize={fileListVirtualizer.getTotalSize()}
-                  virtualItems={fileListVirtualizer.getVirtualItems()}
+              <div className="flex h-full min-h-0">
+                <div
+                  ref={scrollContainerRef}
+                  className="min-h-0 min-w-0 flex-1 overflow-auto [overflow-anchor:none]"
+                >
+                  <DiffPanelFileList
+                    collapsedFiles={collapsedFiles}
+                    commentAnnotationsByFile={commentAnnotationsByFile}
+                    diffRenderMode={diffRenderMode}
+                    draftSelectedLines={draftSelectedLines}
+                    getFileInteractionHandlers={getFileInteractionHandlers}
+                    getSelectedLinesForFile={getSelectedLinesForFile}
+                    handleFilePointerDownCapture={handleFilePointerDownCapture}
+                    measureElement={fileListVirtualizer.measureElement}
+                    onOpenDraftComment={openDraftComment}
+                    onToggleFileCollapsed={toggleFileCollapsed}
+                    projectId={projectId}
+                    renderCommentAnnotation={renderCommentAnnotation}
+                    renderableFiles={visibleRenderableFiles}
+                    totalSize={fileListVirtualizer.getTotalSize()}
+                    virtualItems={fileListVirtualizer.getVirtualItems()}
+                  />
+                </div>
+                <DiffChangedFilesTree
+                  files={renderableFiles}
+                  selectedPaths={focusedFilePaths}
+                  onSelectedPathsChange={setFocusedFilePaths}
                 />
               </div>
             ) : (

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -33,6 +33,7 @@ type DiffPanelContentProps = {
   selectedCommentJumpKey: number;
   diffRenderMode: "stacked" | "split";
   layoutMode?: "split" | "overlay" | "main";
+  showFileTree?: boolean;
 };
 
 export function DiffPanelContent({
@@ -44,6 +45,7 @@ export function DiffPanelContent({
   selectedCommentJumpKey,
   diffRenderMode,
   layoutMode = "split",
+  showFileTree = true,
 }: DiffPanelContentProps) {
   const [collapsedFiles, setCollapsedFiles] = useState<Record<string, boolean>>({});
   const [focusedFilePaths, setFocusedFilePaths] = useState<readonly string[]>([]);
@@ -229,11 +231,20 @@ export function DiffPanelContent({
                     virtualItems={fileListVirtualizer.getVirtualItems()}
                   />
                 </div>
-                <DiffChangedFilesTree
-                  files={renderableFiles}
-                  selectedPaths={focusedFilePaths}
-                  onSelectedPathsChange={setFocusedFilePaths}
-                />
+                <div
+                  className="min-h-0 shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-out"
+                  style={{
+                    width: showFileTree ? "min(28rem, calc(100% - 2.5rem))" : 0,
+                    opacity: showFileTree ? 1 : 0,
+                  }}
+                  aria-hidden={!showFileTree}
+                >
+                  <DiffChangedFilesTree
+                    files={renderableFiles}
+                    selectedPaths={focusedFilePaths}
+                    onSelectedPathsChange={setFocusedFilePaths}
+                  />
+                </div>
               </div>
             ) : (
               <div className="h-full overflow-auto p-3">

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -68,8 +68,15 @@ export function DiffPanelContent({
         : [],
     [renderablePatch],
   );
-  const selectedFilePathSet = useMemo(() => new Set(focusedFilePaths), [focusedFilePaths]);
-  const hasFocusedFiles = focusedFilePaths.length > 0;
+  const normalizedFocusedFilePaths = useMemo(
+    () => focusedFilePaths.map((filePath) => filePath.replace(/\/+$/, "")),
+    [focusedFilePaths],
+  );
+  const selectedFilePathSet = useMemo(
+    () => new Set(normalizedFocusedFilePaths),
+    [normalizedFocusedFilePaths],
+  );
+  const hasFocusedFiles = showFileTree && normalizedFocusedFilePaths.length > 0;
   const visibleRenderableFiles = useMemo(() => {
     if (!hasFocusedFiles) {
       return renderableFiles;
@@ -77,7 +84,7 @@ export function DiffPanelContent({
 
     const isVisiblePath = (filePath: string) =>
       selectedFilePathSet.has(filePath) ||
-      focusedFilePaths.some((selectedPath) => filePath.startsWith(`${selectedPath}/`));
+      normalizedFocusedFilePaths.some((selectedPath) => filePath.startsWith(`${selectedPath}/`));
     const selectedFileStillVisible = selectedFilePath ? isVisiblePath(selectedFilePath) : true;
 
     return renderableFiles.filter((fileDiff) => {
@@ -86,7 +93,13 @@ export function DiffPanelContent({
         isVisiblePath(filePath) || (!selectedFileStillVisible && filePath === selectedFilePath)
       );
     });
-  }, [focusedFilePaths, hasFocusedFiles, renderableFiles, selectedFilePath, selectedFilePathSet]);
+  }, [
+    hasFocusedFiles,
+    normalizedFocusedFilePaths,
+    renderableFiles,
+    selectedFilePath,
+    selectedFilePathSet,
+  ]);
 
   const {
     annotationCountByFile,
@@ -118,6 +131,7 @@ export function DiffPanelContent({
       return;
     }
 
+    setFocusedFilePaths([]);
     const timeout = window.setTimeout(() => setRenderFileTree(false), 200);
     return () => window.clearTimeout(timeout);
   }, [showFileTree]);

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -49,6 +49,7 @@ export function DiffPanelContent({
 }: DiffPanelContentProps) {
   const [collapsedFiles, setCollapsedFiles] = useState<Record<string, boolean>>({});
   const [focusedFilePaths, setFocusedFilePaths] = useState<readonly string[]>([]);
+  const [renderFileTree, setRenderFileTree] = useState(showFileTree);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const draftCardRef = useRef<HTMLDivElement | null>(null);
   const { diff, isLoading, error } = useDesktopDiff(projectId, baseline, isGitRepo);
@@ -110,6 +111,16 @@ export function DiffPanelContent({
     draftComment,
     setDraftComment,
   });
+
+  useEffect(() => {
+    if (showFileTree) {
+      setRenderFileTree(true);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setRenderFileTree(false), 200);
+    return () => window.clearTimeout(timeout);
+  }, [showFileTree]);
 
   useEffect(() => {
     if (!hasCommentContext) {
@@ -239,11 +250,13 @@ export function DiffPanelContent({
                   }}
                   aria-hidden={!showFileTree}
                 >
-                  <DiffChangedFilesTree
-                    files={renderableFiles}
-                    selectedPaths={focusedFilePaths}
-                    onSelectedPathsChange={setFocusedFilePaths}
-                  />
+                  {renderFileTree ? (
+                    <DiffChangedFilesTree
+                      files={renderableFiles}
+                      selectedPaths={focusedFilePaths}
+                      onSelectedPathsChange={setFocusedFilePaths}
+                    />
+                  ) : null}
                 </div>
               </div>
             ) : (

--- a/src/app/components/workspace/diff/DiffPanelFileList.tsx
+++ b/src/app/components/workspace/diff/DiffPanelFileList.tsx
@@ -198,6 +198,7 @@ export function DiffPanelFileList({
                 options={{
                   diffStyle: diffRenderMode === "split" ? "split" : "unified",
                   lineDiffType: "none",
+                  overflow: "wrap",
                   theme: resolveDiffThemeName("dark"),
                   themeType: "dark",
                   unsafeCSS: DIFF_PANEL_UNSAFE_CSS,

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -268,7 +268,12 @@ export function CodeWorkspaceView({
         >
           <div className="pointer-events-auto grid gap-2.5">
             <div className="grid grid-cols-[minmax(0,1fr)_800px_minmax(0,1fr)] items-end gap-3">
-              <div className="mb-1.5 min-w-0 self-end opacity-0 xl:opacity-100">
+              <div
+                className={cn(
+                  "mb-1.5 min-w-0 self-end",
+                  state.activeView === "gitops" ? "opacity-100" : "opacity-0 xl:opacity-100",
+                )}
+              >
                 {(state.activeView === "thread" || state.activeView === "gitops") &&
                 !state.takeoverVisible ? (
                   <button
@@ -410,7 +415,12 @@ export function CodeWorkspaceView({
                   </div>
                 )}
               </div>
-              <div className="mb-1.5 min-w-0 self-end opacity-0 xl:opacity-100">
+              <div
+                className={cn(
+                  "mb-1.5 min-w-0 self-end",
+                  state.activeView === "gitops" ? "opacity-100" : "opacity-0 xl:opacity-100",
+                )}
+              >
                 {state.activeView === "gitops" && !state.takeoverVisible ? (
                   <button
                     type="button"

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { FolderGit2, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import type { AppShellController } from "../../app-shell/useAppShellController";
 import { defaultPiSettings } from "../../../../shared/default-pi-settings";
 import { Composer } from "../../components/workspace/Composer";
@@ -60,6 +60,9 @@ export function CodeWorkspaceView({
   onToggleSidebar,
 }: CodeWorkspaceViewProps) {
   const [composerPromptResetKey, setComposerPromptResetKey] = useState(0);
+  const [gitOpsFileTreeVisibilityByThread, setGitOpsFileTreeVisibilityByThread] = useState<
+    Record<string, boolean>
+  >({});
   const [composerLayoutVersion, setComposerLayoutVersion] = useState(0);
   const footerRef = useRef<HTMLElement>(null);
   const mainViewRef = useRef<HTMLElement>(null);
@@ -80,6 +83,17 @@ export function CodeWorkspaceView({
   const showThreadFooter = state.activeView === "thread";
   const showDiffInMainView = state.activeView === "gitops";
   const showDesktopTerminalDrawer = state.activeView === "thread" && terminalDrawerVisible;
+  const gitOpsFileTreeStateKey = `${composerProjectId}:${terminalSessionPath ?? "project"}`;
+  const gitOpsFileTreeVisible =
+    gitOpsFileTreeVisibilityByThread[gitOpsFileTreeStateKey] ??
+    shellState?.appSettings.gitDiffFileTreeDefaultVisible ??
+    true;
+  const toggleGitOpsFileTree = () => {
+    setGitOpsFileTreeVisibilityByThread((current) => ({
+      ...current,
+      [gitOpsFileTreeStateKey]: !(current[gitOpsFileTreeStateKey] ?? gitOpsFileTreeVisible),
+    }));
+  };
   const { error: diffLoadError } = useDesktopDiff(
     composerProjectId,
     diffBaseline,
@@ -178,6 +192,7 @@ export function CodeWorkspaceView({
                 selectedCommentJumpKey={selectedDiffCommentJumpKey}
                 diffRenderMode={diffRenderMode}
                 layoutMode="main"
+                showFileTree={gitOpsFileTreeVisible}
               />
             ) : (
               <CodeWorkspaceMainView
@@ -203,6 +218,7 @@ export function CodeWorkspaceView({
                     gitOpsDefaultMode: "commit",
                     gitDiffBaselineDefault: { kind: "head" },
                     gitDiffRenderModeDefault: "stacked",
+                    gitDiffFileTreeDefaultVisible: true,
                     projectDeletionMode: "pi-only",
                     useAgentsSkillsPaths: false,
                     piTuiTakeover: false,
@@ -253,7 +269,8 @@ export function CodeWorkspaceView({
           <div className="pointer-events-auto grid gap-2.5">
             <div className="grid grid-cols-[minmax(0,1fr)_800px_minmax(0,1fr)] items-end gap-3">
               <div className="mb-1.5 min-w-0 self-end opacity-0 xl:opacity-100">
-                {state.activeView === "thread" && !state.takeoverVisible ? (
+                {(state.activeView === "thread" || state.activeView === "gitops") &&
+                !state.takeoverVisible ? (
                   <button
                     type="button"
                     className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] opacity-70 transition hover:bg-[rgba(169,178,215,0.1)] hover:text-[color:var(--text)] hover:opacity-100"
@@ -298,6 +315,7 @@ export function CodeWorkspaceView({
                           gitOpsDefaultMode: "commit",
                           gitDiffBaselineDefault: { kind: "head" },
                           gitDiffRenderModeDefault: "stacked",
+                          gitDiffFileTreeDefaultVisible: true,
                           projectDeletionMode: "pi-only",
                           useAgentsSkillsPaths: false,
                           piTuiTakeover: false,
@@ -393,9 +411,21 @@ export function CodeWorkspaceView({
                 )}
               </div>
               <div className="mb-1.5 min-w-0 self-end opacity-0 xl:opacity-100">
-                {state.activeView === "thread" &&
-                !state.takeoverVisible &&
-                !showDesktopTerminalDrawer ? (
+                {state.activeView === "gitops" && !state.takeoverVisible ? (
+                  <button
+                    type="button"
+                    className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] opacity-70 transition hover:bg-[rgba(169,178,215,0.1)] hover:text-[color:var(--text)] hover:opacity-100"
+                    onClick={toggleGitOpsFileTree}
+                    aria-label={gitOpsFileTreeVisible ? "Hide changed files" : "Show changed files"}
+                    data-tooltip={
+                      gitOpsFileTreeVisible ? "Hide changed files" : "Show changed files"
+                    }
+                  >
+                    <FolderGit2 size={15} />
+                  </button>
+                ) : state.activeView === "thread" &&
+                  !state.takeoverVisible &&
+                  !showDesktopTerminalDrawer ? (
                   <DesktopComposerStatus
                     contextUsage={activeComposerState?.contextUsage ?? null}
                     model={activeComposerState?.currentModel ?? null}

--- a/src/app/views/settings/settingsDescriptorProjects.tsx
+++ b/src/app/views/settings/settingsDescriptorProjects.tsx
@@ -154,6 +154,23 @@ export function buildProjectsSettingsDescriptors({
         </div>
       ),
     },
+
+    {
+      id: "projects.git-diff-file-tree-default",
+      category: "projects",
+      title: "Diff file tree",
+      description: "Default visibility for the GitOps changed-file tree.",
+      keywords: "git diff file tree changed files sidebar default",
+      render: () => (
+        <ToggleBox
+          checked={appSettings.gitDiffFileTreeDefaultVisible}
+          label="Show file tree"
+          onClick={() =>
+            controller.setGitDiffFileTreeDefaultVisible(!appSettings.gitDiffFileTreeDefaultVisible)
+          }
+        />
+      ),
+    },
     {
       id: "projects.deletion-mode",
       category: "projects",

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -246,6 +246,11 @@ export function useSettingsController({
         key: "gitDiffRenderModeDefault",
         value,
       }),
+    setGitDiffFileTreeDefaultVisible: (value: AppSettings["gitDiffFileTreeDefaultVisible"]) =>
+      void onAction("settings.update", {
+        key: "gitDiffFileTreeDefaultVisible",
+        value,
+      }),
     updatePiSetting: <Key extends keyof PiSettings>(key: Key, value: PiSettings[Key]) =>
       void onAction("pi-settings.update", {
         piSettingsKey: key,


### PR DESCRIPTION
## Summary
- Adds a GitOps changed-files tree powered by `@pierre/trees` on the RHS of the diff view.
- Supports file/folder selection to focus the diff to selected paths, with search and git status metadata.
- Adds GitOps controls to hide/show both the main sidebar and the changed-files tree.
- Adds a global project setting for the default GitOps file tree visibility.
- Enables wrapped diff lines and unmounts the hidden file tree after its close animation to avoid background work.

## Details
- File tree visibility is kept in app React state per project/session; only the global default is persisted in app settings.
- The RHS tree animates with the same width/opacity pattern as the main sidebar.
- The tree uses terminal drawer width and keeps its scrollbar visually outside the content alignment.
- Directory selections normalize trailing slashes before filtering diff files.

## Validation
- Pre-commit/pre-push hooks ran typechecks and tests successfully during commits/push.
- `vitest run`: 11 files / 40 tests passing via hooks.

Refs #171
