### PR TITLE
Improve large model picker menus

### DIFF
--- a/src/app/components/workspace/composer/ComposerModelPopover.tsx
+++ b/src/app/components/workspace/composer/ComposerModelPopover.tsx
@@ -1,4 +1,5 @@
-import { type RefObject, useEffect, useMemo, useState } from "react";
+import { Check, Search } from "lucide-react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import type { ComposerModel, ComposerThinkingLevel } from "../../../desktop/types";
 import { menuOptionClass, popoverPanelClass, toolbarButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
@@ -41,7 +42,7 @@ function TriggerButton({
       type="button"
       className={cn(
         toolbarButtonClass,
-        "grid w-52 gap-0.5 rounded-xl px-2.5 py-2 text-left hover:bg-[rgba(255,255,255,0.045)]",
+        "grid w-full gap-0.5 rounded-xl px-2.5 py-2 text-left hover:bg-[rgba(255,255,255,0.045)]",
         active && "bg-[rgba(255,255,255,0.05)] text-[color:var(--text)]",
       )}
       onClick={onClick}
@@ -54,7 +55,10 @@ function TriggerButton({
 
 function MenuList({ items }: { items: MenuOption[] }) {
   return (
-    <div className={cn("-mx-1.5 -mt-1.5 pr-0", items.length > 10 && "max-h-72 overflow-y-auto")}>
+    <div
+      role="menu"
+      className={cn("-mx-1.5 -mt-1.5 pr-0", items.length > 10 && "max-h-72 overflow-y-auto")}
+    >
       <div className="grid min-w-0 pl-1 pt-1.5 pr-0 pb-2.5">
         {items.map((item) => (
           <button
@@ -64,11 +68,14 @@ function MenuList({ items }: { items: MenuOption[] }) {
             aria-checked={item.selected}
             className={cn(
               menuOptionClass,
-              "mr-1 grid-cols-[minmax(0,1fr)] text-[color:var(--text)]",
+              "mr-1 text-[color:var(--text)]",
               item.selected && "bg-[rgba(255,255,255,0.06)]",
             )}
             onClick={item.onSelect}
           >
+            <span className="inline-flex items-center justify-center text-[color:var(--accent)]">
+              {item.selected ? <Check size={13} /> : null}
+            </span>
             <span className="min-w-0">
               <span className="block truncate">{item.label}</span>
               {item.description ? (
@@ -109,6 +116,8 @@ export function ComposerModelPopover({
 
   const [openMenu, setOpenMenu] = useState<NestedMenu>(null);
   const [selectedProvider, setSelectedProvider] = useState(currentModel?.provider ?? "");
+  const [modelSearch, setModelSearch] = useState("");
+  const modelSearchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (currentModel?.provider) {
@@ -123,6 +132,17 @@ export function ComposerModelPopover({
     () => availableModels.filter((model) => model.provider === selectedProvider),
     [availableModels, selectedProvider],
   );
+
+  const normalizedModelSearch = modelSearch.trim().toLowerCase();
+  const visibleModelsForProvider = useMemo(() => {
+    if (!normalizedModelSearch) {
+      return modelsForProvider;
+    }
+
+    return modelsForProvider.filter((model) =>
+      `${model.name} ${model.provider} ${model.id}`.toLowerCase().includes(normalizedModelSearch),
+    );
+  }, [modelsForProvider, normalizedModelSearch]);
 
   const currentModelForSelectedProvider =
     currentModel?.provider === selectedProvider ? currentModel : null;
@@ -140,9 +160,10 @@ export function ComposerModelPopover({
     }
 
     if (openMenu === "model") {
-      return modelsForProvider.map((availableModel) => ({
+      return visibleModelsForProvider.map((availableModel) => ({
         id: `${availableModel.provider}/${availableModel.id}`,
         label: availableModel.name,
+        description: `${availableModel.provider}/${availableModel.id}`,
         selected:
           currentModel?.provider === availableModel.provider &&
           currentModel.id === availableModel.id,
@@ -170,27 +191,55 @@ export function ComposerModelPopover({
     currentModel?.id,
     currentModel?.provider,
     currentThinkingLevel,
-    modelsForProvider,
     onSelectModel,
     onSelectThinkingLevel,
     openMenu,
     providers,
     selectedProvider,
     thinkingLevelLabels,
+    visibleModelsForProvider,
   ]);
+
+  const showModelSearch = openMenu === "model" && modelsForProvider.length > 12;
+
+  useEffect(() => {
+    if (showModelSearch) {
+      modelSearchRef.current?.focus();
+    }
+  }, [showModelSearch]);
 
   return (
     <SurfacePanel
       ref={panelRef}
       id="composer-model-menu"
-      role="menu"
-      className={`absolute bottom-[calc(100%+8px)] left-0 z-[60] grid w-52 max-w-[calc(100vw-2rem)] rounded-2xl border-[color:var(--border-strong)] p-1.5 shadow-[0_18px_40px_rgba(0,0,0,0.28)] ${popoverPanelClass}`}
+      className={cn(
+        "absolute bottom-[calc(100%+8px)] left-0 z-[60] grid w-52 max-w-[calc(100vw-2rem)] overflow-x-hidden rounded-2xl border-[color:var(--border-strong)] p-1.5 shadow-[0_18px_40px_rgba(0,0,0,0.28)]",
+        popoverPanelClass,
+      )}
     >
+      {showModelSearch ? (
+        <label className="relative mb-1 block">
+          <Search
+            size={13}
+            className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-[color:var(--muted)]"
+          />
+          <input
+            ref={modelSearchRef}
+            value={modelSearch}
+            onChange={(event) => setModelSearch(event.currentTarget.value)}
+            className="h-8 w-full rounded-lg border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.055)] px-2.5 pl-8 text-[12px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
+            placeholder={`Search ${modelsForProvider.length} models…`}
+            aria-label="Search models"
+          />
+        </label>
+      ) : null}
       {openMenuItems.length > 0 ? (
         <>
           <MenuList items={openMenuItems} />
           <div className="mx-2 mb-1 h-px bg-[rgba(169,178,215,0.08)]" />
         </>
+      ) : showModelSearch ? (
+        <div className="px-2 py-3 text-[12px] text-[color:var(--muted)]">No matching models</div>
       ) : null}
 
       <div className="relative min-w-0">
@@ -198,7 +247,10 @@ export function ComposerModelPopover({
           label="Provider"
           value={selectedProvider || "Choose provider"}
           active={openMenu === "provider"}
-          onClick={() => setOpenMenu((current) => (current === "provider" ? null : "provider"))}
+          onClick={() => {
+            setModelSearch("");
+            setOpenMenu((current) => (current === "provider" ? null : "provider"));
+          }}
         />
       </div>
 
@@ -209,7 +261,16 @@ export function ComposerModelPopover({
             currentModelForSelectedProvider?.name ?? modelsForProvider[0]?.name ?? "Choose model"
           }
           active={openMenu === "model"}
-          onClick={() => setOpenMenu((current) => (current === "model" ? null : "model"))}
+          onClick={() => {
+            setOpenMenu((current) => {
+              if (current === "model") {
+                setModelSearch("");
+                return null;
+              }
+
+              return "model";
+            });
+          }}
         />
       </div>
 
@@ -218,7 +279,10 @@ export function ComposerModelPopover({
           label="Reasoning"
           value={thinkingLevelLabels[currentThinkingLevel]}
           active={openMenu === "thinking"}
-          onClick={() => setOpenMenu((current) => (current === "thinking" ? null : "thinking"))}
+          onClick={() => {
+            setModelSearch("");
+            setOpenMenu((current) => (current === "thinking" ? null : "thinking"));
+          }}
         />
       </div>
     </SurfacePanel>

--- a/src/app/views/settings/helpers.ts
+++ b/src/app/views/settings/helpers.ts
@@ -29,7 +29,8 @@ export function buildModelMenuItems(
     },
     ...availableModels.map((model) => ({
       id: `${model.provider}/${model.id}`,
-      label: `${model.provider}/${model.id}`,
+      label: model.name,
+      description: `${model.provider}/${model.id}`,
       selected: selectedModel?.provider === model.provider && selectedModel.id === model.id,
     })),
   ];

--- a/src/app/views/settings/settingsDescriptorModels.tsx
+++ b/src/app/views/settings/settingsDescriptorModels.tsx
@@ -118,6 +118,7 @@ export function buildModelSettingsDescriptors({
           ...providerModels.map((model) => ({
             value: `${model.provider}/${model.id}`,
             label: model.name,
+            description: `${model.provider}/${model.id}`,
           })),
         ]}
         onOpenChange={(open) => setOpenSelectId(open ? id : null)}

--- a/src/app/views/settings/settingsUi.tsx
+++ b/src/app/views/settings/settingsUi.tsx
@@ -1,4 +1,5 @@
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, Search } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { DictationModelId } from "../../desktop/types";
 import { popoverPanelClass, composerTextActionButtonClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
@@ -54,13 +55,42 @@ export function InlineSelect({
   onChange: (value: string) => void;
   onOpenChange: (open: boolean) => void;
 }) {
+  const [search, setSearch] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const selectedOption = options.find((option) => option.value === value) ?? options[0] ?? null;
   const alignMenuRight = className?.includes("justify-self-end") ?? false;
+  const showSearch = options.length > 12;
+  const normalizedSearch = search.trim().toLowerCase();
+  const visibleOptions = useMemo(() => {
+    if (!normalizedSearch) {
+      return options;
+    }
+
+    return options.filter((option) =>
+      `${option.label} ${option.value} ${option.description ?? ""}`
+        .toLowerCase()
+        .includes(normalizedSearch),
+    );
+  }, [normalizedSearch, options]);
   const compactOptionClass =
     "flex min-h-0 w-full items-center rounded-md border border-transparent px-2 py-1 text-left text-[11.5px] leading-4 text-[color:var(--text)] transition-colors hover:bg-[rgba(255,255,255,0.045)]";
 
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      return;
+    }
+
+    if (showSearch) {
+      searchInputRef.current?.focus();
+    }
+  }, [open, showSearch]);
+
   return (
-    <span className={cn("relative block max-w-full", className, "w-52")} data-inline-select-root>
+    <span
+      className={cn("relative block max-w-full text-[13px]", className, "w-52")}
+      data-inline-select-root
+    >
       <button
         type="button"
         className={cn(
@@ -68,7 +98,12 @@ export function InlineSelect({
           "grid h-8 w-full grid-cols-[minmax(0,1fr)_auto] justify-start gap-2 rounded-lg px-2.5 pr-8 text-left font-normal",
           open && "border-[rgba(169,178,215,0.22)] bg-[rgba(255,255,255,0.1)]",
         )}
-        onClick={() => onOpenChange(!open)}
+        onClick={() => {
+          if (open) {
+            setSearch("");
+          }
+          onOpenChange(!open);
+        }}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={`${id}-menu`}
@@ -87,39 +122,62 @@ export function InlineSelect({
       {open ? (
         <div
           id={`${id}-menu`}
-          role="menu"
           className={cn(
             popoverPanelClass,
             options.length > 10 && "max-h-64 overflow-y-auto",
-            "absolute top-[calc(100%+6px)] z-[60] grid max-w-[min(34rem,calc(100vw-2rem))] min-w-full rounded-xl border border-[color:var(--border-strong)] bg-[rgba(45,48,64,0.98)] p-1 shadow-[0_18px_40px_rgba(0,0,0,0.28)]",
+            "absolute top-[calc(100%+6px)] z-[60] grid min-w-full max-w-[calc(100vw-2rem)] overflow-x-hidden rounded-xl border border-[color:var(--border-strong)] bg-[rgba(45,48,64,0.98)] p-1 shadow-[0_18px_40px_rgba(0,0,0,0.28)]",
+            showSearch && "w-[26.5rem]",
             alignMenuRight ? "right-0" : "left-0",
           )}
         >
-          {options.map((option) => (
-            <button
-              key={option.value}
-              type="button"
-              role="menuitemradio"
-              aria-checked={option.value === value}
-              className={cn(
-                compactOptionClass,
-                option.value === value && "bg-[rgba(255,255,255,0.06)]",
-              )}
-              onClick={() => {
-                onChange(option.value);
-                onOpenChange(false);
-              }}
-            >
-              <span className="min-w-0 flex-1">
-                <span className="block truncate leading-4">{option.label}</span>
-                {option.description ? (
-                  <span className="block truncate text-[10px] leading-3 text-[color:var(--muted)]">
-                    {option.description}
+          {showSearch ? (
+            <label className="relative mb-1 block">
+              <Search
+                size={13}
+                className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-[color:var(--muted)]"
+              />
+              <input
+                ref={searchInputRef}
+                value={search}
+                onChange={(event) => setSearch(event.currentTarget.value)}
+                className="h-8 w-full rounded-lg border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.055)] px-2.5 pl-8 text-[13px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
+                placeholder={`Search ${options.length} options…`}
+                aria-label="Search options"
+              />
+            </label>
+          ) : null}
+          {visibleOptions.length > 0 ? (
+            <div role="menu" className="grid min-w-0">
+              {visibleOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={option.value === value}
+                  className={cn(
+                    compactOptionClass,
+                    option.value === value && "bg-[rgba(255,255,255,0.06)]",
+                  )}
+                  onClick={() => {
+                    onChange(option.value);
+                    setSearch("");
+                    onOpenChange(false);
+                  }}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[13px] leading-4">{option.label}</span>
+                    {option.description ? (
+                      <span className="block truncate text-[11px] leading-3 text-[color:var(--muted)]">
+                        {option.description}
+                      </span>
+                    ) : null}
                   </span>
-                ) : null}
-              </span>
-            </button>
-          ))}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="px-2 py-3 text-[12px] text-[color:var(--muted)]">No matches</div>
+          )}
         </div>
       ) : null}
     </span>


### PR DESCRIPTION
## Summary
- Add search to large model lists in the composer agent popover and settings inline selects.
- Show provider/model IDs as secondary text so OpenRouter model names remain distinguishable.
- Keep picker widths stable, truncate long labels, and avoid horizontal scrolling.

## Validation
- Biome format/check on changed files.
- Commit hook ran Biome, typechecks, and tests.
- Pre-push hook ran lint and typechecks.
