### PR TITLE
Fix tooltip edge clipping

### DIFF
--- a/src/app/components/common/IconButton.tsx
+++ b/src/app/components/common/IconButton.tsx
@@ -8,7 +8,7 @@ type IconButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">
   icon: ReactNode;
   active?: boolean;
   tooltip?: string | null;
-  tooltipPlacement?: "top" | "right";
+  tooltipPlacement?: "top" | "right" | "left";
 };
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton(

--- a/src/app/components/common/NavButton.tsx
+++ b/src/app/components/common/NavButton.tsx
@@ -25,6 +25,7 @@ export function NavButton({
       data-active={active ? "true" : "false"}
       aria-current={active ? "page" : undefined}
       data-tooltip={typeof title === "string" ? title : undefined}
+      data-tooltip-placement={typeof title === "string" ? "right" : undefined}
       {...buttonProps}
     >
       {icon}

--- a/src/app/components/common/Tooltip.tsx
+++ b/src/app/components/common/Tooltip.tsx
@@ -12,7 +12,7 @@ import { cn } from "../../utils/cn";
 
 type TooltipProps = PropsWithChildren<{
   content: ReactNode;
-  placement?: "top" | "right";
+  placement?: "top" | "right" | "left";
   className?: string;
   contentClassName?: string;
 }>;
@@ -28,6 +28,7 @@ export function Tooltip({
   const present = useAnimatedPresence(open, 120);
   const tooltipId = useId();
   const anchorRef = useRef<HTMLSpanElement>(null);
+  const contentRef = useRef<HTMLSpanElement>(null);
   const [position, setPosition] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
   const [positionReady, setPositionReady] = useState(false);
 
@@ -39,22 +40,35 @@ export function Tooltip({
 
     const updatePosition = () => {
       const rect = anchorRef.current?.getBoundingClientRect();
+      const tooltipRect = contentRef.current?.getBoundingClientRect();
       if (!rect) {
         return;
       }
 
       const viewportPadding = 12;
-      const left =
-        placement === "right"
-          ? Math.min(window.innerWidth - viewportPadding, rect.right + 10)
-          : Math.min(
-              window.innerWidth - viewportPadding,
-              Math.max(viewportPadding, rect.left + rect.width / 2),
-            );
+      const tooltipWidth = tooltipRect?.width ?? 0;
+      const centeredLeft = rect.left + rect.width / 2;
+      const minCenteredLeft =
+        tooltipWidth > 0 ? viewportPadding + tooltipWidth / 2 : viewportPadding;
+      const maxCenteredLeft =
+        tooltipWidth > 0
+          ? window.innerWidth - viewportPadding - tooltipWidth / 2
+          : window.innerWidth - viewportPadding;
+      const left = (() => {
+        if (placement === "right") {
+          return Math.min(window.innerWidth - viewportPadding - tooltipWidth, rect.right + 10);
+        }
+        if (placement === "left") {
+          return Math.max(viewportPadding + tooltipWidth, rect.left - 10);
+        }
+
+        return Math.min(maxCenteredLeft, Math.max(minCenteredLeft, centeredLeft));
+      })();
 
       setPosition({
         left,
-        top: placement === "right" ? rect.top + rect.height / 2 : rect.top - 8,
+        top:
+          placement === "right" || placement === "left" ? rect.top + rect.height / 2 : rect.top - 8,
       });
       setPositionReady(true);
     };
@@ -83,6 +97,7 @@ export function Tooltip({
       {present
         ? createPortal(
             <span
+              ref={contentRef}
               id={tooltipId}
               role="tooltip"
               data-open={open ? "true" : "false"}

--- a/src/app/components/common/ViewHeader.tsx
+++ b/src/app/components/common/ViewHeader.tsx
@@ -41,6 +41,7 @@ export function ViewHeader({
               onClick={onClose}
               aria-label={closeLabel}
               data-tooltip={closeLabel}
+              data-tooltip-placement="left"
             >
               <X size={14} />
             </button>

--- a/src/app/components/workspace/thread/ThreadTimelineRowChrome.tsx
+++ b/src/app/components/workspace/thread/ThreadTimelineRowChrome.tsx
@@ -111,6 +111,7 @@ export function TimelineRowShell({
           aria-expanded={expanded}
           aria-label={ariaLabel}
           data-tooltip={ariaLabel}
+          data-tooltip-align="start"
         >
           {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </button>

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -189,6 +189,7 @@ export function ChatWorkspaceView({
                   onClick={onToggleSidebar}
                   aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
                   data-tooltip={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                  data-tooltip-placement="right"
                 >
                   {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
                 </button>

--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -155,6 +155,7 @@ export function ArtifactPanel({
             disabled={!selectedArtifact}
             aria-label="Download artifact"
             data-tooltip="Download"
+            data-tooltip-placement="left"
           >
             <Download size={14} />
           </button>
@@ -168,6 +169,7 @@ export function ArtifactPanel({
             aria-label={fullscreen ? "Exit artifact fullscreen" : "Artifact fullscreen"}
             onClick={onToggleFullscreen}
             data-tooltip={fullscreen ? "Exit fullscreen" : "Fullscreen"}
+            data-tooltip-placement="left"
           >
             {fullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
           </button>
@@ -177,6 +179,7 @@ export function ArtifactPanel({
             aria-label="Hide artifacts"
             onClick={onClose}
             data-tooltip="Hide artifacts"
+            data-tooltip-placement="left"
           >
             <PanelRightClose size={14} />
           </button>

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -293,6 +293,7 @@ export function CodeWorkspaceView({
                     onClick={onToggleSidebar}
                     aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
                     data-tooltip={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                    data-tooltip-placement="right"
                   >
                     {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
                   </button>

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -187,6 +187,7 @@ export function SettingsView({
           onClick={closeSettings}
           aria-label="Close app settings"
           data-tooltip="Close app settings"
+          data-tooltip-placement="left"
         >
           <X size={14} />
         </button>

--- a/src/app/views/settings/settingsUi.tsx
+++ b/src/app/views/settings/settingsUi.tsx
@@ -18,6 +18,7 @@ export function ToggleBox({
       aria-label={label}
       aria-pressed={checked}
       data-tooltip={label}
+      data-tooltip-placement="left"
     >
       {checked ? <Check size={13} /> : null}
     </button>

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -104,7 +104,7 @@ button[data-tooltip]::after {
   position: absolute;
   top: -8px;
   left: 50%;
-  z-index: 120;
+  z-index: 1000;
   width: max-content;
   max-width: 180px;
   transform: translate(-50%, calc(-100% + 4px));
@@ -132,6 +132,37 @@ button[data-tooltip][aria-disabled="true"]::after {
   display: none;
 }
 
+button[data-tooltip][data-tooltip-align="start"]::after {
+  left: 0;
+  transform: translate(0, calc(-100% + 4px));
+}
+
+button[data-tooltip][data-tooltip-align="start"]:is(:hover, :focus-visible)::after {
+  transform: translate(0, calc(-100% - 2px));
+}
+
+button[data-tooltip][data-tooltip-placement="right"]::after {
+  top: 50%;
+  right: auto;
+  left: calc(100% + 8px);
+  transform: translate(-4px, -50%);
+}
+
+button[data-tooltip][data-tooltip-placement="right"]:is(:hover, :focus-visible)::after {
+  transform: translate(2px, -50%);
+}
+
+button[data-tooltip][data-tooltip-placement="left"]::after {
+  top: 50%;
+  right: calc(100% + 8px);
+  left: auto;
+  transform: translate(4px, -50%);
+}
+
+button[data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::after {
+  transform: translate(-2px, -50%);
+}
+
 .tooltip-anchor {
   position: relative;
   display: inline-flex;
@@ -141,7 +172,7 @@ button[data-tooltip][aria-disabled="true"]::after {
 .tooltip-content {
   pointer-events: none;
   position: fixed;
-  z-index: 120;
+  z-index: 1000;
   width: max-content;
   max-width: 360px;
   border: 1px solid var(--border-strong);
@@ -173,6 +204,15 @@ button[data-tooltip][aria-disabled="true"]::after {
 
 .tooltip-content[data-placement="right"][data-open="true"][data-ready="true"] {
   transform: translate(2px, -50%);
+  opacity: 1;
+}
+
+.tooltip-content[data-placement="left"] {
+  transform: translate(calc(-100% + 4px), -50%);
+}
+
+.tooltip-content[data-placement="left"][data-open="true"][data-ready="true"] {
+  transform: translate(calc(-100% - 2px), -50%);
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- Fixes tooltip clipping for settings controls near the right edge.
- Adds explicit left/right/start alignment variants for native `data-tooltip` tooltips.
- Improves portal tooltip positioning so top tooltips clamp within the viewport and left placement is supported.
- Raises tooltip z-index to avoid popovers/panels sitting above tooltips.

## Details
- Sidebar nav and sidebar show/hide controls now place tooltips to the right.
- Settings close buttons and toggle boxes now place tooltips to the left.
- Thread collapse/expand tooltips remain above the control but align from the start to avoid left-edge clipping.
- Right-edge artifact panel actions use left-placed tooltips.

## Validation
- Pre-commit hooks passed: Biome, TypeScript checks, and Vitest.

Closes #188
