### PR TITLE
Theme chat and inbox styling gaps

### DIFF
--- a/src/app/components/sidebar/inbox/InboxThreadRow.tsx
+++ b/src/app/components/sidebar/inbox/InboxThreadRow.tsx
@@ -37,7 +37,7 @@ export function InboxThreadRow({
         {running ? (
           <ActivitySpinner className="h-3.5 w-3.5 text-[color:var(--text)]" />
         ) : unread ? (
-          <span className="h-2 w-2 rounded-full bg-[rgba(183,186,245,0.95)]" />
+          <span className="h-2 w-2 rounded-full bg-[color:var(--accent)]" />
         ) : null}
       </div>
 

--- a/src/app/components/workspace/composer/ComposerContextMeter.tsx
+++ b/src/app/components/workspace/composer/ComposerContextMeter.tsx
@@ -27,18 +27,18 @@ function formatTokens(value: number | null | undefined, options: { compact?: boo
 
 function getMeterTone(percent: number | null | undefined) {
   if (percent === null || percent === undefined) {
-    return "rgba(146,153,184,0.64)";
+    return "var(--muted)";
   }
 
   if (percent > 90) {
-    return "#ff9f9f";
+    return "var(--danger)";
   }
 
   if (percent > 70) {
-    return "#f2c27f";
+    return "var(--warning)";
   }
 
-  return "#9bb7ff";
+  return "var(--accent)";
 }
 
 type Point = {
@@ -168,7 +168,7 @@ export function ComposerContextMeter({
       <button
         ref={buttonRef}
         type="button"
-        className="relative inline-flex h-7 w-7 items-center justify-center rounded-full text-[color:var(--muted)] transition-colors hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]"
+        className="relative inline-flex h-7 w-7 items-center justify-center rounded-full text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
         onClick={() => setPinned((current) => !current)}
         aria-label={label}
         aria-expanded={open}
@@ -176,7 +176,7 @@ export function ComposerContextMeter({
         <span
           className={cn("absolute inset-[7px] rounded-full", isCompacting && "animate-pulse")}
           style={{
-            background: `conic-gradient(${tone} ${meterPercent * 3.6}deg, rgba(255,255,255,0.08) 0deg)`,
+            background: `conic-gradient(${tone} ${meterPercent * 3.6}deg, var(--border-strong) 0deg)`,
           }}
         />
         <span className="absolute inset-[11px] rounded-full bg-[color:var(--panel)]" />
@@ -185,7 +185,7 @@ export function ComposerContextMeter({
       {open ? (
         <div
           ref={popoverRef}
-          className="absolute bottom-full left-0 z-[130] grid w-56 gap-2 rounded-xl border border-[color:var(--border)] bg-[color:var(--panel)] p-3 text-[12px] text-[color:var(--muted)] shadow-[0_18px_44px_rgba(0,0,0,0.4)]"
+          className="absolute bottom-full left-0 z-[130] grid w-56 gap-2 rounded-xl border border-[color:var(--border)] bg-[color:var(--panel)] p-3 text-[12px] text-[color:var(--muted)] shadow-[var(--shadow)]"
           onMouseEnter={openHoverPreview}
           onMouseDown={(event) => event.preventDefault()}
         >
@@ -219,7 +219,7 @@ export function ComposerContextMeter({
             </div>
           ) : null}
           {isCompacting ? (
-            <div className="rounded-lg border border-[rgba(155,183,255,0.2)] bg-[rgba(155,183,255,0.08)] px-2 py-1.5 text-[11px] text-[#cbd7ff]">
+            <div className="rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-bg-subtle)] px-2 py-1.5 text-[11px] text-[color:var(--accent)]">
               Compacting session context…
             </div>
           ) : null}

--- a/src/app/components/workspace/composer/ComposerModelPopover.tsx
+++ b/src/app/components/workspace/composer/ComposerModelPopover.tsx
@@ -42,8 +42,8 @@ function TriggerButton({
       type="button"
       className={cn(
         toolbarButtonClass,
-        "grid w-full gap-0.5 rounded-xl px-2.5 py-2 text-left hover:bg-[rgba(255,255,255,0.045)]",
-        active && "bg-[rgba(255,255,255,0.05)] text-[color:var(--text)]",
+        "grid w-full gap-0.5 rounded-xl px-2.5 py-2 text-left hover:bg-[color:var(--surface-hover)]",
+        active && "bg-[color:var(--accent-bg-subtle)] text-[color:var(--text)]",
       )}
       onClick={onClick}
     >
@@ -69,7 +69,7 @@ function MenuList({ items }: { items: MenuOption[] }) {
             className={cn(
               menuOptionClass,
               "mr-1 text-[12px] text-[color:var(--text)]",
-              item.selected && "bg-[rgba(255,255,255,0.06)]",
+              item.selected && "bg-[color:var(--accent-bg-subtle)]",
             )}
             onClick={item.onSelect}
           >
@@ -213,7 +213,7 @@ export function ComposerModelPopover({
       ref={panelRef}
       id="composer-model-menu"
       className={cn(
-        "absolute bottom-[calc(100%+8px)] left-0 z-[60] grid w-52 max-w-[calc(100vw-2rem)] overflow-x-hidden rounded-2xl border-[color:var(--border-strong)] p-1.5 text-[12px] shadow-[0_18px_40px_rgba(0,0,0,0.28)]",
+        "absolute bottom-[calc(100%+8px)] left-0 z-[60] grid w-52 max-w-[calc(100vw-2rem)] overflow-x-hidden rounded-2xl border-[color:var(--border-strong)] p-1.5 text-[12px]",
         popoverPanelClass,
       )}
     >
@@ -227,7 +227,7 @@ export function ComposerModelPopover({
             ref={modelSearchRef}
             value={modelSearch}
             onChange={(event) => setModelSearch(event.currentTarget.value)}
-            className="h-8 w-full rounded-lg border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.055)] px-2.5 pl-8 text-[11px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
+            className="h-8 w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--panel-2)] px-2.5 pl-8 text-[11px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
             placeholder={`Search ${modelsForProvider.length} models…`}
             aria-label="Search models"
           />
@@ -236,7 +236,7 @@ export function ComposerModelPopover({
       {openMenuItems.length > 0 ? (
         <>
           <MenuList items={openMenuItems} />
-          <div className="mx-2 mb-1 h-px bg-[rgba(169,178,215,0.08)]" />
+          <div className="mx-2 mb-1 h-px bg-[color:var(--border)]" />
         </>
       ) : showModelSearch ? (
         <div className="px-2 py-3 text-[11px] text-[color:var(--muted)]">No matching models</div>

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -439,7 +439,7 @@ export function InboxComposer({
                     <Paperclip size={16} />
                   </span>
                   {attachments.length > 0 ? (
-                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
+                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[color:var(--accent-bg-subtle)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
                       {attachments.length}
                     </span>
                   ) : null}
@@ -604,7 +604,7 @@ export function InboxComposer({
         </output>
       ) : null}
 
-      <div className="h-px bg-[rgba(169,178,215,0.07)]" />
+      <div className="h-px bg-[color:var(--border)]" />
 
       <div className="flex items-center justify-end gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
         <div className="relative mr-auto inline-flex h-7 items-center">

--- a/src/app/components/workspace/thread/ThreadTimeline.tsx
+++ b/src/app/components/workspace/thread/ThreadTimeline.tsx
@@ -22,7 +22,7 @@ type ThreadTimelineProps = {
 };
 
 const timelineQuickActionButtonClass =
-  "pointer-events-auto h-6 w-6 shrink-0 rounded-full bg-[rgba(146,153,184,0.22)] hover:bg-[rgba(146,153,184,0.32)] disabled:cursor-not-allowed disabled:opacity-45";
+  "pointer-events-auto h-6 w-6 shrink-0 rounded-full bg-[color:var(--panel-2)] hover:bg-[color:var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-45";
 
 export function ThreadTimeline({
   messages,
@@ -313,9 +313,9 @@ export function ThreadTimeline({
       </div>
       {isCompacting ? (
         <div className="pointer-events-none absolute right-4 bottom-4 left-4 z-20 flex justify-center">
-          <div className="rounded-full border border-[rgba(155,183,255,0.18)] bg-[color:var(--panel)] px-3 py-2 text-[13px] text-[#cbd7ff] shadow-[0_18px_44px_rgba(0,0,0,0.36)]">
+          <div className="rounded-full border border-[color:var(--accent-border)] bg-[color:var(--panel)] px-3 py-2 text-[13px] text-[color:var(--accent)] shadow-[var(--shadow)]">
             <div className="flex items-center gap-2">
-              <span className="h-2 w-2 animate-pulse rounded-full bg-[#9bb7ff]" />
+              <span className="h-2 w-2 animate-pulse rounded-full bg-[color:var(--accent)]" />
               <span>Compacting session context…</span>
             </div>
           </div>

--- a/src/app/components/workspace/thread/ThreadTimelineRow.tsx
+++ b/src/app/components/workspace/thread/ThreadTimelineRow.tsx
@@ -64,7 +64,7 @@ export function ThreadTimelineRow({
           className="group flex w-full items-center justify-center py-1 text-[13px] text-[color:var(--muted-2)]"
           onClick={onJumpToEarlierMessages}
         >
-          <span className="rounded-[12px] px-3 py-1 transition-colors group-hover:bg-[rgba(255,255,255,0.03)] group-focus-visible:bg-[rgba(255,255,255,0.03)]">
+          <span className="rounded-[12px] px-3 py-1 transition-colors group-hover:bg-[color:var(--surface-hover)] group-focus-visible:bg-[color:var(--surface-hover)]">
             {row.hiddenCount} earlier messages
           </span>
         </button>
@@ -167,7 +167,7 @@ export function ThreadTimelineRow({
         >
           <div className="grid min-w-0 gap-3">
             {showCompactionDivider ? (
-              <div className="h-px w-full bg-[rgba(161,173,221,0.14)]" />
+              <div className="h-px w-full bg-[color:var(--border-strong)]" />
             ) : null}
             <FoldedTimelineRow
               label={summaryLabel}
@@ -189,7 +189,7 @@ export function ThreadTimelineRow({
       >
         <div className="grid min-w-0 gap-3">
           {showCompactionDivider ? (
-            <div className="h-px w-full bg-[rgba(161,173,221,0.14)]" />
+            <div className="h-px w-full bg-[color:var(--border-strong)]" />
           ) : null}
           <RowLeadToggleSurface onToggle={() => onToggleRowCollapse(row.id)}>
             <ThreadMessage message={row.message} />

--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -73,9 +73,9 @@ export function ArtifactPanel({
   return (
     <section
       aria-label="Artifacts drawer"
-      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden border-l border-[rgba(169,178,215,0.08)] bg-[color:var(--workspace)]"
+      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden border-l border-[color:var(--border)] bg-[color:var(--workspace)]"
     >
-      <div className="flex h-11 items-center justify-between gap-3 border-b border-[rgba(169,178,215,0.08)] px-3">
+      <div className="flex h-11 items-center justify-between gap-3 border-b border-[color:var(--border)] px-3">
         <div className="flex min-w-0 items-center gap-2 text-[13px] text-[color:var(--text)]">
           <FileCode2 size={15} className="shrink-0 text-[color:var(--muted)]" />
           {selectedArtifact ? (
@@ -87,7 +87,7 @@ export function ArtifactPanel({
         <div className="flex items-center gap-1">
           {selectedArtifact ? (
             <select
-              className="h-7 rounded-md border border-[rgba(169,178,215,0.08)] bg-[rgba(255,255,255,0.03)] px-2 text-[11px] text-[color:var(--muted)] outline-none transition-colors hover:bg-[rgba(255,255,255,0.05)] hover:text-[color:var(--text)]"
+              className="h-7 rounded-md border border-[color:var(--border)] bg-[color:var(--panel-2)] px-2 text-[11px] text-[color:var(--muted)] outline-none transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
               value={selectedVersion}
               onChange={(event) => {
                 const value = event.target.value;
@@ -175,7 +175,7 @@ export function ArtifactPanel({
           </button>
           <button
             type="button"
-            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[color:var(--muted)] transition-colors duration-150 ease-out hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[color:var(--muted)] transition-colors duration-150 ease-out hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
             aria-label="Hide artifacts"
             onClick={onClose}
             data-tooltip="Hide artifacts"
@@ -201,9 +201,9 @@ export function ArtifactPanel({
                   key={artifact.slug}
                   type="button"
                   className={cn(
-                    "rounded-lg px-3 py-2.5 text-left text-[12px] text-[color:var(--muted)] transition-colors hover:bg-[rgba(255,255,255,0.04)] hover:text-[color:var(--text)]",
+                    "rounded-lg px-3 py-2.5 text-left text-[12px] text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]",
                     artifact.slug === selectedArtifact?.slug &&
-                      "bg-[rgba(183,186,245,0.1)] text-[color:var(--text)]",
+                      "bg-[color:var(--accent-bg-subtle)] text-[color:var(--text)]",
                   )}
                   onClick={() => {
                     setSelectedArtifactId(artifact.slug);
@@ -222,7 +222,7 @@ export function ArtifactPanel({
 
         {view === "code" ? (
           <textarea
-            className="h-full w-full resize-none overflow-auto bg-[#111521] p-3 font-mono text-[12px] leading-5 text-[color:var(--text)] outline-none"
+            className="h-full w-full resize-none overflow-auto bg-[color:var(--panel)] p-3 font-mono text-[12px] leading-5 text-[color:var(--text)] outline-none"
             value={draft}
             spellCheck={false}
             readOnly={showingHistoricalVersion}
@@ -255,7 +255,7 @@ export function ArtifactPanel({
         {view === "preview" && selectedArtifact?.kind !== "markdown" ? (
           <div className="relative h-full bg-[color:var(--sidebar)]">
             {previewError ? (
-              <pre className="absolute right-2 bottom-2 left-2 z-10 max-h-32 overflow-auto rounded-lg border border-[#f2a7a7]/30 bg-[#2b1720]/95 p-2 text-[11px] whitespace-pre-wrap text-[color:var(--danger)]">
+              <pre className="absolute right-2 bottom-2 left-2 z-10 max-h-32 overflow-auto rounded-lg border border-[color:var(--danger-border)] bg-[color:var(--danger-bg)] p-2 text-[11px] whitespace-pre-wrap text-[color:var(--danger)]">
                 {previewError}
               </pre>
             ) : null}

--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -255,7 +255,7 @@ export function ArtifactPanel({
         {view === "preview" && selectedArtifact?.kind !== "markdown" ? (
           <div className="relative h-full bg-[color:var(--sidebar)]">
             {previewError ? (
-              <pre className="absolute right-2 bottom-2 left-2 z-10 max-h-32 overflow-auto rounded-lg border border-[color:var(--danger-border)] bg-[color:var(--danger-bg)] p-2 text-[11px] whitespace-pre-wrap text-[color:var(--danger)]">
+              <pre className="absolute right-2 bottom-2 left-2 z-10 max-h-32 overflow-auto rounded-lg border border-[color:var(--danger-border)] bg-[color:var(--panel)] p-2 text-[11px] whitespace-pre-wrap text-[color:var(--danger)] shadow-[var(--shadow)]">
                 {previewError}
               </pre>
             ) : null}

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -162,7 +162,7 @@ export function InboxView({
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] px-6 pt-6 pb-4">
       <div className="w-full pb-5">
-        <div className="grid w-full gap-2 rounded-[18px] border border-[rgba(169,178,215,0.09)] bg-[rgba(43,47,62,0.72)] px-4 py-3 shadow-[0_18px_48px_rgba(7,8,14,0.16)]">
+        <div className="grid w-full gap-2 rounded-[18px] border border-[color:var(--border)] bg-[color:var(--panel)] px-4 py-3 shadow-[var(--shadow)]">
           <div className="flex min-w-0 items-center gap-2 text-[11px] leading-4 text-[color:var(--muted-2)]">
             <span className="truncate">{thread.projectName}</span>
             <span aria-hidden="true">•</span>


### PR DESCRIPTION
## Summary
- Replace remaining hardcoded chat timeline, composer popover, context meter, and artifact drawer colors with theme variables.
- Theme inbox card, composer attachment/divider accents, and unread dot styling.
- Keep warning/danger/accent states mapped to the existing token set so alternate themes can adapt these surfaces.

## Validation
- Pre-commit hook ran biome, typechecks, and vitest during commit.
- Pre-push hook ran lint and typecheck during push.
