### PR TITLE
Fix dot-formatted model context windows

### DIFF
--- a/.pi/skills/howcode-dual-native-extension/SKILL.md
+++ b/.pi/skills/howcode-dual-native-extension/SKILL.md
@@ -30,6 +30,8 @@ The core invariant: **one extension file owns the tool schema, prompt text, vali
 5. **Do not import DB/native modules into runtime-host worker code.** Runtime-host must use `invokeMainRequest` for DB-backed data.
 6. **No prompt character limits.** Prompt the extension toward short sentences/options, but do not enforce brittle character counts.
 7. **Composer interception must be explicit.** While a pending tool UI is active, Enter/Escape/submit must answer/dismiss the tool instead of sending normal user text.
+8. **Pending tool UI must be lifecycle-safe.** Creating a new pending request must resolve/reject any previous request, abort signals must clear pending state, and the renderer must not hide the card until answer/dismiss IPC succeeds.
+9. **Composer context must travel with answers.** Answer/dismiss actions must include the same composer context used to create/lookup the runtime (`composerMode`, `chatGroupId`, session path/project id as applicable) so chat/code runtimes are not recreated with mismatched settings cwd.
 
 ## Reference files
 Read these before implementing a new dual native extension:
@@ -75,13 +77,20 @@ Read these before implementing a new dual native extension:
 - Add settings UI toggle in the settings descriptor flow.
 - Add optimistic update handling.
 - Snapshot global defaults into `session_native_extensions` when a session is created or first materialized.
+- Treat a missing snapshot row (`null`) differently from an explicit empty snapshot (`[]`): missing rows should fall back to current defaults and then persist that snapshot; explicit empty arrays mean disabled for that session.
 - Never let toggling the global setting mutate an existing session’s enabled toolkit.
 
 ### 7. Wire desktop UI
 - Surface pending tool state in `ComposerState`.
 - Render composer-adjacent UI above the composer using existing overlay/measurement patterns.
 - Add a specific action such as `composer.answer-native-questions` to resolve the pending tool promise.
+- Keep `shared/desktop-actions.ts`, `shared/desktop-action-contracts.ts`, and `shared/desktop-action-coverage.ts` in sync for that action.
+- Include composer context fields in action payloads if the runtime lookup depends on mode/session dir/group.
 - Ensure normal composer submission is overridden while pending.
+- Preserve normal textarea editing: ArrowLeft/ArrowRight overrides should not steal caret movement while the user is editing freeform text.
+- Be deliberate about outside-click dismissal. If the pending tool requires the user to click/focus the main composer to type an answer, outside-click dismissal is harmful; prefer explicit Dismiss/Escape instead and document the exception in review notes.
+- Keep local UI state consistent: reset dismissed/answers on new requests, clear stale custom/freeform state when predefined single-choice options are picked, and allow clearing/replacing custom multi-select answers.
+- Dismissed/cancelled state should be explicit in the resolved payload (for example `answers: null`) rather than conflated with an intentionally blank answer.
 
 ### 8. Wire Pi TUI takeover
 - In `desktop/terminal/terminal-command.helpers.ts`, when `launchMode === "pi-session"`:
@@ -94,6 +103,8 @@ Read these before implementing a new dual native extension:
 - Let git hooks run on commit; do not bypass them.
 - For this repo, do not manually run typechecks/tests unless explicitly asked. If committing, hooks will run configured checks.
 - Validate by inspecting the exact launch args and desktop runtime registration path.
+- For runtime actions that call `getOrCreateRuntimeForSessionPath(..., { suspendDisposal: true })`, schedule disposal again in `finally` after the answer/update path completes.
+- If adding copied `.mjs` native extension assets, update watch-mode copying too, including platforms where `fs.watch` emits events without `filename`.
 - If the dev app is running, test both surfaces:
   - desktop: model/tool call creates composer-adjacent pending UI
   - takeover: `pi --session ... --extension ...` loads same tool and uses TUI UI
@@ -103,10 +114,16 @@ Read these before implementing a new dual native extension:
 - [ ] Desktop runtime imports that same `.mjs` file and only injects callbacks.
 - [ ] TUI takeover passes that same `.mjs` file via `--extension`.
 - [ ] Per-session snapshot controls availability for both surfaces.
+- [ ] Missing session snapshot rows fallback to current defaults and then persist; explicit empty snapshots stay disabled.
 - [ ] Existing sessions keep their snapshot after global setting changes.
 - [ ] Worker code does not import DB/native modules.
 - [ ] Composer submit is intercepted while pending.
+- [ ] Answer/dismiss payload includes composer context needed for chat/code runtime lookup.
+- [ ] Pending request lifecycle handles replacement, abort, dismiss, and IPC failure without hanging the agent or hiding the only UI.
+- [ ] Runtime disposal is re-armed after suspended runtime mutations.
+- [ ] Desktop action coverage registry is updated for new actions.
 - [ ] Build script copies native extension assets for packaged builds.
+- [ ] Build watch mode refreshes copied native extension assets.
 - [ ] Commit hooks pass.
 
 ## Error handling
@@ -122,9 +139,25 @@ Action: move DB access behind runtime-host main request IPC via `desktop/runtime
 Cause: runtime reads global setting directly instead of session snapshot.
 Action: fix the runtime to read `session_native_extensions` for persisted sessions and only snapshot defaults for new sessions.
 
+### Error: legacy sessions never receive a newly enabled native extension
+Cause: missing `session_native_extensions` rows are treated the same as explicit empty snapshots.
+Action: make snapshot readers return `null` for missing rows; at runtime, fallback to current defaults, persist that snapshot for the session, and only treat `[]` as explicitly disabled.
+
+### Error: answering a pending desktop tool recreates the runtime or loses state
+Cause: the answer action omitted composer mode/session-dir/group context or failed to re-arm runtime disposal after a suspended lookup.
+Action: include composer context in the action payload and schedule runtime disposal in `finally`.
+
+### Error: pending composer tool UI disappears but the agent keeps waiting
+Cause: the renderer optimistically hid the card before the desktop answer/dismiss action succeeded.
+Action: have the card await an ok/failure result before setting local dismissed state; surface action errors in composer UI.
+
 ### Error: desktop and TUI behavior drift
 Cause: two separate tool implementations exist.
 Action: move schema/prompt/result/TUI logic back into the shared `.mjs` file and keep desktop-specific code as injected callbacks.
+
+### Error: custom/freeform answers stay selected incorrectly
+Cause: UI state tracks predefined and freeform answers independently without clearing stale values.
+Action: clear custom state when a single-choice predefined option is picked; allow empty custom submissions to remove prior custom answers; replace previous custom values instead of accumulating stale entries.
 
 ## Output contract
 When completing a dual native extension task, report:

--- a/.pi/skills/howcode-dual-native-extension/references/file-map.md
+++ b/.pi/skills/howcode-dual-native-extension/references/file-map.md
@@ -14,6 +14,7 @@ Use these files as concrete references when adding a new dual-surface Howcode-na
 
 - `scripts/build-electron-runtime.ts`
   - Copies `.mjs` native extension assets into `build/desktop/native-extensions/` for packaged/runtime builds.
+  - In watch mode, re-copies native extension assets after edits, including watch events without a filename.
 
 ## Desktop runtime-host adapter
 - `desktop/runtime-host/native-ask-questions-tool.cts`
@@ -23,6 +24,7 @@ Use these files as concrete references when adding a new dual-surface Howcode-na
 
 - `desktop/runtime-host/live-runtime-registry.cts`
   - Reads enabled native extensions per session.
+  - Falls back from a missing snapshot row to current defaults and persists that legacy/session-first-materialized snapshot.
   - Registers native custom tools during session creation.
   - Publishes composer state when pending native tool state changes.
 
@@ -60,6 +62,7 @@ Use these files as concrete references when adding a new dual-surface Howcode-na
 - `shared/desktop-composer-contracts.ts`
 - `shared/desktop-action-contracts.ts`
 - `shared/desktop-actions.ts`
+- `shared/desktop-action-coverage.ts`
 - `shared/pi-thread-action-payloads.ts`
 - `desktop/runtime/composer-state.cts`
 - `desktop/pi-threads/composer-actions.cts`

--- a/.pi/skills/howcode-dual-native-extension/references/implementation-checklist.md
+++ b/.pi/skills/howcode-dual-native-extension/references/implementation-checklist.md
@@ -20,7 +20,8 @@ Use this as the ordered checklist for adding a new Howcode-native dual-surface e
 1. Add or extend a `desktop/native-extensions/*-extension-path.cts` helper.
 2. Return source path in dev and copied build path in packaged runtime.
 3. Update `scripts/build-electron-runtime.ts` to copy the `.mjs` asset.
-4. Do not copy to user data unless bare dependency resolution is solved.
+4. Update watch mode so copied `.mjs` assets refresh on edits; handle `fs.watch` events that omit `filename`.
+5. Do not copy to user data unless bare dependency resolution is solved.
 
 ## Runtime-host desktop adapter
 1. Add `desktop/runtime-host/<tool>-tool.cts`.
@@ -33,15 +34,23 @@ Use this as the ordered checklist for adding a new Howcode-native dual-surface e
 1. Add global setting if needed.
 2. Add session snapshot reads/writes in main-safe DB code.
 3. Add runtime-host main requests if worker code needs snapshot/defaults.
-4. For persisted sessions, read snapshot only.
-5. For new sessions, snapshot global defaults once and store them.
+4. For persisted sessions, read snapshot first.
+5. If the snapshot row is missing (`null`), fallback to current defaults and persist that snapshot for legacy/first-materialized sessions.
+6. If the snapshot row exists but is empty (`[]`), treat native extensions as explicitly disabled for that session.
+7. For new sessions, snapshot global defaults once and store them.
 
 ## Composer UI
 1. Add `ComposerState` field for pending request.
 2. Render UI above composer using overlay pattern.
 3. Route submit/dismiss to a specific desktop action.
-4. Ensure normal user prompts do not send while pending.
-5. Support empty/other/freeform behavior as product requires.
+4. Add the action to contracts, canonical action list, payload readers, router, and action coverage registry.
+5. Include composer context (`composerMode`, `chatGroupId`, session path/project id as needed) on answer/dismiss payloads.
+6. Ensure normal user prompts do not send while pending.
+7. Preserve text editing in the composer while pending; ArrowLeft/ArrowRight should move the caret unless it is already at the boundary where question navigation makes sense.
+8. Do not optimistically hide the only pending UI before answer/dismiss IPC succeeds.
+9. Reset local pending-card state when a new request arrives.
+10. Support empty/other/freeform behavior as product requires, including clearing stale custom answers.
+11. Prefer explicit Dismiss/Escape over outside-click dismissal when clicking/focusing the composer is part of answering the pending tool.
 
 ## TUI takeover
 1. In `desktop/terminal/terminal-command.helpers.ts`, read session snapshot.
@@ -51,5 +60,7 @@ Use this as the ordered checklist for adding a new Howcode-native dual-surface e
 ## Final validation
 1. Confirm no duplicate tool implementation exists.
 2. Confirm worker-reachable files do not import DB/native modules.
-3. Commit and let hooks run.
-4. Report exact paths changed and which surfaces were validated.
+3. Confirm runtime mutations that suspend disposal re-schedule disposal in `finally`.
+4. Confirm pending requests settle on replacement, abort, answer, and dismiss.
+5. Commit and let hooks run.
+6. Report exact paths changed and which surfaces were validated.

--- a/desktop/app-settings/keys.cts
+++ b/desktop/app-settings/keys.cts
@@ -22,3 +22,5 @@ export const projectDeletionModeKey = "projectDeletionMode";
 export const useAgentsSkillsPathsKey = "useAgentsSkillsPaths";
 export const howcodeNativeAskQuestionsKey = "howcodeNativeAskQuestions";
 export const piTuiTakeoverKey = "piTuiTakeover";
+export const hoverToFocusKey = "hoverToFocus";
+export const hoverToBlurKey = "hoverToBlur";

--- a/desktop/app-settings/readers.cts
+++ b/desktop/app-settings/readers.cts
@@ -20,6 +20,8 @@ import {
   gitDiffRenderModeDefaultKey,
   gitOpsDefaultModeKey,
   howcodeNativeAskQuestionsKey,
+  hoverToBlurKey,
+  hoverToFocusKey,
   initializeGitOnProjectCreateKey,
   piTuiTakeoverKey,
   preferredProjectLocationKey,
@@ -237,6 +239,24 @@ export function loadAppSettings(): AppSettings {
       `,
     )
     .get(piTuiTakeoverKey) as PreferenceRow | undefined;
+  const hoverToFocusRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(hoverToFocusKey) as PreferenceRow | undefined;
+  const hoverToBlurRow = db
+    .prepare(
+      `
+        SELECT value_json AS valueJson
+        FROM app_preferences
+        WHERE key = ?
+      `,
+    )
+    .get(hoverToBlurKey) as PreferenceRow | undefined;
   const dictationModelIdRow = db
     .prepare(
       `
@@ -304,5 +324,7 @@ export function loadAppSettings(): AppSettings {
     howcodeNativeAskQuestions:
       parseBooleanPreference(howcodeNativeAskQuestionsRow?.valueJson) ?? false,
     piTuiTakeover: parseBooleanPreference(piTuiTakeoverRow?.valueJson) ?? false,
+    hoverToFocus: parseBooleanPreference(hoverToFocusRow?.valueJson) ?? true,
+    hoverToBlur: parseBooleanPreference(hoverToBlurRow?.valueJson) ?? false,
   };
 }

--- a/desktop/app-settings/writers.cts
+++ b/desktop/app-settings/writers.cts
@@ -29,6 +29,8 @@ import {
   gitDiffRenderModeDefaultKey,
   gitOpsDefaultModeKey,
   howcodeNativeAskQuestionsKey,
+  hoverToBlurKey,
+  hoverToFocusKey,
   initializeGitOnProjectCreateKey,
   piTuiTakeoverKey,
   preferredProjectLocationKey,
@@ -249,4 +251,22 @@ export function setHowcodeNativeAskQuestions(enabled: boolean) {
 
 export function setPiTuiTakeover(enabled: boolean) {
   writeAppPreference(piTuiTakeoverKey, JSON.stringify(enabled));
+}
+
+export function setHoverToFocus(enabled: boolean) {
+  if (enabled) {
+    deleteAppPreference(hoverToFocusKey);
+    return;
+  }
+
+  writeAppPreference(hoverToFocusKey, JSON.stringify(false));
+}
+
+export function setHoverToBlur(enabled: boolean) {
+  if (!enabled) {
+    deleteAppPreference(hoverToBlurKey);
+    return;
+  }
+
+  writeAppPreference(hoverToBlurKey, JSON.stringify(true));
 }

--- a/desktop/pi-threads/settings-actions.cts
+++ b/desktop/pi-threads/settings-actions.cts
@@ -35,6 +35,8 @@ import {
   setGitDiffRenderModeDefault,
   setGitOpsDefaultMode,
   setHowcodeNativeAskQuestions,
+  setHoverToBlur,
+  setHoverToFocus,
   setInitializeGitOnProjectCreate,
   setPiTuiTakeover,
   setPreferredProjectLocation,
@@ -140,6 +142,16 @@ export async function handleSettingsDesktopAction(
 
   if (key === "piTuiTakeover") {
     setPiTuiTakeover(getSettingsBooleanValue(payload) ?? false);
+    return handledAction();
+  }
+
+  if (key === "hoverToFocus") {
+    setHoverToFocus(getSettingsBooleanValue(payload) ?? true);
+    return handledAction();
+  }
+
+  if (key === "hoverToBlur") {
+    setHoverToBlur(getSettingsBooleanValue(payload) ?? false);
     return handledAction();
   }
 

--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -26,6 +26,7 @@ import {
 } from "./live-thread-publisher.cts";
 import { emitDesktopEvent } from "./host-events.cts";
 import { clearRuntimeToolProgress, rememberRuntimeToolProgress } from "./live-tool-progress.cts";
+import { normalizeModelRegistryContextWindows } from "../../shared/model-context-window-normalization.ts";
 
 function getRuntimeDiagnosticExtensionLabel(extensionPath: string) {
   if (extensionPath.startsWith("command:")) return `/${extensionPath.slice("command:".length)}`;
@@ -122,7 +123,9 @@ async function createRuntime(options: {
   } = await getPiModule();
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  const modelRegistry = normalizeModelRegistryContextWindows(
+    ModelRegistry.create(authStorage, `${agentDir}/models.json`),
+  );
   const settingsManager = createRuntimeSettingsManager({
     SettingsManager,
     cwd: options.cwd,

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -8,6 +8,7 @@ import { parseCompactSlashCommand } from "../../shared/composer-slash-commands.t
 import { getDesktopWorkingDirectory } from "../../shared/desktop-working-directory.ts";
 import { createLocalThreadDraft, getPersistedSessionPath } from "../../shared/session-paths.ts";
 import { getPiModule } from "../pi-module.cts";
+import { normalizeModelRegistryContextWindows } from "../../shared/model-context-window-normalization.ts";
 import { discoverHeadlessAgentSessionResources } from "../runtime/agent-session-extensions.cts";
 import { buildComposerAttachmentPrompt } from "../runtime/attachments.cts";
 import {
@@ -210,7 +211,9 @@ export async function setComposerModel(
     const cwd = request.projectId ?? getDesktopWorkingDirectory();
     const agentDir = getAgentDir();
     const authStorage = AuthStorage.create();
-    const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+    const modelRegistry = normalizeModelRegistryContextWindows(
+      ModelRegistry.create(authStorage, `${agentDir}/models.json`),
+    );
     const model = modelRegistry.find(provider, modelId);
     if (!model) throw new Error(`Unknown Pi model: ${provider}/${modelId}`);
     const currentComposer = await buildComposerStateSnapshot({ projectId: cwd, sessionPath: null });

--- a/desktop/runtime-host/skill-creator-service.cts
+++ b/desktop/runtime-host/skill-creator-service.cts
@@ -8,6 +8,7 @@ import { mapAgentMessagesToUiMessages } from "../../shared/pi-message-mapper.ts"
 import { loadAppSettings } from "../app-settings/readers.cts";
 import { getChatSessionDir } from "../chat-session-dir.cts";
 import { getPiModule } from "../pi-module.cts";
+import { normalizeModelRegistryContextWindows } from "../../shared/model-context-window-normalization.ts";
 import { bindHeadlessAgentSessionExtensions } from "../runtime/agent-session-extensions.cts";
 import {
   clampThinkingLevel,
@@ -160,7 +161,9 @@ async function createSkillCreatorSession(cwd: string, projectPath?: string | nul
   } = await getPiModule();
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  const modelRegistry = normalizeModelRegistryContextWindows(
+    ModelRegistry.create(authStorage, `${agentDir}/models.json`),
+  );
   const settingsManager = SettingsManager.create(cwd, agentDir);
   const bundledSkillsPath = await resolveBundledSkillsPath();
   const resourceLoader = new DefaultResourceLoader({

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -32,6 +32,7 @@ import {
   abortRuntimeExtensionCommand,
   isRuntimeExtensionCommandRunning,
 } from "./runtime-registry.cts";
+import { normalizeModelRegistryContextWindows } from "../../shared/model-context-window-normalization.ts";
 import {
   getLiveThread,
   publishComposerUpdate,
@@ -166,7 +167,9 @@ async function setDraftComposerModel(cwd: string, provider: string, modelId: str
   const { AuthStorage, ModelRegistry, SettingsManager, getAgentDir } = await getPiModule();
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  const modelRegistry = normalizeModelRegistryContextWindows(
+    ModelRegistry.create(authStorage, `${agentDir}/models.json`),
+  );
   const model = modelRegistry.find(provider, modelId);
 
   if (!model) {

--- a/desktop/runtime/composer-state.cts
+++ b/desktop/runtime/composer-state.cts
@@ -19,6 +19,10 @@ import {
 import { isHeadlessExtensionCommandRunning } from "./agent-session-extensions.cts";
 import { buildQueuedPrompts } from "./composer-queue";
 import { getNativeAskQuestionsRequest } from "./native-ask-questions-state.cts";
+import {
+  normalizeModelContextWindowValue,
+  normalizeModelRegistryContextWindows,
+} from "../../shared/model-context-window-normalization.ts";
 import type { PiRuntime } from "./types.cts";
 
 export const DEFAULT_COMPOSER_THINKING_LEVEL: ComposerThinkingLevel = "medium";
@@ -64,10 +68,11 @@ function mapContextUsage(session: AgentSession): ComposerContextUsage | null {
     return null;
   }
 
+  const contextWindow = normalizeModelContextWindowValue(usage.contextWindow);
   const contextUsage = {
     tokens: usage.tokens,
-    contextWindow: usage.contextWindow,
-    percent: usage.percent,
+    contextWindow,
+    percent: usage.tokens !== null ? (usage.tokens / contextWindow) * 100 : usage.percent,
   };
   contextUsageCache.set(session, contextUsage);
   return contextUsage;
@@ -200,7 +205,9 @@ export async function createComposerSnapshotSession(request: ComposerStateReques
     : (request.projectId ?? getDesktopWorkingDirectory());
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  const modelRegistry = normalizeModelRegistryContextWindows(
+    ModelRegistry.create(authStorage, `${agentDir}/models.json`),
+  );
   const settingsManager = createRuntimeSettingsManager({
     SettingsManager,
     cwd,

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -35,6 +35,7 @@ import {
   withRuntimeMutationLock,
 } from "./registry/runtime-registry-state.cts";
 export { withRuntimeMutationLock } from "./registry/runtime-registry-state.cts";
+import { normalizeModelRegistryContextWindows } from "../../shared/model-context-window-normalization.ts";
 import type { RuntimeRecord } from "./registry/runtime-registry-state.cts";
 import type { PiRuntime } from "./types.cts";
 
@@ -127,7 +128,9 @@ async function createRuntime(options: {
   } = await getPiModule();
   const agentDir = getAgentDir();
   const authStorage = AuthStorage.create();
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  const modelRegistry = normalizeModelRegistryContextWindows(
+    ModelRegistry.create(authStorage, `${agentDir}/models.json`),
+  );
   const settingsManager = createRuntimeSettingsManager({
     SettingsManager,
     cwd: options.cwd,

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -89,7 +89,9 @@ export type DesktopSettingsUpdatePayload =
   | { key: "projectDeletionMode"; value: ProjectDeletionMode }
   | { key: "useAgentsSkillsPaths"; value: boolean }
   | { key: "howcodeNativeAskQuestions"; value: boolean }
-  | { key: "piTuiTakeover"; value: boolean };
+  | { key: "piTuiTakeover"; value: boolean }
+  | { key: "hoverToFocus"; value: boolean }
+  | { key: "hoverToBlur"; value: boolean };
 
 export type DesktopActionPayloadMap = {
   "threads.collapse-all": EmptyActionPayload;

--- a/shared/desktop-settings-contracts.ts
+++ b/shared/desktop-settings-contracts.ts
@@ -43,6 +43,8 @@ export type AppSettings = {
   useAgentsSkillsPaths: boolean;
   howcodeNativeAskQuestions: boolean;
   piTuiTakeover: boolean;
+  hoverToFocus: boolean;
+  hoverToBlur: boolean;
 };
 
 export type PiTransportMode = "sse" | "websocket" | "auto";

--- a/shared/model-context-window-normalization.ts
+++ b/shared/model-context-window-normalization.ts
@@ -1,7 +1,8 @@
 const DOT_FORMATTED_CONTEXT_WINDOW_MAX = 1_000;
 
-type ModelWithContextWindow = {
+type ModelWithTokenLimits = {
   contextWindow?: number | null;
+  maxTokens?: number | null;
 };
 
 export function normalizeModelContextWindowValue(value: number): number;
@@ -25,18 +26,37 @@ export function normalizeModelContextWindowValue(value: number | null | undefine
   return Math.round(value);
 }
 
-export function normalizeModelContextWindow<T extends ModelWithContextWindow>(model: T): T {
-  const contextWindow = normalizeModelContextWindowValue(model.contextWindow);
-  if (contextWindow !== model.contextWindow) {
-    model.contextWindow = contextWindow;
+function normalizeTokenLimitField<T extends ModelWithTokenLimits>(model: T, field: keyof T) {
+  const normalized = normalizeModelContextWindowValue(model[field] as number | null | undefined);
+  if (normalized !== model[field]) {
+    model[field] = normalized as T[keyof T];
   }
+}
+
+export function normalizeModelContextWindow<T extends ModelWithTokenLimits>(model: T): T {
+  normalizeTokenLimitField(model, "contextWindow");
+  normalizeTokenLimitField(model, "maxTokens");
   return model;
+}
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as { then?: unknown }).then === "function";
+}
+
+function normalizeModelsResult<T extends ModelWithTokenLimits[]>(models: T | Promise<T>) {
+  if (isPromiseLike(models)) {
+    return models.then((resolvedModels) =>
+      resolvedModels.map((model) => normalizeModelContextWindow(model)),
+    );
+  }
+
+  return models.map((model) => normalizeModelContextWindow(model));
 }
 
 export function normalizeModelRegistryContextWindows<T>(modelRegistry: T): T {
   const registry = modelRegistry as T & {
-    find?: (...args: unknown[]) => ModelWithContextWindow | null | undefined;
-    getAvailable?: (...args: unknown[]) => Promise<ModelWithContextWindow[]>;
+    find?: (...args: unknown[]) => ModelWithTokenLimits | null | undefined;
+    getAvailable?: (...args: unknown[]) => ModelWithTokenLimits[] | Promise<ModelWithTokenLimits[]>;
   };
   const originalFind = registry.find?.bind(registry);
   if (originalFind) {
@@ -48,10 +68,8 @@ export function normalizeModelRegistryContextWindows<T>(modelRegistry: T): T {
 
   const originalGetAvailable = registry.getAvailable?.bind(registry);
   if (originalGetAvailable) {
-    registry.getAvailable = async (...args: unknown[]) => {
-      const models = await originalGetAvailable(...args);
-      return models.map((model) => normalizeModelContextWindow(model));
-    };
+    registry.getAvailable = (...args: unknown[]) =>
+      normalizeModelsResult(originalGetAvailable(...args));
   }
 
   return modelRegistry;

--- a/shared/model-context-window-normalization.ts
+++ b/shared/model-context-window-normalization.ts
@@ -1,0 +1,58 @@
+const DOT_FORMATTED_CONTEXT_WINDOW_MAX = 1_000;
+
+type ModelWithContextWindow = {
+  contextWindow?: number | null;
+};
+
+export function normalizeModelContextWindowValue(value: number): number;
+export function normalizeModelContextWindowValue(value: null | undefined): null | undefined;
+export function normalizeModelContextWindowValue(
+  value: number | null | undefined,
+): number | null | undefined;
+export function normalizeModelContextWindowValue(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return value;
+  }
+
+  if (Number.isInteger(value)) {
+    return value;
+  }
+
+  if (value < DOT_FORMATTED_CONTEXT_WINDOW_MAX) {
+    return Number(String(value).replace(".", ""));
+  }
+
+  return Math.round(value);
+}
+
+export function normalizeModelContextWindow<T extends ModelWithContextWindow>(model: T): T {
+  const contextWindow = normalizeModelContextWindowValue(model.contextWindow);
+  if (contextWindow !== model.contextWindow) {
+    model.contextWindow = contextWindow;
+  }
+  return model;
+}
+
+export function normalizeModelRegistryContextWindows<T>(modelRegistry: T): T {
+  const registry = modelRegistry as T & {
+    find?: (...args: unknown[]) => ModelWithContextWindow | null | undefined;
+    getAvailable?: (...args: unknown[]) => Promise<ModelWithContextWindow[]>;
+  };
+  const originalFind = registry.find?.bind(registry);
+  if (originalFind) {
+    registry.find = (...args: unknown[]) => {
+      const model = originalFind(...args);
+      return model ? normalizeModelContextWindow(model) : model;
+    };
+  }
+
+  const originalGetAvailable = registry.getAvailable?.bind(registry);
+  if (originalGetAvailable) {
+    registry.getAvailable = async (...args: unknown[]) => {
+      const models = await originalGetAvailable(...args);
+      return models.map((model) => normalizeModelContextWindow(model));
+    };
+  }
+
+  return modelRegistry;
+}

--- a/shared/pi-thread-action-payloads.ts
+++ b/shared/pi-thread-action-payloads.ts
@@ -273,7 +273,9 @@ export function getSettingsKey(payload: DesktopActionPayloadInput) {
     payload.key === "projectDeletionMode" ||
     payload.key === "useAgentsSkillsPaths" ||
     payload.key === "howcodeNativeAskQuestions" ||
-    payload.key === "piTuiTakeover"
+    payload.key === "piTuiTakeover" ||
+    payload.key === "hoverToFocus" ||
+    payload.key === "hoverToBlur"
     ? (payload.key as keyof AppSettings)
     : null;
 }

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -391,6 +391,8 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                   useAgentsSkillsPaths: false,
                   howcodeNativeAskQuestions: false,
                   piTuiTakeover: false,
+                  hoverToFocus: true,
+                  hoverToBlur: false,
                 }
               }
               chatSidebarState={controller.chatSidebarState}
@@ -480,6 +482,8 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               workspaceContentClass={workspaceContentClass}
               onOpenGitOps={handleOpenGitOpsFromTakeover}
               onSetDiffBaseline={handleSetDiffBaseline}
+              hoverToFocus={controller.shellState?.appSettings.hoverToFocus ?? true}
+              hoverToBlur={controller.shellState?.appSettings.hoverToBlur ?? false}
             />
 
             {terminalDrawerPresent ? (
@@ -495,6 +499,8 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                     projectId={composerProjectId}
                     sessionPath={terminalSessionPath}
                     onClose={controller.handleCloseTerminalDrawer}
+                    hoverToFocus={controller.shellState?.appSettings.hoverToFocus ?? true}
+                    hoverToBlur={controller.shellState?.appSettings.hoverToBlur ?? false}
                   />
                 </div>
               </div>

--- a/src/app/app-shell/AppShellOverlays.tsx
+++ b/src/app/app-shell/AppShellOverlays.tsx
@@ -17,6 +17,8 @@ type AppShellOverlaysProps = {
   workspaceContentClass: string;
   onOpenGitOps: () => void;
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void;
+  hoverToFocus?: boolean;
+  hoverToBlur?: boolean;
 };
 
 export function AppShellOverlays({
@@ -31,6 +33,8 @@ export function AppShellOverlays({
   workspaceContentClass,
   onOpenGitOps,
   onSetDiffBaseline,
+  hoverToFocus = true,
+  hoverToBlur = false,
 }: AppShellOverlaysProps) {
   const controllerRef = useRef(controller);
   const { projectGitState } = controller;
@@ -65,6 +69,8 @@ export function AppShellOverlays({
             projectGitState={projectGitState}
             diffBaseline={diffBaseline}
             onSetDiffBaseline={onSetDiffBaseline}
+            hoverToFocus={hoverToFocus}
+            hoverToBlur={hoverToBlur}
           />
         </div>
       </div>

--- a/src/app/app-shell/controller-optimistic-updates.ts
+++ b/src/app/app-shell/controller-optimistic-updates.ts
@@ -47,7 +47,9 @@ export function getOptimisticallyUpdatedShellState(
     payload.key !== "projectDeletionMode" &&
     payload.key !== "useAgentsSkillsPaths" &&
     payload.key !== "howcodeNativeAskQuestions" &&
-    payload.key !== "piTuiTakeover"
+    payload.key !== "piTuiTakeover" &&
+    payload.key !== "hoverToFocus" &&
+    payload.key !== "hoverToBlur"
   ) {
     return currentState;
   }
@@ -231,6 +233,16 @@ export function getOptimisticallyUpdatedShellState(
       ? payload.value
       : currentState.appSettings.piTuiTakeover;
 
+  const nextHoverToFocus =
+    payload.key === "hoverToFocus" && typeof payload.value === "boolean"
+      ? payload.value
+      : currentState.appSettings.hoverToFocus;
+
+  const nextHoverToBlur =
+    payload.key === "hoverToBlur" && typeof payload.value === "boolean"
+      ? payload.value
+      : currentState.appSettings.hoverToBlur;
+
   return {
     ...currentState,
     appSettings: {
@@ -259,6 +271,8 @@ export function getOptimisticallyUpdatedShellState(
       useAgentsSkillsPaths: nextUseAgentsSkillsPaths,
       howcodeNativeAskQuestions: nextHowcodeNativeAskQuestions,
       piTuiTakeover: nextPiTuiTakeover,
+      hoverToFocus: nextHoverToFocus,
+      hoverToBlur: nextHoverToBlur,
     },
   } satisfies ShellState;
 }

--- a/src/app/components/workspace/Composer.tsx
+++ b/src/app/components/workspace/Composer.tsx
@@ -38,6 +38,8 @@ export type ComposerProps = {
   dictationMaxDurationSeconds: number;
   favoriteFolders: string[];
   showDictationButton: boolean;
+  hoverToFocus: boolean;
+  hoverToBlur: boolean;
   diffRenderMode: ProjectDiffRenderMode;
   diffComments: SavedDiffComment[];
   diffCommentCount: number;

--- a/src/app/components/workspace/TerminalPanel.tsx
+++ b/src/app/components/workspace/TerminalPanel.tsx
@@ -32,6 +32,8 @@ type TerminalPanelProps = {
   projectGitState?: ProjectGitState | null;
   diffBaseline?: ProjectDiffBaseline;
   onSetDiffBaseline?: (baseline: ProjectDiffBaseline) => void;
+  hoverToFocus?: boolean;
+  hoverToBlur?: boolean;
 };
 
 export const TerminalPanel = memo(function TerminalPanel({
@@ -44,6 +46,8 @@ export const TerminalPanel = memo(function TerminalPanel({
   projectGitState = null,
   diffBaseline,
   onSetDiffBaseline,
+  hoverToFocus = true,
+  hoverToBlur = false,
 }: TerminalPanelProps) {
   const statusId: FeatureStatusId = "feature:terminal.panel";
   const panelRef = useRef<HTMLDivElement>(null);
@@ -69,6 +73,8 @@ export const TerminalPanel = memo(function TerminalPanel({
           keepAliveMsOnUnmount={PI_TUI_KEEP_ALIVE_MS}
           closeWhenSessionFileIdleMs={PI_TUI_SESSION_FILE_IDLE_POLL_MS}
           backgroundCssVar="--workspace"
+          hoverToFocus={hoverToFocus}
+          hoverToBlur={hoverToBlur}
           className="terminal-viewport--flush relative z-0 min-h-0 rounded-none bg-[color:var(--workspace)]"
         />
         <div className="relative z-[80] overflow-visible rounded-b-[20px] border-x border-b border-[color:var(--border)] bg-[rgba(39,42,57,0.94)] shadow-[var(--shadow)]">
@@ -146,6 +152,8 @@ export const TerminalPanel = memo(function TerminalPanel({
           onProcessExit={onClose}
           preserveSessionOnUnmount
           backgroundCssVar="--sidebar"
+          hoverToFocus={hoverToFocus}
+          hoverToBlur={hoverToBlur}
           className="terminal-viewport--flush terminal-viewport--bottom-reserve absolute inset-0 h-auto min-h-0 rounded-none bg-[color:var(--sidebar)]"
         />
       </div>

--- a/src/app/components/workspace/composer/ComposerContextMeter.tsx
+++ b/src/app/components/workspace/composer/ComposerContextMeter.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 import type { ComposerContextUsage } from "../../../desktop/types";
 import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
 import { ghostButtonClass } from "../../../ui/classes";
@@ -41,6 +41,33 @@ function getMeterTone(percent: number | null | undefined) {
   return "#9bb7ff";
 }
 
+type Point = {
+  x: number;
+  y: number;
+};
+
+function getTriangleArea(a: Point, b: Point, c: Point) {
+  return Math.abs((a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y)) / 2);
+}
+
+function isPointInTriangle(point: Point, a: Point, b: Point, c: Point) {
+  const area = getTriangleArea(a, b, c);
+  const areaA = getTriangleArea(point, b, c);
+  const areaB = getTriangleArea(a, point, c);
+  const areaC = getTriangleArea(a, b, point);
+
+  return Math.abs(area - (areaA + areaB + areaC)) < 0.5;
+}
+
+function isPointInExpandedRect(point: Point, rect: DOMRect, padding: number) {
+  return (
+    point.x >= rect.left - padding &&
+    point.x <= rect.right + padding &&
+    point.y >= rect.top - padding &&
+    point.y <= rect.bottom + padding
+  );
+}
+
 export function ComposerContextMeter({
   contextUsage,
   isCompacting,
@@ -51,6 +78,7 @@ export function ComposerContextMeter({
   const [pinned, setPinned] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const clearHoverTriangleRef = useRef<(() => void) | null>(null);
   const percent = contextUsage?.percent ?? null;
   const tokens = contextUsage?.tokens ?? null;
   const contextWindow = contextUsage?.contextWindow ?? null;
@@ -71,12 +99,72 @@ export function ComposerContextMeter({
     refs: [buttonRef, popoverRef],
   });
 
+  const clearHoverTriangle = useCallback(() => {
+    clearHoverTriangleRef.current?.();
+    clearHoverTriangleRef.current = null;
+  }, []);
+
+  const openHoverPreview = useCallback(() => {
+    clearHoverTriangle();
+    setHovered(true);
+  }, [clearHoverTriangle]);
+
+  const closeHoverPreview = useCallback(() => {
+    clearHoverTriangle();
+    setHovered(false);
+  }, [clearHoverTriangle]);
+
+  const handleMouseLeave = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (pinned) {
+        return;
+      }
+
+      const button = buttonRef.current;
+      const popover = popoverRef.current;
+      if (!button || !popover) {
+        closeHoverPreview();
+        return;
+      }
+
+      clearHoverTriangle();
+
+      const origin = { x: event.clientX, y: event.clientY };
+      const popoverRect = popover.getBoundingClientRect();
+      const buttonRect = button.getBoundingClientRect();
+      const padding = 10;
+      const triangleLeft = { x: popoverRect.left - padding, y: popoverRect.bottom + padding };
+      const triangleRight = { x: popoverRect.right + padding, y: popoverRect.bottom + padding };
+
+      const handlePointerMove = (pointerEvent: PointerEvent) => {
+        const point = { x: pointerEvent.clientX, y: pointerEvent.clientY };
+
+        if (
+          isPointInExpandedRect(point, popoverRect, padding) ||
+          isPointInExpandedRect(point, buttonRect, padding) ||
+          isPointInTriangle(point, origin, triangleLeft, triangleRight)
+        ) {
+          setHovered(true);
+          return;
+        }
+
+        closeHoverPreview();
+      };
+
+      const timeout = window.setTimeout(closeHoverPreview, 900);
+      window.addEventListener("pointermove", handlePointerMove, { passive: true });
+      clearHoverTriangleRef.current = () => {
+        window.clearTimeout(timeout);
+        window.removeEventListener("pointermove", handlePointerMove);
+      };
+    },
+    [clearHoverTriangle, closeHoverPreview, pinned],
+  );
+
+  useEffect(() => clearHoverTriangle, [clearHoverTriangle]);
+
   return (
-    <div
-      className="relative"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-    >
+    <div className="relative" onMouseEnter={openHoverPreview} onMouseLeave={handleMouseLeave}>
       <button
         ref={buttonRef}
         type="button"
@@ -98,6 +186,7 @@ export function ComposerContextMeter({
         <div
           ref={popoverRef}
           className="absolute bottom-full left-0 z-[130] grid w-56 gap-2 rounded-xl border border-[rgba(169,178,215,0.18)] bg-[#2d3040] p-3 text-[12px] text-[color:var(--muted)] shadow-[0_18px_44px_rgba(0,0,0,0.4)]"
+          onMouseEnter={openHoverPreview}
           onMouseDown={(event) => event.preventDefault()}
         >
           <div className="grid gap-1">

--- a/src/app/components/workspace/composer/ComposerGitOpsMessageField.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsMessageField.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEventHandler, ReactNode } from "react";
+import type { KeyboardEventHandler, ReactNode, RefObject } from "react";
 import { ComposerTextField } from "./ComposerTextField";
 
 type ComposerGitOpsMessageFieldProps = {
@@ -17,6 +17,9 @@ type ComposerGitOpsMessageFieldProps = {
   value: string;
   commitFocused: boolean;
   isGitRepo: boolean;
+  hoverToFocus: boolean;
+  hoverToBlur: boolean;
+  hoverBoundaryRef?: RefObject<HTMLElement | null>;
 };
 
 export function ComposerGitOpsMessageField({
@@ -35,6 +38,9 @@ export function ComposerGitOpsMessageField({
   value,
   commitFocused,
   isGitRepo,
+  hoverToFocus,
+  hoverToBlur,
+  hoverBoundaryRef,
 }: ComposerGitOpsMessageFieldProps) {
   const errorMessage = actionErrorMessage ?? diffCommentError;
   const statusMessage = errorMessage ?? actionStatusMessage;
@@ -68,6 +74,9 @@ export function ComposerGitOpsMessageField({
       statusTone={statusTone}
       reservedLineCount={1}
       onHeightChange={onLayoutChange}
+      hoverToFocus={hoverToFocus}
+      hoverToBlur={hoverToBlur}
+      hoverBoundaryRef={hoverBoundaryRef}
     />
   );
 

--- a/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerGitOpsSurface.tsx
@@ -215,6 +215,9 @@ export function ComposerGitOpsSurface({
             diffCommentError={diffCommentError ?? diffLoadError}
             hasDiffComments={false}
             isGitRepo={isGitRepo}
+            hoverToFocus={appSettings.hoverToFocus}
+            hoverToBlur={appSettings.hoverToBlur}
+            hoverBoundaryRef={composerPanelRef}
             onBlur={() => setCommitFocused(false)}
             onChange={handleCommitMessageChange}
             onFocus={() => setCommitFocused(true)}
@@ -244,6 +247,9 @@ export function ComposerGitOpsSurface({
           diffCommentError={diffCommentError ?? diffLoadError}
           hasDiffComments
           isGitRepo={isGitRepo}
+          hoverToFocus={appSettings.hoverToFocus}
+          hoverToBlur={appSettings.hoverToBlur}
+          hoverBoundaryRef={composerPanelRef}
           onBlur={() => setCommitFocused(false)}
           onChange={handleCommitMessageChange}
           onFocus={() => setCommitFocused(true)}

--- a/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptInputPanel.tsx
@@ -27,9 +27,12 @@ type ComposerPromptInputPanelProps = {
   errorMessage: string | null;
   extensionRunning: boolean;
   inputLocked: boolean;
+  hoverToFocus: boolean;
+  hoverToBlur: boolean;
   favoriteFolders: string[];
   pickerLoading: boolean;
   pickerOpen: boolean;
+  hoverBoundaryRef: RefObject<HTMLElement | null>;
   pickerPanelRef: RefObject<HTMLDivElement | null>;
   pickerState: Parameters<typeof ComposerFilePicker>[0]["picker"];
   placeholderText: string;
@@ -68,7 +71,10 @@ export function ComposerPromptInputPanel({
   errorMessage,
   extensionRunning,
   inputLocked,
+  hoverToFocus,
+  hoverToBlur,
   favoriteFolders,
+  hoverBoundaryRef,
   pickerLoading,
   pickerOpen,
   pickerPanelRef,
@@ -272,6 +278,9 @@ export function ComposerPromptInputPanel({
                 ariaExpanded={slashCommands.open}
                 placeholder={placeholderText}
                 readOnly={inputLocked}
+                hoverToFocus={hoverToFocus}
+                hoverToBlur={hoverToBlur}
+                hoverBoundaryRef={hoverBoundaryRef}
                 placeholderTone={errorMessage ? "error" : "muted"}
                 statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                 reservedLineCount={1}

--- a/src/app/components/workspace/composer/ComposerPromptSurface.tsx
+++ b/src/app/components/workspace/composer/ComposerPromptSurface.tsx
@@ -43,6 +43,8 @@ export function ComposerPromptSurface({
   dictationMaxDurationSeconds,
   favoriteFolders,
   showDictationButton,
+  hoverToFocus,
+  hoverToBlur,
   onOpenTakeoverTerminal,
   onToggleTerminal,
   onToggleArtifacts,
@@ -428,6 +430,9 @@ export function ComposerPromptSurface({
               attachPickerAttachments={attachPickerAttachments}
               cancelDictation={cancelDictation}
               handlePaste={handlePaste}
+              hoverToFocus={hoverToFocus}
+              hoverToBlur={hoverToBlur}
+              hoverBoundaryRef={composerPanelRef}
               onAction={onAction}
               onLayoutChange={onLayoutChange}
               onOpenSettingsView={onOpenSettingsView}

--- a/src/app/components/workspace/composer/ComposerTextField.tsx
+++ b/src/app/components/workspace/composer/ComposerTextField.tsx
@@ -2,12 +2,15 @@ import {
   type ClipboardEvent,
   type KeyboardEvent,
   type ReactNode,
+  type RefObject,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
 } from "react";
 import { cn } from "../../../utils/cn";
+import { useHoverToFocus } from "../../../hooks/useHoverToFocus";
 
 type ComposerTextFieldProps = {
   value: string;
@@ -22,6 +25,9 @@ type ComposerTextFieldProps = {
   reservedLineCount?: number;
   trailingAdornment?: ReactNode;
   readOnly?: boolean;
+  hoverToFocus?: boolean;
+  hoverToBlur?: boolean;
+  hoverBoundaryRef?: RefObject<HTMLElement | null>;
   onHeightChange?: (height: number) => void;
   onChange: (value: string) => void;
   onInput?: () => void;
@@ -45,6 +51,9 @@ export function ComposerTextField({
   reservedLineCount = 4,
   trailingAdornment = null,
   readOnly = false,
+  hoverToFocus = true,
+  hoverToBlur = false,
+  hoverBoundaryRef,
   onHeightChange,
   onChange,
   onInput,
@@ -65,7 +74,7 @@ export function ComposerTextField({
   const [trailingContainerHeight, setTrailingContainerHeight] = useState<number | null>(null);
   const lineHeightRef = useRef(20);
 
-  const focusTextareaAtEnd = () => {
+  const focusTextareaAtEnd = useCallback(() => {
     const textarea = textareaRef.current;
     if (!textarea) {
       return;
@@ -74,7 +83,15 @@ export function ComposerTextField({
     textarea.focus();
     const cursorPosition = textarea.value.length;
     textarea.setSelectionRange(cursorPosition, cursorPosition);
-  };
+  }, []);
+  const handleHoverToFocus = useHoverToFocus({
+    enabled: hoverToFocus,
+    boundaryRef: hoverBoundaryRef ?? wrapperRef,
+    targetRef: textareaRef,
+    focus: focusTextareaAtEnd,
+    blur: () => textareaRef.current?.blur(),
+    blurOnLeave: hoverToBlur,
+  });
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -189,17 +206,7 @@ export function ComposerTextField({
       ref={wrapperRef}
       className="grid min-w-0 gap-1"
       style={reservedHeight ? { minHeight: `${reservedHeight}px` } : undefined}
-      onPointerEnter={(event) => {
-        if (event.pointerType !== "mouse") {
-          return;
-        }
-
-        if (document.activeElement === textareaRef.current) {
-          return;
-        }
-
-        focusTextareaAtEnd();
-      }}
+      onPointerEnter={handleHoverToFocus}
       onPointerDown={(event) => {
         if (event.target === textareaRef.current) {
           return;

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -549,6 +549,9 @@ export function InboxComposer({
                   placeholderTone={errorMessage ? "error" : "muted"}
                   statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                   reservedLineCount={1}
+                  hoverToFocus={appSettings.hoverToFocus}
+                  hoverToBlur={appSettings.hoverToBlur}
+                  hoverBoundaryRef={composerPanelRef}
                 />
               </div>
             </div>

--- a/src/app/components/workspace/terminal/TerminalViewport.tsx
+++ b/src/app/components/workspace/terminal/TerminalViewport.tsx
@@ -11,6 +11,7 @@ import {
   writeDesktopTerminal,
 } from "../../../hooks/useDesktopTerminal";
 import { cn } from "../../../utils/cn";
+import { useHoverToFocus } from "../../../hooks/useHoverToFocus";
 import {
   cancelScheduledTerminalClose,
   scheduleTerminalClose,
@@ -48,6 +49,8 @@ type TerminalViewportProps = {
   closeWhenSessionFileIdleMs?: number;
   maxKeepAliveMsOnUnmount?: number;
   backgroundCssVar?: TerminalBackgroundCssVar;
+  hoverToFocus?: boolean;
+  hoverToBlur?: boolean;
   className?: string;
 };
 
@@ -82,6 +85,8 @@ export function TerminalViewport({
   closeWhenSessionFileIdleMs = 0,
   maxKeepAliveMsOnUnmount = DEFAULT_MAX_KEEP_ALIVE_MS_ON_UNMOUNT,
   backgroundCssVar = "--terminal-bg",
+  hoverToFocus = true,
+  hoverToBlur = false,
   className,
 }: TerminalViewportProps) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -111,6 +116,28 @@ export function TerminalViewport({
     (effectiveLaunchMode === "pi-session" ? getPersistedSessionPath(sessionPath) : null);
   const viewportStyle = useMemo(() => terminalWrapperStyle(backgroundCssVar), [backgroundCssVar]);
   const terminalStyle = useMemo(() => terminalStyleVars(backgroundCssVar), [backgroundCssVar]);
+  const focusTerminal = useCallback(() => {
+    terminalHandleRef.current?.focus();
+  }, []);
+  const blurTerminal = useCallback(() => {
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement) {
+      activeElement.blur();
+    }
+  }, []);
+  const isTerminalFocused = useCallback(() => {
+    const terminalElement = terminalInstanceRef.current?.element;
+    const activeElement = document.activeElement;
+    return !!terminalElement && !!activeElement && terminalElement.contains(activeElement);
+  }, []);
+  const handleHoverToFocus = useHoverToFocus({
+    enabled: hoverToFocus,
+    boundaryRef: viewportRef,
+    focus: focusTerminal,
+    blur: blurTerminal,
+    blurOnLeave: hoverToBlur,
+    isFocused: isTerminalFocused,
+  });
 
   const scrollTerminalToBottom = useCallback(() => {
     const terminalElement = terminalInstanceRef.current?.element;
@@ -602,6 +629,7 @@ export function TerminalViewport({
     <div
       ref={viewportRef}
       style={viewportStyle}
+      onPointerEnter={handleHoverToFocus}
       className={cn(
         "terminal-viewport relative h-full min-h-[220px] min-w-0 w-full flex-1 overflow-hidden rounded-[12px] bg-[color:var(--terminal-surface)] text-[color:var(--text)]",
         className,

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -234,6 +234,8 @@ export function ChatWorkspaceView({
                   }
                   favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
                   showDictationButton={shellState?.appSettings.showDictationButton ?? true}
+                  hoverToFocus={shellState?.appSettings.hoverToFocus ?? true}
+                  hoverToBlur={shellState?.appSettings.hoverToBlur ?? false}
                   diffRenderMode={diffRenderMode}
                   diffComments={[]}
                   diffCommentCount={0}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -229,6 +229,8 @@ export function CodeWorkspaceView({
                     useAgentsSkillsPaths: false,
                     howcodeNativeAskQuestions: false,
                     piTuiTakeover: false,
+                    hoverToFocus: true,
+                    hoverToBlur: false,
                   }
                 }
                 piSettings={shellState?.piSettings ?? defaultPiSettings}
@@ -334,6 +336,8 @@ export function CodeWorkspaceView({
                           useAgentsSkillsPaths: false,
                           howcodeNativeAskQuestions: false,
                           piTuiTakeover: false,
+                          hoverToFocus: true,
+                          hoverToBlur: false,
                         }
                       }
                       diffBaseline={diffBaseline}
@@ -400,6 +404,8 @@ export function CodeWorkspaceView({
                         }
                         favoriteFolders={shellState?.appSettings.favoriteFolders ?? []}
                         showDictationButton={shellState?.appSettings.showDictationButton ?? true}
+                        hoverToFocus={shellState?.appSettings.hoverToFocus ?? true}
+                        hoverToBlur={shellState?.appSettings.hoverToBlur ?? false}
                         diffRenderMode={diffRenderMode}
                         diffComments={diffComments}
                         diffCommentCount={diffCommentCount}

--- a/src/app/hooks/useHoverToFocus.ts
+++ b/src/app/hooks/useHoverToFocus.ts
@@ -1,0 +1,107 @@
+import { type PointerEvent, type RefObject, useCallback, useEffect } from "react";
+
+const DEFAULT_HOVER_TOLERANCE_PX = 20;
+
+function isPointInsideRectWithTolerance({
+  clientX,
+  clientY,
+  rect,
+  tolerancePx,
+}: {
+  clientX: number;
+  clientY: number;
+  rect: DOMRect;
+  tolerancePx: number;
+}) {
+  return (
+    clientX >= rect.left - tolerancePx &&
+    clientX <= rect.right + tolerancePx &&
+    clientY >= rect.top - tolerancePx &&
+    clientY <= rect.bottom + tolerancePx
+  );
+}
+
+export function useHoverToFocus<T extends HTMLElement>({
+  enabled,
+  boundaryRef,
+  targetRef,
+  focus,
+  blur,
+  blurOnLeave = false,
+  tolerancePx = DEFAULT_HOVER_TOLERANCE_PX,
+  isFocused,
+}: {
+  enabled: boolean;
+  boundaryRef?: RefObject<HTMLElement | null>;
+  targetRef?: RefObject<T | null>;
+  focus: () => void;
+  blur?: () => void;
+  blurOnLeave?: boolean;
+  tolerancePx?: number;
+  isFocused?: () => boolean;
+}) {
+  const ownsFocus = useCallback(() => {
+    if (isFocused) {
+      return isFocused();
+    }
+
+    return !!targetRef?.current && document.activeElement === targetRef.current;
+  }, [isFocused, targetRef]);
+
+  const focusIfNeeded = useCallback(() => {
+    if (!ownsFocus()) {
+      focus();
+    }
+  }, [focus, ownsFocus]);
+
+  const blurIfNeeded = useCallback(() => {
+    if (blurOnLeave && ownsFocus()) {
+      blur?.();
+    }
+  }, [blur, blurOnLeave, ownsFocus]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const handlePointerMove = (event: globalThis.PointerEvent) => {
+      if (event.pointerType !== "mouse") {
+        return;
+      }
+
+      const boundary = boundaryRef?.current ?? targetRef?.current;
+      if (!boundary) {
+        return;
+      }
+
+      const inside = isPointInsideRectWithTolerance({
+        clientX: event.clientX,
+        clientY: event.clientY,
+        rect: boundary.getBoundingClientRect(),
+        tolerancePx,
+      });
+
+      if (inside) {
+        focusIfNeeded();
+        return;
+      }
+
+      blurIfNeeded();
+    };
+
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    return () => window.removeEventListener("pointermove", handlePointerMove);
+  }, [blurIfNeeded, boundaryRef, enabled, focusIfNeeded, targetRef, tolerancePx]);
+
+  return useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      if (!enabled || event.pointerType !== "mouse") {
+        return;
+      }
+
+      focusIfNeeded();
+    },
+    [enabled, focusIfNeeded],
+  );
+}

--- a/src/app/views/settings/settingsDescriptorCommon.tsx
+++ b/src/app/views/settings/settingsDescriptorCommon.tsx
@@ -77,5 +77,33 @@ export function buildCommonSettingsDescriptors({
         />
       ),
     },
+    {
+      id: "common.hover-to-focus",
+      category: "pi-runtime",
+      title: "Hover to type",
+      description: "Focus composer and terminal input when the mouse enters their typing surface.",
+      keywords: "hover focus type composer terminal drawer input",
+      render: () => (
+        <ToggleBox
+          checked={appSettings.hoverToFocus}
+          label="Hover to type"
+          onClick={controller.toggleHoverToFocus}
+        />
+      ),
+    },
+    {
+      id: "common.hover-to-blur",
+      category: "pi-runtime",
+      title: "Stop typing on hover leave",
+      description: "Blur composer and terminal input when the cursor leaves their hover area.",
+      keywords: "hover blur leave stop typing composer terminal drawer input",
+      render: () => (
+        <ToggleBox
+          checked={appSettings.hoverToBlur}
+          label="Stop typing on hover leave"
+          onClick={controller.toggleHoverToBlur}
+        />
+      ),
+    },
   ];
 }

--- a/src/app/views/settings/useSettingsController.ts
+++ b/src/app/views/settings/useSettingsController.ts
@@ -266,6 +266,16 @@ export function useSettingsController({
         key: "howcodeNativeAskQuestions",
         value: !appSettings.howcodeNativeAskQuestions,
       }),
+    toggleHoverToFocus: () =>
+      void onAction("settings.update", {
+        key: "hoverToFocus",
+        value: !appSettings.hoverToFocus,
+      }),
+    toggleHoverToBlur: () =>
+      void onAction("settings.update", {
+        key: "hoverToBlur",
+        value: !appSettings.hoverToBlur,
+      }),
     updateFavoriteFolders,
     handleImportProjectUi,
     handleClearClipboardImages,

--- a/src/electron/main/app/create-main-window.ts
+++ b/src/electron/main/app/create-main-window.ts
@@ -33,6 +33,7 @@ export function createMainWindow() {
     height: 980,
     x: 120,
     y: 80,
+    autoHideMenuBar: true,
     icon: getWindowIconPath(),
     webPreferences: {
       preload: path.join(getElectronBuildDirectory(), "preload", "index.cjs"),

--- a/src/test/model-context-window-normalization.test.ts
+++ b/src/test/model-context-window-normalization.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeModelContextWindowValue } from "../../shared/model-context-window-normalization";
+import {
+  normalizeModelContextWindow,
+  normalizeModelContextWindowValue,
+  normalizeModelRegistryContextWindows,
+} from "../../shared/model-context-window-normalization";
 
 describe("model context window normalization", () => {
   it("treats dot-formatted token windows as thousands-grouped values", () => {
@@ -10,5 +14,34 @@ describe("model context window normalization", () => {
   it("keeps normal integer context windows unchanged", () => {
     expect(normalizeModelContextWindowValue(128_000)).toBe(128_000);
     expect(normalizeModelContextWindowValue(1_048_576)).toBe(1_048_576);
+  });
+
+  it("normalizes model context and output token limits", () => {
+    expect(normalizeModelContextWindow({ contextWindow: 202.752, maxTokens: 8.192 })).toEqual({
+      contextWindow: 202_752,
+      maxTokens: 8_192,
+    });
+  });
+
+  it("preserves synchronous getAvailable registries", () => {
+    const registry = normalizeModelRegistryContextWindows({
+      find: () => ({ id: "glm", contextWindow: 202.752, maxTokens: 8.192 }),
+      getAvailable: () => [{ id: "glm", contextWindow: 202.752, maxTokens: 8.192 }],
+    });
+
+    const availableModels = registry.getAvailable();
+    expect(Array.isArray(availableModels)).toBe(true);
+    expect(availableModels).toEqual([{ id: "glm", contextWindow: 202_752, maxTokens: 8_192 }]);
+    expect(registry.find()).toEqual({ id: "glm", contextWindow: 202_752, maxTokens: 8_192 });
+  });
+
+  it("preserves async getAvailable registries", async () => {
+    const registry = normalizeModelRegistryContextWindows({
+      getAvailable: async () => [{ id: "glm", contextWindow: 202.752, maxTokens: 8.192 }],
+    });
+
+    await expect(registry.getAvailable()).resolves.toEqual([
+      { id: "glm", contextWindow: 202_752, maxTokens: 8_192 },
+    ]);
   });
 });

--- a/src/test/model-context-window-normalization.test.ts
+++ b/src/test/model-context-window-normalization.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { normalizeModelContextWindowValue } from "../../shared/model-context-window-normalization";
+
+describe("model context window normalization", () => {
+  it("treats dot-formatted token windows as thousands-grouped values", () => {
+    expect(normalizeModelContextWindowValue(202.752)).toBe(202_752);
+    expect(normalizeModelContextWindowValue(8.192)).toBe(8_192);
+  });
+
+  it("keeps normal integer context windows unchanged", () => {
+    expect(normalizeModelContextWindowValue(128_000)).toBe(128_000);
+    expect(normalizeModelContextWindowValue(1_048_576)).toBe(1_048_576);
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize dot-formatted model token limits such as `202.752` into `202752` before composer context/compaction math uses them.
- Apply the same normalization to `maxTokens` so provider request limits are not accidentally fractional/tiny.
- Preserve synchronous vs async `ModelRegistry.getAvailable()` behavior while wrapping registry results.

## Validation
- Commit hooks ran typechecks and Vitest successfully.
- Added regression coverage for dot-formatted `contextWindow`, `maxTokens`, and sync/async registry wrappers.

Closes #186
