### PR TITLE
Add loading skeletons across workspace surfaces

### DIFF
--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -117,6 +117,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
     handleAction,
     handleProjectReorder,
     handleProjectSelect,
+    handleSetSelectedProject,
     handleShowView,
     handleThreadOpen,
     handleToggleProjectCollapse,
@@ -430,6 +431,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               }}
               onRefreshChatSidebar={controller.refreshChatSidebarState}
               onProjectSelect={handleProjectSelect}
+              onProjectPrimeSelection={handleSetSelectedProject}
               onProjectReorder={handleProjectReorder}
               onLoadProjectThreads={controller.handleLoadProjectThreads}
               onSelectInboxThread={controller.handleSelectInboxThread}

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -360,6 +360,9 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
             <Sidebar
               projects={projects}
               inboxThreads={controller.inboxThreads}
+              inboxLoading={controller.inboxLoading}
+              chatSidebarLoading={controller.chatSidebarLoading}
+              projectsLoading={controller.shellLoading}
               appLaunchedAtMs={controller.appLaunchedAtMs}
               appSettings={
                 controller.shellState?.appSettings ?? {

--- a/src/app/app-shell/useAppShellCommands.ts
+++ b/src/app/app-shell/useAppShellCommands.ts
@@ -212,6 +212,8 @@ export function useAppShellCommands({
     handleProjectReorder,
     handleProjectSelect: (projectId: string) =>
       dispatch({ type: getProjectSelectionAction(workspaceState.activeView), projectId }),
+    handleSetSelectedProject: (projectId: string) =>
+      dispatch({ type: "set-selected-project", projectId }),
     handleReturnToDesktopFromTakeover,
     handleSelectInboxThread,
     handleShowTakeoverTerminal,

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -36,6 +36,7 @@ export function useAppShellController() {
   const { toast, showToast } = useToast();
   const {
     shellState,
+    shellLoading,
     loadArchivedThreads,
     loadComposerState,
     listComposerAttachmentEntries,
@@ -199,6 +200,7 @@ export function useAppShellController() {
     handleAction,
     ...commands,
     inboxThreads,
+    inboxLoading: inboxQuery.isLoading,
     handleSetSkillsProjectScopeActive: setSkillsProjectScopeActive,
     handleSetExtensionsProjectScopeActive: setExtensionsProjectScopeActive,
     handleLoadProjectThreads: loadProjectThreads,
@@ -209,6 +211,7 @@ export function useAppShellController() {
     projects,
     projectGitState,
     shellState,
+    shellLoading,
     skillsProjectScopeActive,
     state,
     selectedInboxThread,
@@ -216,6 +219,7 @@ export function useAppShellController() {
     terminalRunningSessionPaths,
     toast,
     chatSidebarState,
+    chatSidebarLoading: state.activeView === "chat" && chatSidebarState === null,
     selectedChatGroupId,
     handleCreateChatGroup,
     handleSelectChatGroup: setSelectedChatGroupId,

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -55,10 +55,17 @@ export function useAppShellController() {
     threadHistoryCompactions,
   );
   const selectedPersistedSessionPath = getPersistedSessionPath(state.selectedSessionPath);
+  const threadDataMatchesSelection = threadData?.sessionPath === selectedPersistedSessionPath;
+  const activeThreadLoading = Boolean(
+    selectedPersistedSessionPath &&
+      !(liveThreadData?.sessionPath === selectedPersistedSessionPath || threadDataMatchesSelection),
+  );
   const effectiveThreadData =
     threadHistoryCompactions === 0 && liveThreadData?.sessionPath === selectedPersistedSessionPath
       ? liveThreadData
-      : threadData;
+      : threadDataMatchesSelection
+        ? threadData
+        : null;
   const inboxQuery = useDesktopInbox();
   const inboxThreads = inboxQuery.data ?? [];
   const selectedInboxThread = useMemo(
@@ -192,6 +199,7 @@ export function useAppShellController() {
   return {
     activeComposerState,
     activeThreadData,
+    activeThreadLoading,
     archivedThreads,
     collapsedProjectIds,
     composerProjectId,

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -5,7 +5,7 @@ import type { ArchivedThread, ComposerState, ProjectGitState, ThreadData } from 
 import { useDesktopBridge } from "../hooks/useDesktopBridge";
 import { useDesktopInbox } from "../hooks/useDesktopInbox";
 import { useDesktopShell } from "../hooks/useDesktopShell";
-import { useDesktopThread } from "../hooks/useDesktopThread";
+import { useDesktopThreadQuery } from "../hooks/useDesktopThread";
 import { useToast } from "../hooks/useToast";
 import { createInitialWorkspaceState, workspaceReducer } from "../state/workspace";
 import { deriveControllerViewModel } from "./controller-view-model";
@@ -26,6 +26,7 @@ export function useAppShellController() {
   const [composerState, setComposerState] = useState<ComposerState | null>(null);
   const [liveThreadData, setLiveThreadData] = useState<ThreadData | null>(null);
   const [projectGitState, setProjectGitState] = useState<ProjectGitState | null>(null);
+  const [projectGitLoading, setProjectGitLoading] = useState(false);
   const [extensionsProjectScopeActive, setExtensionsProjectScopeActive] = useState(false);
   const [skillsProjectScopeActive, setSkillsProjectScopeActive] = useState(false);
   const [threadRefreshKey, setThreadRefreshKey] = useState(0);
@@ -33,6 +34,7 @@ export function useAppShellController() {
   const [selectedChatGroupId, setSelectedChatGroupId] = useState<string | null>(null);
   const [chatSidebarState, setChatSidebarState] =
     useState<Awaited<ReturnType<typeof getChatSidebarStateQuery>>>(null);
+  const [chatSidebarLoading, setChatSidebarLoading] = useState(false);
   const { toast, showToast } = useToast();
   const {
     shellState,
@@ -49,15 +51,17 @@ export function useAppShellController() {
   } = useDesktopShell();
   const invokeDesktopAction = useDesktopBridge();
   const projects = shellState?.projects ?? [];
-  const threadData = useDesktopThread(
+  const threadQuery = useDesktopThreadQuery(
     state.selectedSessionPath,
     threadRefreshKey,
     threadHistoryCompactions,
   );
+  const threadData = threadQuery.data ?? null;
   const selectedPersistedSessionPath = getPersistedSessionPath(state.selectedSessionPath);
   const threadDataMatchesSelection = threadData?.sessionPath === selectedPersistedSessionPath;
   const activeThreadLoading = Boolean(
     selectedPersistedSessionPath &&
+      (threadQuery.isLoading || threadQuery.isFetching) &&
       !(liveThreadData?.sessionPath === selectedPersistedSessionPath || threadDataMatchesSelection),
   );
   const effectiveThreadData =
@@ -91,7 +95,24 @@ export function useAppShellController() {
 
   useEffect(() => {
     if (state.activeView === "chat") {
-      void getChatSidebarStateQuery(selectedChatGroupId).then(setChatSidebarState);
+      let cancelled = false;
+      setChatSidebarLoading(true);
+
+      void getChatSidebarStateQuery(selectedChatGroupId)
+        .then((nextState) => {
+          if (!cancelled) {
+            setChatSidebarState(nextState);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setChatSidebarLoading(false);
+          }
+        });
+
+      return () => {
+        cancelled = true;
+      };
     }
   }, [state.activeView, selectedChatGroupId]);
 
@@ -135,6 +156,7 @@ export function useAppShellController() {
     setComposerState,
     setLiveThreadData,
     setProjectGitState,
+    setProjectGitLoading,
     setThreadHistoryCompactions,
   });
 
@@ -218,6 +240,7 @@ export function useAppShellController() {
     appLaunchedAtMs,
     projects,
     projectGitState,
+    projectGitLoading,
     shellState,
     shellLoading,
     skillsProjectScopeActive,
@@ -227,7 +250,7 @@ export function useAppShellController() {
     terminalRunningSessionPaths,
     toast,
     chatSidebarState,
-    chatSidebarLoading: state.activeView === "chat" && chatSidebarState === null,
+    chatSidebarLoading,
     selectedChatGroupId,
     handleCreateChatGroup,
     handleSelectChatGroup: setSelectedChatGroupId,

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -52,6 +52,7 @@ export function useAppShellEffects({
   setComposerState,
   setLiveThreadData,
   setProjectGitState,
+  setProjectGitLoading,
   setThreadHistoryCompactions,
 }: {
   projects: Project[];
@@ -77,6 +78,7 @@ export function useAppShellEffects({
   setComposerState: Dispatch<SetStateAction<ComposerState | null>>;
   setLiveThreadData: Dispatch<SetStateAction<ThreadData | null>>;
   setProjectGitState: Dispatch<SetStateAction<ProjectGitState | null>>;
+  setProjectGitLoading: Dispatch<SetStateAction<boolean>>;
   setThreadHistoryCompactions: Dispatch<SetStateAction<number>>;
 }) {
   useProjectShellSync({
@@ -101,6 +103,7 @@ export function useAppShellEffects({
     loadProjectGitState,
     setComposerState,
     setProjectGitState,
+    setProjectGitLoading,
   });
 
   useWatchedSessionSync(workspaceState);

--- a/src/app/app-shell/useComposerGitStateSync.ts
+++ b/src/app/app-shell/useComposerGitStateSync.ts
@@ -17,6 +17,7 @@ type UseComposerGitStateSyncInput = {
   loadProjectGitState: (projectId: string) => Promise<ProjectGitState | null>;
   setComposerState: Dispatch<SetStateAction<ComposerState | null>>;
   setProjectGitState: Dispatch<SetStateAction<ProjectGitState | null>>;
+  setProjectGitLoading: Dispatch<SetStateAction<boolean>>;
 };
 
 export function useComposerGitStateSync({
@@ -29,6 +30,7 @@ export function useComposerGitStateSync({
   loadProjectGitState,
   setComposerState,
   setProjectGitState,
+  setProjectGitLoading,
 }: UseComposerGitStateSyncInput) {
   useEffect(() => {
     if (!shellComposerState) {
@@ -97,17 +99,25 @@ export function useComposerGitStateSync({
   useEffect(() => {
     if (!composerProjectId) {
       setProjectGitState(null);
+      setProjectGitLoading(false);
       return;
     }
 
     setProjectGitState(null);
+    setProjectGitLoading(true);
 
     let cancelled = false;
 
     const syncProjectGitState = async () => {
-      const nextProjectGitState = await loadProjectGitState(composerProjectId);
-      if (!cancelled) {
-        setProjectGitState(nextProjectGitState);
+      try {
+        const nextProjectGitState = await loadProjectGitState(composerProjectId);
+        if (!cancelled) {
+          setProjectGitState(nextProjectGitState);
+        }
+      } finally {
+        if (!cancelled) {
+          setProjectGitLoading(false);
+        }
       }
     };
 
@@ -116,7 +126,7 @@ export function useComposerGitStateSync({
     return () => {
       cancelled = true;
     };
-  }, [composerProjectId, loadProjectGitState, setProjectGitState]);
+  }, [composerProjectId, loadProjectGitState, setProjectGitLoading, setProjectGitState]);
 
   useEffect(() => {
     if (workspaceState.activeView !== "gitops" || !composerProjectId) {
@@ -124,6 +134,7 @@ export function useComposerGitStateSync({
     }
 
     let cancelled = false;
+    setProjectGitLoading(true);
 
     void loadProjectGitState(composerProjectId)
       .then((nextProjectGitState) => {
@@ -133,10 +144,21 @@ export function useComposerGitStateSync({
       })
       .catch((error) => {
         console.warn("Failed to refresh project git state for the diff panel.", error);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setProjectGitLoading(false);
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [composerProjectId, loadProjectGitState, setProjectGitState, workspaceState.activeView]);
+  }, [
+    composerProjectId,
+    loadProjectGitState,
+    setProjectGitLoading,
+    setProjectGitState,
+    workspaceState.activeView,
+  ]);
 }

--- a/src/app/components/common/Skeleton.tsx
+++ b/src/app/components/common/Skeleton.tsx
@@ -1,0 +1,6 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "../../utils/cn";
+
+export function SkeletonBlock({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div aria-hidden="true" className={cn("skeleton-block", className)} {...props} />;
+}

--- a/src/app/components/sidebar/ProjectTree.tsx
+++ b/src/app/components/sidebar/ProjectTree.tsx
@@ -38,6 +38,7 @@ type ProjectTreeProps = {
   collapsedProjectIds: Record<string, boolean>;
   onAction: DesktopActionInvoker;
   onProjectSelect: (projectId: string) => void;
+  onProjectPrimeSelection: (projectId: string) => void;
   onProjectReorder: (projectIds: string[]) => void;
   onThreadOpen: (
     projectId: string,
@@ -95,6 +96,7 @@ export function ProjectTree({
   collapsedProjectIds,
   onAction,
   onProjectSelect,
+  onProjectPrimeSelection,
   onProjectReorder,
   onThreadOpen,
   onToggleProjectCollapse,
@@ -220,6 +222,9 @@ export function ProjectTree({
                         }}
                         onSubmitEdit={() => handleSubmitEdit(project.id)}
                         onCreateSession={() => {
+                          if (activeView !== "chat") {
+                            onProjectPrimeSelection(project.id);
+                          }
                           void onAction("thread.new", { projectId: project.id });
                           setOpenProjectMenuId(null);
                         }}

--- a/src/app/components/sidebar/ProjectTree.tsx
+++ b/src/app/components/sidebar/ProjectTree.tsx
@@ -220,9 +220,6 @@ export function ProjectTree({
                         }}
                         onSubmitEdit={() => handleSubmitEdit(project.id)}
                         onCreateSession={() => {
-                          if (activeView !== "chat") {
-                            onProjectSelect(project.id);
-                          }
                           void onAction("thread.new", { projectId: project.id });
                           setOpenProjectMenuId(null);
                         }}

--- a/src/app/components/sidebar/Sidebar.tsx
+++ b/src/app/components/sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import type { Project, View } from "../../types";
 type SidebarNavigableView = Exclude<View, "gitops">;
 import { NavButton } from "../common/NavButton";
 import { SettingsMenu } from "./SettingsMenu";
+import { SidebarChatSkeleton, SidebarInboxSkeleton } from "./SidebarSkeletons";
 import { SidebarChatSection } from "./chat/SidebarChatSection";
 import { SidebarInboxSection } from "./inbox/SidebarInboxSection";
 import { SidebarProjectsSection } from "./projects/SidebarProjectsSection";
@@ -16,7 +17,10 @@ import { SidebarProjectsSection } from "./projects/SidebarProjectsSection";
 type SidebarProps = {
   projects: Project[];
   inboxThreads: InboxThread[];
+  inboxLoading?: boolean;
   chatSidebarState: ChatSidebarState | null;
+  chatSidebarLoading?: boolean;
+  projectsLoading?: boolean;
   appLaunchedAtMs: number;
   appSettings: AppSettings;
   protectedProjectId?: string | null;
@@ -53,7 +57,10 @@ type SidebarProps = {
 export function Sidebar({
   projects,
   inboxThreads,
+  inboxLoading = false,
   chatSidebarState,
+  chatSidebarLoading = false,
+  projectsLoading = false,
   appLaunchedAtMs,
   appSettings,
   protectedProjectId = null,
@@ -165,7 +172,9 @@ export function Sidebar({
         </nav>
       ) : null}
 
-      {activeView === "inbox" ? (
+      {activeView === "inbox" && inboxLoading && inboxThreads.length === 0 ? (
+        <SidebarInboxSkeleton />
+      ) : activeView === "inbox" ? (
         <SidebarInboxSection
           appLaunchedAtMs={appLaunchedAtMs}
           terminalRunningSessionPaths={terminalRunningSessionPaths}
@@ -174,6 +183,8 @@ export function Sidebar({
           onDismissThread={onDismissInboxThread}
           onSelectThread={onSelectInboxThread}
         />
+      ) : activeView === "chat" && chatSidebarLoading ? (
+        <SidebarChatSkeleton />
       ) : activeView === "chat" ? (
         <SidebarChatSection
           chatState={chatSidebarState}
@@ -194,6 +205,7 @@ export function Sidebar({
           protectedProjectId={protectedProjectId}
           projectScopeLockActive={projectScopeLockActive}
           projects={projects}
+          loading={projectsLoading}
           selectedProjectId={selectedProjectId}
           selectedThreadId={selectedThreadId}
           terminalRunningProjectIds={terminalRunningProjectIds}

--- a/src/app/components/sidebar/Sidebar.tsx
+++ b/src/app/components/sidebar/Sidebar.tsx
@@ -47,6 +47,7 @@ type SidebarProps = {
   onNewChat: (groupId: string | null) => void;
   onRefreshChatSidebar: () => Promise<unknown>;
   onProjectSelect: (projectId: string) => void;
+  onProjectPrimeSelection: (projectId: string) => void;
   onProjectReorder: (projectIds: string[]) => void;
   onLoadProjectThreads: (projectId: string, options?: { chat?: boolean }) => Promise<unknown>;
   onSelectInboxThread: (thread: InboxThread) => void;
@@ -87,6 +88,7 @@ export function Sidebar({
   onNewChat,
   onRefreshChatSidebar,
   onProjectSelect,
+  onProjectPrimeSelection,
   onProjectReorder,
   onLoadProjectThreads,
   onSelectInboxThread,
@@ -183,7 +185,7 @@ export function Sidebar({
           onDismissThread={onDismissInboxThread}
           onSelectThread={onSelectInboxThread}
         />
-      ) : activeView === "chat" && chatSidebarLoading ? (
+      ) : activeView === "chat" && chatSidebarLoading && !chatSidebarState ? (
         <SidebarChatSkeleton />
       ) : activeView === "chat" ? (
         <SidebarChatSection
@@ -215,6 +217,7 @@ export function Sidebar({
           onLoadProjectThreads={onLoadProjectThreads}
           onOpenSettingsPanel={onOpenSettingsPanel}
           onProjectSelect={onProjectSelect}
+          onProjectPrimeSelection={onProjectPrimeSelection}
           onProjectReorder={onProjectReorder}
           onThreadOpen={onThreadOpen}
           onToggleProjectCollapse={onToggleProjectCollapse}

--- a/src/app/components/sidebar/SidebarSkeletons.tsx
+++ b/src/app/components/sidebar/SidebarSkeletons.tsx
@@ -1,0 +1,77 @@
+import { SkeletonBlock } from "../common/Skeleton";
+
+const projectSkeletonRows = [
+  "project-a",
+  "project-b",
+  "project-c",
+  "project-d",
+  "project-e",
+  "project-f",
+];
+const chatSkeletonRows = ["chat-a", "chat-b", "chat-c", "chat-d", "chat-e"];
+const inboxSkeletonRows = ["inbox-a", "inbox-b", "inbox-c", "inbox-d", "inbox-e"];
+
+export function SidebarProjectsSkeleton() {
+  return (
+    <div className="sidebar-scroll-region" aria-label="Loading projects" aria-busy="true">
+      <div className="sidebar-list px-1 pt-1">
+        {projectSkeletonRows.map((rowId, index) => (
+          <div key={rowId} className="grid gap-1.5 py-1.5">
+            <div className="grid h-7 grid-cols-[16px_minmax(0,1fr)_32px] items-center gap-2 px-1.5">
+              <SkeletonBlock className="h-3.5 w-3.5 rounded-md" />
+              <SkeletonBlock className="h-3.5 w-[min(9rem,80%)]" />
+              <SkeletonBlock className="h-5 w-7 justify-self-end rounded-lg opacity-70" />
+            </div>
+            {index < 3 ? (
+              <div className="ml-6 grid gap-1.5">
+                <SkeletonBlock className="h-3 w-[72%] opacity-70" />
+                <SkeletonBlock className="h-3 w-[56%] opacity-55" />
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SidebarChatSkeleton() {
+  return (
+    <div className="sidebar-scroll-region" aria-label="Loading chats" aria-busy="true">
+      <div className="sidebar-list px-1 pt-1">
+        {chatSkeletonRows.map((rowId, index) => (
+          <div key={rowId} className="grid gap-1.5 py-1.5">
+            <div className="grid h-7 grid-cols-[16px_minmax(0,1fr)_24px] items-center gap-2 px-1.5">
+              <SkeletonBlock className="h-3.5 w-3.5 rounded-md" />
+              <SkeletonBlock className="h-3.5 w-[min(8rem,76%)]" />
+              <SkeletonBlock className="h-4 w-5 justify-self-end rounded-md opacity-60" />
+            </div>
+            <div className="ml-6 grid gap-1.5">
+              <SkeletonBlock className="h-3 w-[76%] opacity-70" />
+              {index % 2 === 0 ? <SkeletonBlock className="h-3 w-[52%] opacity-55" /> : null}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SidebarInboxSkeleton() {
+  return (
+    <div className="sidebar-scroll-region" aria-label="Loading inbox" aria-busy="true">
+      <div className="sidebar-list px-1 pt-1">
+        {inboxSkeletonRows.map((rowId, index) => (
+          <div key={rowId} className="grid gap-1.5 rounded-xl px-1.5 py-2">
+            <div className="flex items-center justify-between gap-3">
+              <SkeletonBlock className="h-3.5 w-[68%]" />
+              <SkeletonBlock className="h-3 w-8 opacity-60" />
+            </div>
+            <SkeletonBlock className="h-3 w-[86%] opacity-65" />
+            {index < 3 ? <SkeletonBlock className="h-3 w-[58%] opacity-45" /> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
+++ b/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
@@ -37,6 +37,7 @@ type SidebarProjectsSectionProps = {
   onLoadProjectThreads: (projectId: string, options?: { chat?: boolean }) => Promise<unknown>;
   onOpenSettingsPanel: () => void;
   onProjectSelect: (projectId: string) => void;
+  onProjectPrimeSelection: (projectId: string) => void;
   onProjectReorder: (projectIds: string[]) => void;
   onThreadOpen: (projectId: string, threadId: string, sessionPath: string) => void;
   onToggleProjectCollapse: (projectId: string) => void;
@@ -59,6 +60,7 @@ export function SidebarProjectsSection({
   onLoadProjectThreads,
   onOpenSettingsPanel,
   onProjectSelect,
+  onProjectPrimeSelection,
   onProjectReorder,
   onThreadOpen,
   onToggleProjectCollapse,
@@ -361,6 +363,7 @@ export function SidebarProjectsSection({
               collapsedProjectIds={effectiveCollapsedProjectIds}
               onAction={onAction}
               onProjectSelect={onProjectSelect}
+              onProjectPrimeSelection={onProjectPrimeSelection}
               onProjectReorder={onProjectReorder}
               onThreadOpen={onThreadOpen}
               onToggleProjectCollapse={onToggleProjectCollapse}

--- a/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
+++ b/src/app/components/sidebar/projects/SidebarProjectsSection.tsx
@@ -8,6 +8,7 @@ import type { Project, View } from "../../../types";
 import { cn } from "../../../utils/cn";
 import { IconButton } from "../../common/IconButton";
 import { ProjectTree } from "../ProjectTree";
+import { SidebarProjectsSkeleton } from "../SidebarSkeletons";
 import { SidebarProjectsCreatePopover } from "./SidebarProjectsCreatePopover";
 import {
   type SidebarProjectsFilterMode,
@@ -26,6 +27,7 @@ type SidebarProjectsSectionProps = {
   protectedProjectId?: string | null;
   projectScopeLockActive: boolean;
   projects: Project[];
+  loading?: boolean;
   selectedProjectId: string;
   selectedThreadId: string | null;
   terminalRunningProjectIds: ReadonlySet<string>;
@@ -47,6 +49,7 @@ export function SidebarProjectsSection({
   protectedProjectId = null,
   projectScopeLockActive,
   projects,
+  loading = false,
   selectedProjectId,
   selectedThreadId,
   terminalRunningProjectIds,
@@ -322,7 +325,9 @@ export function SidebarProjectsSection({
         ) : null}
       </div>
 
-      {visibleProjects.length > 0 || pendingProject ? (
+      {loading && visibleProjects.length === 0 && !pendingProject ? (
+        <SidebarProjectsSkeleton />
+      ) : visibleProjects.length > 0 || pendingProject ? (
         <>
           {pendingProject ? (
             <div className="sidebar-tree-item" aria-live="polite">

--- a/src/app/components/workspace/DiffPanel.tsx
+++ b/src/app/components/workspace/DiffPanel.tsx
@@ -12,6 +12,7 @@ type DiffPanelProps = {
   diffRenderMode: "stacked" | "split";
   layoutMode?: "split" | "overlay" | "main";
   showFileTree?: boolean;
+  loading?: boolean;
 };
 
 export function DiffPanel({
@@ -24,6 +25,7 @@ export function DiffPanel({
   diffRenderMode,
   layoutMode = "split",
   showFileTree = true,
+  loading = false,
 }: DiffPanelProps) {
   return (
     <DiffWorkerPoolProvider>
@@ -37,6 +39,7 @@ export function DiffPanel({
         diffRenderMode={diffRenderMode}
         layoutMode={layoutMode}
         showFileTree={showFileTree}
+        loading={loading}
       />
     </DiffWorkerPoolProvider>
   );

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -10,6 +10,7 @@ import { DiffCommentAnnotationCard } from "./DiffCommentAnnotationCard";
 import { DiffPanelEmptyState } from "./DiffPanelEmptyState";
 import { DiffChangedFilesTree } from "./DiffChangedFilesTree";
 import { DiffPanelFileList } from "./DiffPanelFileList";
+import { DiffPanelSkeleton } from "./DiffPanelSkeleton";
 import {
   DIFF_FILE_ESTIMATED_FILE_GAP,
   DIFF_FILE_ESTIMATED_HEADER_HEIGHT,
@@ -34,6 +35,7 @@ type DiffPanelContentProps = {
   diffRenderMode: "stacked" | "split";
   layoutMode?: "split" | "overlay" | "main";
   showFileTree?: boolean;
+  loading?: boolean;
 };
 
 export function DiffPanelContent({
@@ -46,8 +48,10 @@ export function DiffPanelContent({
   diffRenderMode,
   layoutMode = "split",
   showFileTree = true,
+  loading = false,
 }: DiffPanelContentProps) {
   const [collapsedFiles, setCollapsedFiles] = useState<Record<string, boolean>>({});
+  const [diffContentReady, setDiffContentReady] = useState(false);
   const [focusedFilePaths, setFocusedFilePaths] = useState<readonly string[]>([]);
   const [renderFileTree, setRenderFileTree] = useState(showFileTree);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -68,6 +72,17 @@ export function DiffPanelContent({
         : [],
     [renderablePatch],
   );
+
+  useEffect(() => {
+    if (!renderablePatch || renderablePatch.kind !== "files") {
+      setDiffContentReady(false);
+      return;
+    }
+
+    setDiffContentReady(false);
+    const timeout = window.setTimeout(() => setDiffContentReady(true), 120);
+    return () => window.clearTimeout(timeout);
+  }, [renderablePatch]);
   const normalizedFocusedFilePaths = useMemo(
     () => focusedFilePaths.map((filePath) => filePath.replace(/\/+$/, "")),
     [focusedFilePaths],
@@ -164,6 +179,10 @@ export function DiffPanelContent({
   const fileListVirtualizer = useVirtualizer({
     count: visibleRenderableFiles.length,
     getScrollElement: () => scrollContainerRef.current,
+    initialRect: {
+      width: 960,
+      height: 720,
+    },
     estimateSize: (index) =>
       estimatedFileHeights[index] ??
       DIFF_FILE_ESTIMATED_HEADER_HEIGHT + DIFF_FILE_ESTIMATED_FILE_GAP,
@@ -212,66 +231,82 @@ export function DiffPanelContent({
       )}
       {...getFeatureStatusDataAttributes("feature:diff.panel")}
     >
-      {!isGitRepo ? (
+      {loading ? (
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+          <DiffPanelSkeleton showFileTree={showFileTree} />
+        </div>
+      ) : !isGitRepo ? (
         <DiffPanelEmptyState message="Diffs are unavailable because this project is not a git repository." />
       ) : (
         <>
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-            {!renderablePatch ? (
+            {(isLoading || (!hasResolvedPatch && !error)) && !renderablePatch ? (
+              <DiffPanelSkeleton showFileTree={showFileTree} />
+            ) : !renderablePatch ? (
               <div className="flex h-full items-center justify-center px-3 py-2 text-center text-xs text-[color:var(--muted)]">
                 <div className="grid max-w-[42rem] gap-1.5">
                   <p>
-                    {isLoading
-                      ? "Loading diff..."
-                      : error
-                        ? "Diff unavailable."
-                        : hasNoNetChanges
-                          ? `No net changes ${getDiffBaselinePrefix(baseline)} ${getResolvedDiffBaselineLabel(baseline, diff?.resolvedBaseline)}.`
-                          : "No patch available for this worktree."}
+                    {error
+                      ? "Diff unavailable."
+                      : hasNoNetChanges
+                        ? `No net changes ${getDiffBaselinePrefix(baseline)} ${getResolvedDiffBaselineLabel(baseline, diff?.resolvedBaseline)}.`
+                        : "No patch available for this worktree."}
                   </p>
                   {error ? <p className="text-[#f2a7a7]">{error}</p> : null}
                 </div>
               </div>
             ) : renderablePatch.kind === "files" ? (
-              <div className="flex h-full min-h-0">
+              <div className="relative h-full min-h-0">
+                {!diffContentReady ? (
+                  <div className="absolute inset-0 z-10 bg-[color:var(--workspace)]">
+                    <DiffPanelSkeleton showFileTree={showFileTree} />
+                  </div>
+                ) : null}
                 <div
-                  ref={scrollContainerRef}
-                  className="min-h-0 min-w-0 flex-1 overflow-auto [overflow-anchor:none]"
+                  className={cn(
+                    "flex h-full min-h-0 transition-opacity duration-100",
+                    diffContentReady ? "opacity-100" : "opacity-0",
+                  )}
                 >
-                  <DiffPanelFileList
-                    collapsedFiles={collapsedFiles}
-                    commentAnnotationsByFile={commentAnnotationsByFile}
-                    diffRenderMode={diffRenderMode}
-                    draftSelectedLines={draftSelectedLines}
-                    getFileInteractionHandlers={getFileInteractionHandlers}
-                    getSelectedLinesForFile={getSelectedLinesForFile}
-                    handleFilePointerDownCapture={handleFilePointerDownCapture}
-                    measureElement={fileListVirtualizer.measureElement}
-                    onOpenDraftComment={openDraftComment}
-                    onToggleFileCollapsed={toggleFileCollapsed}
-                    projectId={projectId}
-                    renderCommentAnnotation={renderCommentAnnotation}
-                    renderableFiles={visibleRenderableFiles}
-                    totalSize={fileListVirtualizer.getTotalSize()}
-                    virtualItems={fileListVirtualizer.getVirtualItems()}
-                  />
-                </div>
-                <div
-                  className="min-h-0 shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-out"
-                  style={{
-                    width: showFileTree ? "min(28rem, calc(100% - 2.5rem))" : 0,
-                    opacity: showFileTree ? 1 : 0,
-                  }}
-                  aria-hidden={!showFileTree}
-                >
-                  {renderFileTree ? (
-                    <DiffChangedFilesTree
-                      files={renderableFiles}
-                      selectedPaths={focusedFilePaths}
-                      focusedFileCount={hasFocusedFiles ? visibleRenderableFiles.length : 0}
-                      onSelectedPathsChange={setFocusedFilePaths}
+                  <div
+                    ref={scrollContainerRef}
+                    className="min-h-0 min-w-0 flex-1 overflow-auto [overflow-anchor:none]"
+                  >
+                    <DiffPanelFileList
+                      collapsedFiles={collapsedFiles}
+                      commentAnnotationsByFile={commentAnnotationsByFile}
+                      diffRenderMode={diffRenderMode}
+                      draftSelectedLines={draftSelectedLines}
+                      getFileInteractionHandlers={getFileInteractionHandlers}
+                      getSelectedLinesForFile={getSelectedLinesForFile}
+                      handleFilePointerDownCapture={handleFilePointerDownCapture}
+                      measureElement={fileListVirtualizer.measureElement}
+                      onOpenDraftComment={openDraftComment}
+                      onToggleFileCollapsed={toggleFileCollapsed}
+                      projectId={projectId}
+                      renderCommentAnnotation={renderCommentAnnotation}
+                      renderableFiles={visibleRenderableFiles}
+                      totalSize={fileListVirtualizer.getTotalSize()}
+                      virtualItems={fileListVirtualizer.getVirtualItems()}
                     />
-                  ) : null}
+                  </div>
+                  <div
+                    className="min-h-0 shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-out"
+                    style={{
+                      width: showFileTree ? "min(28rem, calc(100% - 2.5rem))" : 0,
+                      opacity: showFileTree ? 1 : 0,
+                    }}
+                    aria-hidden={!showFileTree}
+                  >
+                    {renderFileTree ? (
+                      <DiffChangedFilesTree
+                        files={renderableFiles}
+                        selectedPaths={focusedFilePaths}
+                        focusedFileCount={hasFocusedFiles ? visibleRenderableFiles.length : 0}
+                        onSelectedPathsChange={setFocusedFilePaths}
+                      />
+                    ) : null}
+                  </div>
                 </div>
               </div>
             ) : (

--- a/src/app/components/workspace/diff/DiffPanelContent.tsx
+++ b/src/app/components/workspace/diff/DiffPanelContent.tsx
@@ -240,7 +240,7 @@ export function DiffPanelContent({
       ) : (
         <>
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-            {(isLoading || (!hasResolvedPatch && !error)) && !renderablePatch ? (
+            {isLoading && !renderablePatch ? (
               <DiffPanelSkeleton showFileTree={showFileTree} />
             ) : !renderablePatch ? (
               <div className="flex h-full items-center justify-center px-3 py-2 text-center text-xs text-[color:var(--muted)]">

--- a/src/app/components/workspace/diff/DiffPanelSkeleton.tsx
+++ b/src/app/components/workspace/diff/DiffPanelSkeleton.tsx
@@ -1,0 +1,75 @@
+import { SkeletonBlock } from "../../common/Skeleton";
+
+export function DiffPanelSkeleton({ showFileTree = true }: { showFileTree?: boolean }) {
+  return (
+    <div className="flex h-full min-h-0" aria-label="Loading diff" aria-busy="true">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden px-3 py-3">
+        <div className="grid gap-3">
+          {Array.from({ length: 4 }, (_, index) => {
+            const rowId = `diff-file-${index}`;
+            return (
+              <div
+                key={rowId}
+                className="overflow-hidden rounded-xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.018)]"
+              >
+                <div className="flex h-9 items-center justify-between gap-3 border-b border-[color:var(--border)] px-3">
+                  <SkeletonBlock className="h-3.5 w-[min(18rem,58%)] rounded-md" />
+                  <SkeletonBlock className="h-3 w-16 rounded-md opacity-60" />
+                </div>
+                <div className="grid gap-2 px-3 py-3">
+                  {Array.from({ length: index === 0 ? 8 : 5 }, (_, lineIndex) => {
+                    const lineId = `${rowId}-line-${lineIndex}`;
+                    return (
+                      <div key={lineId} className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-3">
+                        <SkeletonBlock className="h-3 w-8 rounded-md opacity-45" />
+                        <SkeletonBlock
+                          className="h-3 rounded-md opacity-65"
+                          style={{
+                            width: `${lineIndex % 3 === 0 ? 72 : lineIndex % 3 === 1 ? 88 : 54}%`,
+                          }}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {showFileTree ? (
+        <div
+          className="min-h-0 shrink-0 border-l border-[color:var(--border)] px-2.5 py-3"
+          style={{ width: "min(28rem, calc(100% - 2.5rem))" }}
+        >
+          <div className="mb-3 flex h-7 items-center justify-between gap-3 px-2.5">
+            <SkeletonBlock className="h-3.5 w-20 rounded-md" />
+            <SkeletonBlock className="h-3 w-16 rounded-md opacity-60" />
+          </div>
+          <SkeletonBlock className="mb-3 h-8 w-full rounded-[10px] opacity-65" />
+          <div className="grid gap-2 px-1">
+            {Array.from({ length: 10 }, (_, index) => {
+              const rowId = `diff-tree-${index}`;
+              return (
+                <div
+                  key={rowId}
+                  className="grid grid-cols-[14px_minmax(0,1fr)_42px] items-center gap-2"
+                >
+                  <SkeletonBlock className="h-3 w-3 rounded-sm opacity-55" />
+                  <SkeletonBlock
+                    className="h-3 rounded-md"
+                    style={{
+                      width: `${index % 4 === 0 ? 86 : index % 4 === 1 ? 62 : index % 4 === 2 ? 74 : 48}%`,
+                    }}
+                  />
+                  <SkeletonBlock className="h-3 w-9 rounded-md opacity-50" />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/components/workspace/thread/ThreadTimelineSkeleton.tsx
+++ b/src/app/components/workspace/thread/ThreadTimelineSkeleton.tsx
@@ -1,0 +1,53 @@
+import { SkeletonBlock } from "../../common/Skeleton";
+import { CHAT_TEXT_MAX_WIDTH_CLASS } from "../../../ui/layout";
+import { chatScrollableAreaClass, chatViewportClass } from "./thread-layout";
+
+const MESSAGE_SHAPES = [
+  { id: "first-user", align: "end", width: "58%", lines: [92, 64] },
+  { id: "first-assistant", align: "start", width: "72%", lines: [84, 96, 70, 42] },
+  { id: "second-user", align: "end", width: "48%", lines: [88] },
+  { id: "second-assistant", align: "start", width: "68%", lines: [78, 94, 56] },
+] as const;
+
+export function ThreadTimelineSkeleton({
+  composerOverlayHeight = 0,
+}: { composerOverlayHeight?: number }) {
+  return (
+    <div
+      className={`${chatViewportClass} relative`}
+      aria-label="Loading conversation"
+      aria-busy="true"
+    >
+      <div className={`${chatScrollableAreaClass} ml-[2.95rem] mr-[2.05rem]`}>
+        <div
+          className={`mx-auto flex min-h-full w-full min-w-0 flex-col justify-end ${CHAT_TEXT_MAX_WIDTH_CLASS} overflow-x-hidden px-4 pt-4 pb-4`}
+          style={
+            composerOverlayHeight > 0
+              ? { paddingBottom: `calc(1rem + ${composerOverlayHeight}px)` }
+              : undefined
+          }
+        >
+          <div className="grid min-w-0 gap-4">
+            {MESSAGE_SHAPES.map((message) => (
+              <div key={message.id} className="grid gap-2" style={{ justifyItems: message.align }}>
+                <SkeletonBlock className="h-3 w-24 rounded-md opacity-45" />
+                <div
+                  className="grid gap-2 rounded-[18px] border border-[color:var(--border)] bg-[rgba(255,255,255,0.018)] px-4 py-3"
+                  style={{ width: message.width }}
+                >
+                  {message.lines.map((width) => (
+                    <SkeletonBlock
+                      key={`${message.id}-${width}`}
+                      className="h-3 rounded-md opacity-70"
+                      style={{ width: `${width}%` }}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/features/chat/ChatView.tsx
+++ b/src/app/features/chat/ChatView.tsx
@@ -1,4 +1,5 @@
 import { ThreadTimeline } from "../../components/workspace/thread/ThreadTimeline";
+import { ThreadTimelineSkeleton } from "../../components/workspace/thread/ThreadTimelineSkeleton";
 import type { Message } from "../../types";
 
 type ChatViewProps = {
@@ -8,6 +9,7 @@ type ChatViewProps = {
   isCompacting: boolean;
   composerLayoutVersion: number;
   composerOverlayHeight?: number;
+  loading?: boolean;
   onLoadEarlierMessages: () => void;
 };
 
@@ -18,8 +20,13 @@ export function ChatView({
   isCompacting,
   composerLayoutVersion,
   composerOverlayHeight = 0,
+  loading = false,
   onLoadEarlierMessages,
 }: ChatViewProps) {
+  if (loading) {
+    return <ThreadTimelineSkeleton composerOverlayHeight={composerOverlayHeight} />;
+  }
+
   if (messages.length === 0) {
     return <div className="h-full" />;
   }

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -155,6 +155,9 @@ export function ChatWorkspaceView({
               isCompacting={activeThreadData?.isCompacting ?? false}
               composerLayoutVersion={composerLayoutVersion}
               composerOverlayHeight={composerOverlayHeight}
+              loading={
+                controller.activeThreadLoading || (hasConversation && !conversationContentVisible)
+              }
               onLoadEarlierMessages={handleLoadEarlierMessages}
             />
           </main>

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -45,6 +45,7 @@ type CodeWorkspaceMainViewProps = {
   selectedProjectId: string;
   workspaceContentClass: string;
   threadData: ThreadData | null;
+  threadLoading?: boolean;
   composerLayoutVersion: number;
   composerOverlayHeight: number;
   onAction: DesktopActionInvoker;
@@ -80,6 +81,7 @@ export function CodeWorkspaceMainView({
   selectedProjectId,
   workspaceContentClass,
   threadData,
+  threadLoading = false,
   composerLayoutVersion,
   composerOverlayHeight,
   onAction,
@@ -103,6 +105,7 @@ export function CodeWorkspaceMainView({
         isCompacting={threadData?.isCompacting ?? false}
         composerLayoutVersion={composerLayoutVersion}
         composerOverlayHeight={composerOverlayHeight}
+        loading={threadLoading}
         onLoadEarlierMessages={onLoadEarlierMessages}
       />
     );

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -197,7 +197,7 @@ export function CodeWorkspaceView({
                 diffRenderMode={diffRenderMode}
                 layoutMode="main"
                 showFileTree={gitOpsFileTreeVisible}
-                loading={projectGitState === null}
+                loading={controller.projectGitLoading}
               />
             ) : (
               <CodeWorkspaceMainView

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -105,9 +105,10 @@ export function CodeWorkspaceView({
     visible: showWorkspaceFooter,
   });
   const hasThreadConversation = showThreadFooter && (activeThreadData?.messages.length ?? 0) > 0;
+  const hasThreadConversationLayout = hasThreadConversation || controller.activeThreadLoading;
   const [threadContentVisible, setThreadContentVisible] = useState(hasThreadConversation);
   const previousHasThreadConversationRef = useRef(hasThreadConversation);
-  const centerThreadFooter = showThreadFooter && !hasThreadConversation;
+  const centerThreadFooter = showThreadFooter && !hasThreadConversationLayout;
   const footerInset = showWorkspaceFooter && !centerThreadFooter ? footerHeight : 0;
 
   useEffect(() => {

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -167,6 +167,9 @@ export function CodeWorkspaceView({
     state.activeView === "thread" && activeThreadData && !threadContentVisible
       ? { ...activeThreadData, messages: [] }
       : activeThreadData;
+  const threadTimelineLoading =
+    state.activeView === "thread" &&
+    (controller.activeThreadLoading || (hasThreadConversation && !threadContentVisible));
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
@@ -241,6 +244,7 @@ export function CodeWorkspaceView({
                 selectedProjectId={controller.state.selectedProjectId}
                 workspaceContentClass={workspaceContentClass}
                 threadData={visibleThreadData}
+                threadLoading={threadTimelineLoading}
                 composerLayoutVersion={composerLayoutVersion}
                 composerOverlayHeight={composerOverlayHeight}
                 onAction={handleAction}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -194,6 +194,7 @@ export function CodeWorkspaceView({
                 diffRenderMode={diffRenderMode}
                 layoutMode="main"
                 showFileTree={gitOpsFileTreeVisible}
+                loading={projectGitState === null}
               />
             ) : (
               <CodeWorkspaceMainView

--- a/src/app/hooks/useDesktopShell.ts
+++ b/src/app/hooks/useDesktopShell.ts
@@ -220,6 +220,7 @@ export function useDesktopShell() {
 
   return {
     shellState: shellStateQuery.data ?? null,
+    shellLoading: shellStateQuery.isLoading,
     refreshShellState,
     scheduleShellStateRefresh,
     loadProjectThreads,

--- a/src/app/hooks/useDesktopThread.ts
+++ b/src/app/hooks/useDesktopThread.ts
@@ -3,14 +3,14 @@ import { getPersistedSessionPath } from "../../../shared/session-paths";
 import type { ThreadData } from "../desktop/types";
 import { desktopQueryKeys, getThreadQuery } from "../query/desktop-query";
 
-export function useDesktopThread(
+export function useDesktopThreadQuery(
   sessionPath: string | null | undefined,
   refreshKey = 0,
   historyCompactions = 0,
 ) {
   const persistedSessionPath = getPersistedSessionPath(sessionPath);
 
-  const query = useQuery<ThreadData | null>({
+  return useQuery<ThreadData | null>({
     queryKey: persistedSessionPath
       ? desktopQueryKeys.thread(persistedSessionPath, refreshKey, historyCompactions)
       : ["desktop", "thread", null, refreshKey, historyCompactions],
@@ -22,6 +22,14 @@ export function useDesktopThread(
     staleTime: Number.POSITIVE_INFINITY,
     placeholderData: persistedSessionPath ? keepPreviousData : undefined,
   });
+}
+
+export function useDesktopThread(
+  sessionPath: string | null | undefined,
+  refreshKey = 0,
+  historyCompactions = 0,
+) {
+  const query = useDesktopThreadQuery(sessionPath, refreshKey, historyCompactions);
 
   return query.data ?? null;
 }

--- a/src/app/views/ThreadView.tsx
+++ b/src/app/views/ThreadView.tsx
@@ -1,4 +1,5 @@
 import { ThreadTimeline } from "../components/workspace/thread/ThreadTimeline";
+import { ThreadTimelineSkeleton } from "../components/workspace/thread/ThreadTimelineSkeleton";
 import type { Message } from "../types";
 
 type ThreadViewProps = {
@@ -8,6 +9,7 @@ type ThreadViewProps = {
   isCompacting: boolean;
   composerLayoutVersion: number;
   composerOverlayHeight?: number;
+  loading?: boolean;
   onLoadEarlierMessages: () => void;
 };
 
@@ -18,8 +20,13 @@ export function ThreadView({
   isCompacting,
   composerLayoutVersion,
   composerOverlayHeight = 0,
+  loading = false,
   onLoadEarlierMessages,
 }: ThreadViewProps) {
+  if (loading) {
+    return <ThreadTimelineSkeleton composerOverlayHeight={composerOverlayHeight} />;
+  }
+
   if (messages.length === 0) {
     return <div className="h-full" />;
   }

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -55,6 +55,28 @@
   }
 }
 
+@keyframes skeletonShimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.skeleton-block {
+  position: relative;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: rgba(169, 178, 215, 0.075);
+}
+
+.skeleton-block::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(213, 218, 237, 0.075), transparent);
+  animation: skeletonShimmer 1.6s ease-in-out infinite;
+}
+
 .activity-spinner__rotor {
   transform-origin: center;
   animation: activitySpinnerRotate 0.75s step-end infinite;


### PR DESCRIPTION
## Summary
- Add reusable shimmer skeleton primitives and sidebar loading placeholders for projects, chat, and inbox sections.
- Add synchronized GitOps diff/file-tree skeletons so the diff surface loads as one unit instead of flashing empty between phases.
- Add conversation timeline skeletons for chat/code thread loading and remove the code “new session” landing-screen flash.

## Notes
- Loading, empty, and error states remain separate: skeletons only render while async content is pending or hydrating.
- The PR was rebuilt as a clean branch from `origin/dev` to avoid including unrelated local dev commits.

## Validation
- Commit hooks passed on the original commits: Biome, typechecks, Vitest.
- Pre-push hook passed on this branch: lint and typechecks.

Closes #124
