### PR TITLE
Fix queued composer follow-ups creating new sessions

### DIFF
--- a/desktop/pi-threads/composer-actions.cts
+++ b/desktop/pi-threads/composer-actions.cts
@@ -71,13 +71,17 @@ export async function handleComposerDesktopAction(
         return handledAction();
       }
 
-      const composerSendOutcome = await sendComposerPrompt({
+      const composerSendResult = await sendComposerPrompt({
         ...getComposerRequest(payload),
         text,
         attachments,
         streamingBehavior: getComposerStreamingBehavior(payload),
       });
-      return handledAction({ composerSendOutcome });
+      return handledAction({
+        composerSendOutcome: composerSendResult.outcome,
+        composerSendSessionPath: composerSendResult.sessionPath,
+        composerSendThreadId: composerSendResult.threadId,
+      });
     }
 
     case "composer.stop": {

--- a/desktop/runtime-host/client-bridge.cts
+++ b/desktop/runtime-host/client-bridge.cts
@@ -243,7 +243,14 @@ function handleHostMessage(host: HostConnection, message: RuntimeHostToMainMessa
     }
 
     host.pendingRequests.delete(message.id);
-    if (pending.name === "sendComposerPrompt" && (!message.ok || message.result !== "sent")) {
+    const sendOutcome =
+      message.ok &&
+      typeof message.result === "object" &&
+      message.result !== null &&
+      "outcome" in message.result
+        ? message.result.outcome
+        : null;
+    if (pending.name === "sendComposerPrompt" && (!message.ok || sendOutcome !== "sent")) {
       host.busy = false;
     }
     scheduleThreadHostIdleStop(host);

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -279,11 +279,16 @@ export async function sendComposerPrompt(
     attachments?: ComposerAttachment[];
     streamingBehavior?: ComposerStreamingBehavior | null;
   },
-): Promise<"sent" | "stopped"> {
+): Promise<{ outcome: "sent" | "stopped"; sessionPath: string | null; threadId: string | null }> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   const compactInstructions = parseCompactSlashCommand(request.text);
   const runSend = async (runtime: PiRuntime) => {
     const runtimeKey = getPersistedSessionPath(runtime.session.sessionFile);
+    const sendResult = (outcome: "sent" | "stopped") => ({
+      outcome,
+      sessionPath: getPersistedSessionPath(runtime.session.sessionFile),
+      threadId: runtime.session.sessionId ?? null,
+    });
     try {
       if (compactInstructions !== null) {
         if (isRuntimeExtensionCommandRunning(runtime))
@@ -299,7 +304,7 @@ export async function sendComposerPrompt(
           compactInstructions.length > 0 ? compactInstructions : undefined,
         );
         await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-        return "sent" as const;
+        return sendResult("sent");
       }
       const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? []);
       const message = `${attachmentPrompt ? `${attachmentPrompt}\n\n` : ""}${request.text}`;
@@ -312,7 +317,7 @@ export async function sendComposerPrompt(
           if (!isExtensionCommandPrompt(runtime, request.text)) {
             await runtime.session.abort();
             await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-            return "stopped" as const;
+            return sendResult("stopped");
           }
         }
         const promptStreamingBehavior =
@@ -333,7 +338,7 @@ export async function sendComposerPrompt(
       await publishThreadUpdate(runtime, "update").catch((error) =>
         console.error("Composer prompt accepted but thread update publish failed", error),
       );
-      return "sent" as const;
+      return sendResult("sent");
     } finally {
       if (runtimeKey) scheduleRuntimeDisposal(runtimeKey);
     }

--- a/desktop/runtime-host/protocol.cts
+++ b/desktop/runtime-host/protocol.cts
@@ -105,7 +105,11 @@ export type RuntimeHostResponseMap = {
   generateGitCommitMessage: string | null;
   setComposerModel: { ok: true };
   setComposerThinkingLevel: { ok: true };
-  sendComposerPrompt: "sent" | "stopped";
+  sendComposerPrompt: {
+    outcome: "sent" | "stopped";
+    sessionPath: string | null;
+    threadId: string | null;
+  };
   stopComposerRun: { ok: true };
   dequeueComposerPrompt: string | null;
   answerNativeAskQuestions: { ok: boolean };

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -281,11 +281,17 @@ export async function sendComposerPrompt(
     attachments?: ComposerAttachment[];
     streamingBehavior?: ComposerStreamingBehavior | null;
   },
-): Promise<"sent" | "stopped"> {
+): Promise<{ outcome: "sent" | "stopped"; sessionPath: string | null; threadId: string | null }> {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath);
   const compactInstructions = parseCompactSlashCommand(request.text);
 
   const runSend = async (runtime: Awaited<ReturnType<typeof getOrCreateRuntimeForSessionPath>>) => {
+    const sendResult = (outcome: "sent" | "stopped") => ({
+      outcome,
+      sessionPath: getPersistedSessionPath(runtime.session.sessionFile),
+      threadId: runtime.session.sessionId ?? null,
+    });
+
     if (compactInstructions !== null) {
       try {
         if (isRuntimeExtensionCommandRunning(runtime)) {
@@ -311,7 +317,7 @@ export async function sendComposerPrompt(
         );
 
         await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-        return "sent";
+        return sendResult("sent");
       } finally {
         scheduleRuntimeDisposalForRuntime(runtime);
       }
@@ -334,7 +340,7 @@ export async function sendComposerPrompt(
           if (!isExtensionCommandPrompt(runtime, request.text)) {
             await runtime.session.abort();
             await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath });
-            return "stopped";
+            return sendResult("stopped");
           }
         }
 
@@ -353,11 +359,10 @@ export async function sendComposerPrompt(
           request: { ...request, sessionPath: persistedSessionPath },
         });
       }
-
       await publishThreadUpdate(runtime, "update").catch((error) => {
         console.error("Composer prompt accepted but thread update publish failed", error);
       });
-      return "sent";
+      return sendResult("sent");
     } catch (error) {
       scheduleRuntimeDisposalForRuntime(runtime);
       throw error;

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -205,6 +205,8 @@ export type DesktopActionResultData = {
   committed?: boolean;
   composer?: ComposerState;
   composerSendOutcome?: "sent" | "stopped";
+  composerSendSessionPath?: string | null;
+  composerSendThreadId?: string | null;
   dequeuedText?: string | null;
   deletedThreadIds?: string[];
   didMutate?: boolean;

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -258,6 +258,73 @@ export async function runPostDesktopActionEffects({
     }
   }
 
+  if (action === "composer.send" && !hasActionError(actionResult)) {
+    const projectId = getPayloadProjectId(contextualPayload);
+    const submittedSessionPath =
+      typeof contextualPayload.sessionPath === "string" ? contextualPayload.sessionPath : null;
+    const resultSessionPath =
+      typeof actionResult?.result?.composerSendSessionPath === "string"
+        ? actionResult.result.composerSendSessionPath
+        : null;
+    const resultThreadId =
+      typeof actionResult?.result?.composerSendThreadId === "string"
+        ? actionResult.result.composerSendThreadId
+        : null;
+
+    if (
+      projectId &&
+      (!submittedSessionPath || isLocalSessionPath(submittedSessionPath)) &&
+      resultSessionPath &&
+      resultThreadId
+    ) {
+      const shellState = (
+        queryClient as {
+          getQueryData?: (queryKey: readonly unknown[]) => unknown;
+        }
+      ).getQueryData?.(["desktop", "shellState"]) as
+        | {
+            projects?: Array<{
+              id: string;
+              threads: Array<{ id: string; sessionPath?: string | null; title?: string }>;
+            }>;
+          }
+        | null
+        | undefined;
+      const existingThreadTitle =
+        shellState?.projects
+          ?.find((candidate) => candidate.id === projectId)
+          ?.threads.find(
+            (candidate) =>
+              candidate.id === resultThreadId || candidate.sessionPath === resultSessionPath,
+          )?.title ?? null;
+
+      applyProjectThreadToShellState(
+        queryClient,
+        projectId,
+        {
+          id: resultThreadId,
+          title: existingThreadTitle ?? "New thread",
+          age: "Now",
+          lastModifiedMs: Date.now(),
+          sessionPath: resultSessionPath,
+        },
+        {
+          replaceSessionPath: isLocalSessionPath(submittedSessionPath)
+            ? submittedSessionPath
+            : null,
+          revealProject: true,
+        },
+      );
+      dispatch({
+        type: "open-thread",
+        projectId,
+        threadId: resultThreadId,
+        sessionPath: resultSessionPath,
+        view: workspaceState.activeView === "chat" ? "chat" : "thread",
+      });
+    }
+  }
+
   // Settings writes are local and already applied optimistically in the renderer.
   // Refreshing shell state here can race against that optimistic update and briefly
   // snap controls back to stale values before the next state load lands.

--- a/src/app/app-shell/desktop-event-sync.ts
+++ b/src/app/app-shell/desktop-event-sync.ts
@@ -10,7 +10,11 @@ type QueryClientLike = {
 
 export type DesktopEventSelectionState = Pick<
   WorkspaceState,
-  "activeView" | "selectedProjectId" | "selectedSessionPath" | "selectedInboxSessionPath"
+  | "activeView"
+  | "selectedProjectId"
+  | "selectedThreadId"
+  | "selectedSessionPath"
+  | "selectedInboxSessionPath"
 >;
 
 export function getVisibleDesktopSessionPath(workspaceState: DesktopEventSelectionState) {
@@ -26,7 +30,6 @@ export function getVisibleDesktopSessionPath(workspaceState: DesktopEventSelecti
 export function shouldAutoOpenStartedThread({
   reason,
   projectId,
-  isChat,
   workspaceState,
 }: {
   reason: Extract<DesktopEvent, { type: "thread-update" }>["reason"];
@@ -38,18 +41,9 @@ export function shouldAutoOpenStartedThread({
     return false;
   }
 
-  const visibleSessionPath = getVisibleDesktopSessionPath(workspaceState);
-  const localDraftProjectId = getLocalDraftProjectId(workspaceState.selectedSessionPath);
-
-  if (localDraftProjectId) {
-    return false;
-  }
-
-  return (
-    (workspaceState.activeView === "code" && isChat !== true) ||
-    (workspaceState.activeView === "chat" && visibleSessionPath === null && isChat === true) ||
-    (workspaceState.activeView === "thread" && visibleSessionPath === null)
-  );
+  // Do not let background/runtime-host starts steal focus. User-initiated sends and explicit
+  // thread creation open from their action result; ambient thread events should only update caches.
+  return false;
 }
 
 export function shouldDisplayStartedThreadForLocalDraft({

--- a/src/app/app-shell/useDesktopEventSync.ts
+++ b/src/app/app-shell/useDesktopEventSync.ts
@@ -55,6 +55,7 @@ export function useDesktopEventSync({
     workspaceState: {
       activeView: workspaceState.activeView,
       selectedProjectId: workspaceState.selectedProjectId,
+      selectedThreadId: workspaceState.selectedThreadId,
       selectedSessionPath: workspaceState.selectedSessionPath,
       selectedInboxSessionPath: workspaceState.selectedInboxSessionPath,
     } satisfies DesktopEventSelectionState,
@@ -67,6 +68,7 @@ export function useDesktopEventSync({
       workspaceState: {
         activeView: workspaceState.activeView,
         selectedProjectId: workspaceState.selectedProjectId,
+        selectedThreadId: workspaceState.selectedThreadId,
         selectedSessionPath: workspaceState.selectedSessionPath,
         selectedInboxSessionPath: workspaceState.selectedInboxSessionPath,
       },
@@ -75,6 +77,7 @@ export function useDesktopEventSync({
     composerProjectId,
     workspaceState.activeView,
     workspaceState.selectedProjectId,
+    workspaceState.selectedThreadId,
     workspaceState.selectedInboxSessionPath,
     workspaceState.selectedSessionPath,
   ]);
@@ -243,6 +246,18 @@ export function useDesktopEventSync({
           threadId: event.threadId,
           sessionPath: event.sessionPath,
           view: event.isChat === true ? "chat" : "thread",
+        });
+      } else if (
+        isVisibleThreadUpdate &&
+        latestWorkspaceState.selectedThreadId !== event.threadId &&
+        (latestWorkspaceState.activeView === "chat" || latestWorkspaceState.activeView === "thread")
+      ) {
+        dispatch({
+          type: "open-thread",
+          projectId: event.projectId,
+          threadId: event.threadId,
+          sessionPath: event.sessionPath,
+          view: latestWorkspaceState.activeView,
         });
       }
 

--- a/src/test/desktop-event-sync.test.ts
+++ b/src/test/desktop-event-sync.test.ts
@@ -13,6 +13,7 @@ function selectionState(
   return {
     activeView: "code",
     selectedProjectId: "/repo/project-a",
+    selectedThreadId: null,
     selectedSessionPath: null,
     selectedInboxSessionPath: null,
     ...overrides,
@@ -110,14 +111,14 @@ describe("desktop event selection helpers", () => {
     ).toBe(false);
   });
 
-  it("keeps same-project auto-open behavior for empty thread and code views", () => {
+  it("does not auto-open background starts for empty thread and code views", () => {
     expect(
       shouldAutoOpenStartedThread({
         reason: "start",
         projectId: "/repo/project-a",
         workspaceState: selectionState({ activeView: "thread", selectedSessionPath: null }),
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     expect(
       shouldAutoOpenStartedThread({
@@ -125,7 +126,7 @@ describe("desktop event selection helpers", () => {
         projectId: "/repo/project-a",
         workspaceState: selectionState({ activeView: "code" }),
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("does not auto-open non-start updates or when a persisted session is visible", () => {


### PR DESCRIPTION
## Summary
- return persisted session/thread info from composer sends and promote local draft selections after first send
- replace local draft sidebar entries without regressing existing thread titles
- prevent background thread-start events from stealing focus; keep selected thread id aligned from visible events

## Validation
- pre-commit hook: typecheck:web, typecheck:desktop, typecheck:electron, typecheck:scripts, vitest
- pre-push hook: lint, typecheck
