### PR TITLE
Add settings help column

### DIFF
--- a/settings-descriptions.md
+++ b/settings-descriptions.md
@@ -1,0 +1,221 @@
+# Settings descriptions
+
+Edit the `Description` text. Keep each `ID` unchanged so edits can be mapped back.
+
+## src/app/views/settings/settingsDescriptorProjects.tsx
+
+### Default project location
+
+- ID: `projects.default-location`
+- Category: `projects`
+- Description:
+
+Default folder for new projects.
+
+### Initialise git
+
+- ID: `projects.initialize-git`
+- Category: `projects`
+- Description:
+
+Always git init when creating a new project.
+
+### GitOps default
+
+- ID: `projects.gitops-default`
+- Category: `projects`
+- Description:
+
+Default global commit action.
+
+### Diff comparison default
+
+- ID: `projects.git-diff-baseline-default`
+- Category: `projects`
+- Description:
+
+Default baseline setting for git summary.
+
+### Diff view default
+
+- ID: `projects.git-diff-render-default`
+- Category: `projects`
+- Description:
+
+Default layout for the GitOps diff panel.
+
+### Diff file tree
+
+- ID: `projects.git-diff-file-tree-default`
+- Category: `projects`
+- Description:
+
+Default visibility for the GitOps file tree.
+
+### Project deletion cleanup
+
+- ID: `projects.deletion-mode`
+- Category: `projects`
+- Description:
+
+Delete only Pi session files, or nuke the full project folder.
+
+### Project UI import
+
+- ID: `projects.import-ui`
+- Category: `projects`
+- Description:
+
+Scan projects for UI info like repo and origin status.
+
+### Favorite folders
+
+- ID: `projects.favorite-folders`
+- Category: `projects`
+- Description:
+
+Paths shown in the attachment picker alongside Home.
+
+### Clipboard images
+
+- ID: `projects.clipboard-images`
+- Category: `projects`
+- Description:
+
+Delete temp clipboard images.
+
+## src/app/views/settings/settingsDescriptorCommon.tsx
+
+### Send while Pi is responding
+
+- ID: `common.streaming-behavior`
+- Category: `pi-runtime`
+- Description:
+
+Composer follow-up messages behavior.
+
+### Ask questions tool
+
+- ID: `common.howcode-native-ask-questions`
+- Category: `pi-runtime`
+- Description:
+
+Native ask questions tool (GUI+TUI).
+
+### Open in TUI
+
+- ID: `common.pi-tui-takeover`
+- Category: `pi-runtime`
+- Description:
+
+Always use Pi TUI takeover.
+
+### Hover to type
+
+- ID: `common.hover-to-focus`
+- Category: `pi-runtime`
+- Description:
+
+Hover to input for composer and terminal.
+
+### Stop typing on hover leave
+
+- ID: `common.hover-to-blur`
+- Category: `pi-runtime`
+- Description:
+
+Instantly leave input when not in hover area.
+
+## src/app/views/settings/settingsDescriptorModels.tsx
+
+### Chat
+
+- ID: `models.chat`
+- Category: `models`
+- Description:
+
+Default settings for the Chat view.
+
+### Code
+
+- ID: `models.code`
+- Category: `models`
+- Description:
+
+Default settings for the Code view.
+
+### Git commit messages
+
+- ID: `models.git-commit`
+- Category: `models`
+- Description:
+
+Default settings for the GitOps view.
+
+### Skill creator
+
+- ID: `models.skill-creator`
+- Category: `models`
+- Description:
+
+Default settings for the built-in skill creator.
+
+## src/app/views/settings/settingsDescriptorPiRuntime.tsx
+
+### Theme
+
+- ID: `pi-runtime.theme`
+- Category: `pi-runtime`
+- Description:
+
+Select a theme to use. Syncs with Pi's JSON files.
+
+### Transport
+
+- ID: `pi-runtime.transport`
+- Category: `pi-runtime`
+- Description:
+
+Soon to be deprecated.
+
+### Auto compact context
+
+- ID: `pi-runtime.auto-compact`
+- Category: `pi-runtime`
+- Description:
+
+Switch auto compaction on or off.
+
+### Enable skill slash commands
+
+- ID: `pi-runtime.skill-commands`
+- Category: `pi-runtime`
+- Description:
+
+Expose installed skills as /commands.
+
+## src/app/views/settings/settingsDescriptorDictation.tsx
+
+### Speech-to-text model
+
+- ID: `dictation.models`
+- Category: `dictation`
+- Description:
+
+Dictation model selection.
+
+### Max dictation length
+
+- ID: `dictation.max-duration`
+- Category: `dictation`
+- Description:
+
+`Safety net in case you forget. Default is ${DEFAULT_DICTATION_MAX_DURATION_SECONDS / 60} minutes.`
+
+### Toggle dictation
+
+- ID: `dictation.show-button`
+- Category: `dictation`
+- Description:
+
+Hide if you have a preferred dictation system.

--- a/src/app/components/common/Tooltip.tsx
+++ b/src/app/components/common/Tooltip.tsx
@@ -1,6 +1,8 @@
 import {
+  type HTMLAttributes,
   type PropsWithChildren,
   type ReactNode,
+  useEffect,
   useId,
   useLayoutEffect,
   useRef,
@@ -10,27 +12,69 @@ import { createPortal } from "react-dom";
 import { useAnimatedPresence } from "../../hooks/useAnimatedPresence";
 import { cn } from "../../utils/cn";
 
-type TooltipProps = PropsWithChildren<{
-  content: ReactNode;
-  placement?: "top" | "right" | "left";
-  className?: string;
-  contentClassName?: string;
-}>;
+type TooltipProps = PropsWithChildren<
+  HTMLAttributes<HTMLSpanElement> & {
+    content: ReactNode;
+    placement?: "top" | "right" | "left";
+    className?: string;
+    contentClassName?: string;
+    delayMs?: number;
+  }
+>;
 
 export function Tooltip({
   content,
   placement = "top",
   className,
   contentClassName,
+  delayMs = 0,
   children,
+  ...anchorProps
 }: TooltipProps) {
   const [open, setOpen] = useState(false);
   const present = useAnimatedPresence(open, 120);
   const tooltipId = useId();
   const anchorRef = useRef<HTMLSpanElement>(null);
   const contentRef = useRef<HTMLSpanElement>(null);
-  const [position, setPosition] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
+  const openTimerRef = useRef<number | null>(null);
+  const [position, setPosition] = useState<{ left: number; top: number }>({
+    left: 0,
+    top: 0,
+  });
   const [positionReady, setPositionReady] = useState(false);
+
+  const clearOpenTimer = () => {
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+  };
+
+  const showTooltip = () => {
+    clearOpenTimer();
+    if (delayMs <= 0) {
+      setOpen(true);
+      return;
+    }
+
+    openTimerRef.current = window.setTimeout(() => {
+      openTimerRef.current = null;
+      setOpen(true);
+    }, delayMs);
+  };
+
+  const hideTooltip = () => {
+    clearOpenTimer();
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (openTimerRef.current !== null) {
+        window.clearTimeout(openTimerRef.current);
+      }
+    };
+  }, []);
 
   useLayoutEffect(() => {
     if (!present) {
@@ -85,12 +129,13 @@ export function Tooltip({
 
   return (
     <span
+      {...anchorProps}
       ref={anchorRef}
       className={cn("tooltip-anchor", className)}
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
-      onFocus={() => setOpen(true)}
-      onBlur={() => setOpen(false)}
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
       aria-describedby={open ? tooltipId : undefined}
     >
       {children}

--- a/src/app/components/common/Tooltip.tsx
+++ b/src/app/components/common/Tooltip.tsx
@@ -29,6 +29,10 @@ export function Tooltip({
   contentClassName,
   delayMs = 0,
   children,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
   ...anchorProps
 }: TooltipProps) {
   const [open, setOpen] = useState(false);
@@ -132,10 +136,22 @@ export function Tooltip({
       {...anchorProps}
       ref={anchorRef}
       className={cn("tooltip-anchor", className)}
-      onMouseEnter={showTooltip}
-      onMouseLeave={hideTooltip}
-      onFocus={showTooltip}
-      onBlur={hideTooltip}
+      onMouseEnter={(event) => {
+        onMouseEnter?.(event);
+        showTooltip();
+      }}
+      onMouseLeave={(event) => {
+        onMouseLeave?.(event);
+        hideTooltip();
+      }}
+      onFocus={(event) => {
+        onFocus?.(event);
+        showTooltip();
+      }}
+      onBlur={(event) => {
+        onBlur?.(event);
+        hideTooltip();
+      }}
       aria-describedby={open ? tooltipId : undefined}
     >
       {children}

--- a/src/app/ui/classes.ts
+++ b/src/app/ui/classes.ts
@@ -65,7 +65,7 @@ export const primaryButtonClass =
   "min-h-8 rounded-full border border-[color:var(--accent-border)] bg-[color:var(--accent-bg)] px-4 text-[13px] font-medium text-[color:var(--text)] transition-colors duration-150 ease-out hover:border-[color:var(--accent)] hover:bg-[color:var(--accent-bg-strong)] disabled:cursor-not-allowed disabled:border-transparent disabled:bg-[color:var(--panel)] disabled:text-[color:var(--muted-2)]";
 
 export const composerTextActionButtonClass =
-  "inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-[color:var(--border)] bg-[color:var(--panel-2)] px-3 text-[12.5px] font-medium leading-5 text-[color:var(--text)] transition-colors duration-150 ease-out hover:border-[color:var(--accent-border)] hover:bg-[color:var(--accent-bg-subtle)] disabled:cursor-not-allowed disabled:border-transparent disabled:bg-[color:var(--panel)] disabled:text-[color:var(--muted-2)]";
+  "settings-control-text inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-[color:var(--border)] bg-[color:var(--panel-2)] px-3 font-medium text-[color:var(--text)] transition-colors duration-150 ease-out hover:border-[color:var(--accent-border)] hover:bg-[color:var(--accent-bg-subtle)] disabled:cursor-not-allowed disabled:border-transparent disabled:bg-[color:var(--panel)] disabled:text-[color:var(--muted-2)]";
 
 export const interactiveCardClass =
   "rounded-[20px] border border-[color:var(--border)] bg-[color:var(--panel)] text-left shadow-[var(--shadow)] transition-colors duration-150 ease-out hover:bg-[color:var(--panel-2)]";
@@ -111,7 +111,7 @@ export const settingsSelectButtonClass =
   "grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] px-3 py-2.5 text-left transition-colors hover:bg-[rgba(255,255,255,0.04)]";
 
 export const settingsInputClass =
-  "min-w-0 flex-1 rounded-xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] px-3 py-2 text-[13px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]";
+  "settings-control-text min-w-0 flex-1 rounded-xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] px-3 py-2 text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]";
 
 export const settingsListRowClass =
   "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] px-3 py-2";

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -23,11 +23,8 @@ import {
 } from "./settings/settingsGroups";
 import type { SettingsCategoryId } from "./settings/settingsTypes";
 import { buildSettingsDescriptors } from "./settings/settingsDescriptors";
-import {
-  SettingRow,
-  normalizeManagedDictationModelId,
-  settingsHelpRowClass,
-} from "./settings/settingsUi";
+import { settingsHelpRowClass } from "./settings/settingsClasses";
+import { SettingRow, normalizeManagedDictationModelId } from "./settings/settingsUi";
 
 type SettingsViewProps = {
   appSettings: AppSettings;
@@ -422,7 +419,7 @@ export function SettingsView({
             visibleGroups.map((group) => (
               <Fragment key={group.id}>
                 <section className={cn(settingsSectionClass, "min-w-0 gap-1 p-2.5")}>
-                  <div className="flex items-baseline justify-between gap-3 px-1 pb-1">
+                  <div className="flex items-baseline justify-between gap-3 px-1 pt-1 pb-1">
                     <h2 className="text-[15px] font-semibold text-[color:var(--text)]">
                       {group.label}
                     </h2>
@@ -436,7 +433,7 @@ export function SettingsView({
                 {showHelp ? (
                   <aside className="hidden min-w-0 content-start gap-1 rounded-[18px] border border-transparent p-2.5 lg:grid">
                     <div
-                      className="flex items-baseline justify-between gap-3 px-1 pb-1"
+                      className="flex items-baseline justify-between gap-3 px-1 pt-1 pb-1"
                       aria-hidden="true"
                     >
                       <h2 className="invisible text-[15px] font-semibold">{group.label}</h2>

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -227,8 +227,10 @@ export function SettingsView({
     activeCategory,
   });
   const visibleGroups = groupSettingsByCategory({ settings: filteredSettings });
+  const visibleSettingIds = filteredSettings.map((setting) => setting.id).join("|");
 
   useLayoutEffect(() => {
+    void visibleSettingIds;
     if (!showHelp || !settingsScrollRef.current || typeof ResizeObserver === "undefined") {
       setSettingRowHeights((current) => (Object.keys(current).length === 0 ? current : {}));
       return;
@@ -266,7 +268,7 @@ export function SettingsView({
         window.cancelAnimationFrame(frameId);
       }
     };
-  });
+  }, [showHelp, visibleSettingIds]);
 
   return (
     <ViewShell

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -24,7 +24,8 @@ import {
 import type { SettingsCategoryId } from "./settings/settingsTypes";
 import { buildSettingsDescriptors } from "./settings/settingsDescriptors";
 import { settingsHelpRowClass } from "./settings/settingsClasses";
-import { SettingRow, normalizeManagedDictationModelId } from "./settings/settingsUi";
+import { normalizeManagedDictationModelId } from "./settings/settingsDictationHelpers";
+import { SettingRow } from "./settings/settingsUi";
 
 type SettingsViewProps = {
   appSettings: AppSettings;
@@ -426,7 +427,7 @@ export function SettingsView({
                   </div>
                   <div className="grid">
                     {group.settings.map((setting) => (
-                      <SettingRow key={setting.id} setting={setting} />
+                      <SettingRow key={setting.id} setting={setting} showHelp={showHelp} />
                     ))}
                   </div>
                 </section>

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -1,5 +1,6 @@
-import { Search, X } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Info, Search, X } from "lucide-react";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Tooltip } from "../components/common/Tooltip";
 import { ViewHeader } from "../components/common/ViewHeader";
 import { ViewShell } from "../components/common/ViewShell";
 import type {
@@ -22,7 +23,11 @@ import {
 } from "./settings/settingsGroups";
 import type { SettingsCategoryId } from "./settings/settingsTypes";
 import { buildSettingsDescriptors } from "./settings/settingsDescriptors";
-import { SettingRow, normalizeManagedDictationModelId } from "./settings/settingsUi";
+import {
+  SettingRow,
+  normalizeManagedDictationModelId,
+  settingsHelpRowClass,
+} from "./settings/settingsUi";
 
 type SettingsViewProps = {
   appSettings: AppSettings;
@@ -51,6 +56,7 @@ export function SettingsView({
   const [draftPiSettings, setDraftPiSettings] = useState(piSettings);
   const piSettingsRef = useRef(piSettings);
   const draftPiSettingsRef = useRef(draftPiSettings);
+  const settingsScrollRef = useRef<HTMLDivElement>(null);
   const dirtyPiSettingsRef = useRef(new Set<keyof PiSettings>());
   const themeUpdateQueueRef = useRef<Promise<unknown>>(Promise.resolve());
   const pendingThemeRef = useRef<string | null>(null);
@@ -58,7 +64,24 @@ export function SettingsView({
   const [activeCategory, setActiveCategory] = useState<SettingsCategoryId | null>(null);
   const [openSelectId, setOpenSelectId] = useState<string | null>(null);
   const [dictationModelDraft, setDictationModelDraft] = useState<DictationModelId | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
+  const [helpColumnAvailable, setHelpColumnAvailable] = useState(false);
+  const [settingRowHeights, setSettingRowHeights] = useState<Record<string, number>>({});
   const normalizedFilter = filter.trim().toLowerCase();
+
+  useEffect(() => {
+    const query = window.matchMedia("(min-width: 1024px)");
+    const updateHelpAvailability = () => {
+      setHelpColumnAvailable(query.matches);
+      if (!query.matches) {
+        setShowHelp(false);
+      }
+    };
+
+    updateHelpAvailability();
+    query.addEventListener("change", updateHelpAvailability);
+    return () => query.removeEventListener("change", updateHelpAvailability);
+  }, []);
 
   const revertFailedThemeUpdate = useCallback((failedTheme: string) => {
     if (pendingThemeRef.current === failedTheme) {
@@ -206,11 +229,38 @@ export function SettingsView({
     activeCategory,
   });
   const visibleGroups = groupSettingsByCategory({ settings: filteredSettings });
+  useLayoutEffect(() => {
+    if (!showHelp || !settingsScrollRef.current) {
+      setSettingRowHeights({});
+      return;
+    }
+
+    const rows = [...settingsScrollRef.current.querySelectorAll<HTMLElement>("[data-setting-id]")];
+    const updateHeights = () => {
+      const nextHeights = Object.fromEntries(
+        rows.map((row) => [row.dataset.settingId ?? "", row.getBoundingClientRect().height]),
+      );
+      setSettingRowHeights((current) => {
+        const currentKeys = Object.keys(current);
+        const nextKeys = Object.keys(nextHeights);
+        const unchanged =
+          currentKeys.length === nextKeys.length &&
+          nextKeys.every((key) => current[key] === nextHeights[key]);
+        return unchanged ? current : nextHeights;
+      });
+    };
+    const observer = new ResizeObserver(updateHeights);
+    for (const row of rows) {
+      observer.observe(row);
+    }
+    updateHeights();
+    return () => observer.disconnect();
+  });
 
   return (
     <ViewShell
       className="h-full grid-rows-[auto_minmax(0,1fr)] overflow-hidden pb-0"
-      maxWidthClassName="max-w-[1120px]"
+      maxWidthClassName={showHelp ? "max-w-[1460px]" : "max-w-[1120px]"}
     >
       <div className="grid min-w-0 items-center gap-4 lg:grid-cols-[220px_minmax(0,1fr)_auto]">
         <ViewHeader title="App settings" className="items-center" />
@@ -230,19 +280,50 @@ export function SettingsView({
             />
           </label>
         </div>
-        <button
-          type="button"
-          className="inline-flex h-8 w-8 items-center justify-center self-center rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] text-[color:var(--text)] transition-colors duration-150 ease-out hover:bg-[rgba(255,255,255,0.07)]"
-          onClick={closeSettings}
-          aria-label="Close app settings"
-          data-tooltip="Close app settings"
-          data-tooltip-placement="left"
-        >
-          <X size={14} />
-        </button>
+        <div className="flex items-center justify-end gap-2">
+          <Tooltip
+            content={
+              helpColumnAvailable
+                ? showHelp
+                  ? "Hide setting descriptions"
+                  : "Show setting descriptions"
+                : "Window is too small for the help column. Hover settings to see tooltips instead."
+            }
+            placement="left"
+          >
+            <button
+              type="button"
+              className={cn(
+                "inline-flex h-8 w-8 items-center justify-center self-center rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] text-[color:var(--text)] transition-colors duration-150 ease-out hover:bg-[rgba(255,255,255,0.07)] disabled:cursor-not-allowed disabled:opacity-40",
+                showHelp && "border-[color:var(--accent-border)] bg-[color:var(--accent-bg)]",
+              )}
+              onClick={() => setShowHelp((current) => !current)}
+              aria-label={showHelp ? "Hide setting descriptions" : "Show setting descriptions"}
+              aria-pressed={showHelp}
+              disabled={!helpColumnAvailable}
+            >
+              <Info size={14} />
+            </button>
+          </Tooltip>
+          <button
+            type="button"
+            className="inline-flex h-8 w-8 items-center justify-center self-center rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] text-[color:var(--text)] transition-colors duration-150 ease-out hover:bg-[rgba(255,255,255,0.07)]"
+            onClick={closeSettings}
+            aria-label="Close app settings"
+            data-tooltip="Close app settings"
+            data-tooltip-placement="left"
+          >
+            <X size={14} />
+          </button>
+        </div>
       </div>
 
-      <div className="grid min-h-0 min-w-0 items-start gap-4 overflow-hidden lg:grid-cols-[220px_minmax(0,1fr)]">
+      <div
+        className={cn(
+          "grid min-h-0 min-w-0 items-start gap-4 overflow-hidden lg:grid-cols-[220px_minmax(0,1fr)]",
+          showHelp && "lg:grid-cols-[220px_minmax(0,1fr)_minmax(15rem,20rem)]",
+        )}
+      >
         <nav className="sticky top-0 hidden max-h-full overflow-y-auto rounded-[22px] border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] p-2 lg:grid">
           <button
             type="button"
@@ -273,66 +354,105 @@ export function SettingsView({
           ))}
         </nav>
 
-        <div className="grid h-full min-h-0 min-w-0 content-start gap-4 overflow-x-hidden overflow-y-auto pr-1 pb-6">
-          <label className="relative block lg:hidden">
-            <Search
-              size={15}
-              className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-[color:var(--muted)]"
-            />
-            <input
-              type="search"
-              value={filter}
-              onChange={(event) => setFilter(event.currentTarget.value)}
-              className="h-10 w-full min-w-0 flex-1 rounded-xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.055)] px-3 py-2 pl-9 text-[13px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
-              placeholder="Search…"
-              aria-label="Search settings"
-            />
-          </label>
+        <div
+          ref={settingsScrollRef}
+          className={cn(
+            "grid h-full min-h-0 min-w-0 content-start gap-4 overflow-x-hidden overflow-y-auto pr-1 pb-6",
+            showHelp && "lg:col-span-2 lg:grid-cols-[minmax(0,1fr)_minmax(15rem,20rem)] lg:gap-x-4",
+          )}
+        >
+          <div className="grid min-w-0 content-start gap-4 lg:hidden">
+            <label className="relative block lg:hidden">
+              <Search
+                size={15}
+                className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-[color:var(--muted)]"
+              />
+              <input
+                type="search"
+                value={filter}
+                onChange={(event) => setFilter(event.currentTarget.value)}
+                className="h-10 w-full min-w-0 flex-1 rounded-xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.055)] px-3 py-2 pl-9 text-[13px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
+                placeholder="Search…"
+                aria-label="Search settings"
+              />
+            </label>
 
-          <div className="flex flex-wrap items-center gap-1.5 lg:hidden">
-            <button
-              type="button"
-              className={cn(
-                "rounded-full border border-[color:var(--border)] px-3 py-1.5 text-[12px] transition-colors",
-                activeCategory === null && "bg-[color:var(--accent-bg)] text-[color:var(--text)]",
-              )}
-              onClick={() => setActiveCategory(null)}
-            >
-              All
-            </button>
-            {settingsCategories.map((category) => (
+            <div className="flex flex-wrap items-center gap-1.5 lg:hidden">
               <button
-                key={category.id}
                 type="button"
                 className={cn(
-                  "rounded-full border border-[color:var(--border)] px-3 py-1.5 text-[12px] text-[color:var(--muted)] transition-colors",
-                  activeCategory === category.id &&
-                    "bg-[color:var(--accent-bg)] text-[color:var(--text)]",
+                  "rounded-full border border-[color:var(--border)] px-3 py-1.5 text-[12px] transition-colors",
+                  activeCategory === null && "bg-[color:var(--accent-bg)] text-[color:var(--text)]",
                 )}
-                onClick={() => setActiveCategory(category.id)}
+                onClick={() => setActiveCategory(null)}
               >
-                {category.label}
+                All
               </button>
-            ))}
+              {settingsCategories.map((category) => (
+                <button
+                  key={category.id}
+                  type="button"
+                  className={cn(
+                    "rounded-full border border-[color:var(--border)] px-3 py-1.5 text-[12px] text-[color:var(--muted)] transition-colors",
+                    activeCategory === category.id &&
+                      "bg-[color:var(--accent-bg)] text-[color:var(--text)]",
+                  )}
+                  onClick={() => setActiveCategory(category.id)}
+                >
+                  {category.label}
+                </button>
+              ))}
+            </div>
           </div>
 
           {visibleGroups.length > 0 ? (
             visibleGroups.map((group) => (
-              <section key={group.id} className={cn(settingsSectionClass, "min-w-0 gap-1 p-2.5")}>
-                <div className="flex items-baseline justify-between gap-3 px-1 pb-1">
-                  <h2 className="text-[15px] font-semibold text-[color:var(--text)]">
-                    {group.label}
-                  </h2>
-                </div>
-                <div className="grid">
-                  {group.settings.map((setting) => (
-                    <SettingRow key={setting.id} setting={setting} />
-                  ))}
-                </div>
-              </section>
+              <Fragment key={group.id}>
+                <section className={cn(settingsSectionClass, "min-w-0 gap-1 p-2.5")}>
+                  <div className="flex items-baseline justify-between gap-3 px-1 pb-1">
+                    <h2 className="text-[15px] font-semibold text-[color:var(--text)]">
+                      {group.label}
+                    </h2>
+                  </div>
+                  <div className="grid">
+                    {group.settings.map((setting) => (
+                      <SettingRow key={setting.id} setting={setting} />
+                    ))}
+                  </div>
+                </section>
+                {showHelp ? (
+                  <aside className="hidden min-w-0 content-start gap-1 rounded-[18px] border border-transparent p-2.5 lg:grid">
+                    <div
+                      className="flex items-baseline justify-between gap-3 px-1 pb-1"
+                      aria-hidden="true"
+                    >
+                      <h2 className="invisible text-[15px] font-semibold">{group.label}</h2>
+                    </div>
+                    <div className="grid">
+                      {group.settings.map((setting) => (
+                        <div
+                          key={setting.id}
+                          className={settingsHelpRowClass}
+                          style={
+                            settingRowHeights[setting.id]
+                              ? {
+                                  height: `${settingRowHeights[setting.id]}px`,
+                                }
+                              : undefined
+                          }
+                        >
+                          <span className="relative top-[10px] truncate">
+                            {setting.description}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </aside>
+                ) : null}
+              </Fragment>
             ))
           ) : (
-            <div className="rounded-[22px] border border-[rgba(169,178,215,0.12)] bg-[rgba(255,255,255,0.025)] p-8 text-center">
+            <div className="rounded-[22px] border border-[rgba(169,178,215,0.12)] bg-[rgba(255,255,255,0.025)] p-8 text-center lg:col-span-full">
               <div className="text-[14px] text-[color:var(--text)]">No matching settings</div>
               <div className="mt-1 text-[12px] text-[color:var(--muted)]">
                 Try a broader term like “Pi”, “model”, “folder”, or “voice”.

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -229,38 +229,51 @@ export function SettingsView({
     activeCategory,
   });
   const visibleGroups = groupSettingsByCategory({ settings: filteredSettings });
+
   useLayoutEffect(() => {
-    if (!showHelp || !settingsScrollRef.current) {
-      setSettingRowHeights({});
+    if (!showHelp || !settingsScrollRef.current || typeof ResizeObserver === "undefined") {
+      setSettingRowHeights((current) => (Object.keys(current).length === 0 ? current : {}));
       return;
     }
 
+    let frameId: number | null = null;
     const rows = [...settingsScrollRef.current.querySelectorAll<HTMLElement>("[data-setting-id]")];
     const updateHeights = () => {
-      const nextHeights = Object.fromEntries(
-        rows.map((row) => [row.dataset.settingId ?? "", row.getBoundingClientRect().height]),
-      );
-      setSettingRowHeights((current) => {
-        const currentKeys = Object.keys(current);
-        const nextKeys = Object.keys(nextHeights);
-        const unchanged =
-          currentKeys.length === nextKeys.length &&
-          nextKeys.every((key) => current[key] === nextHeights[key]);
-        return unchanged ? current : nextHeights;
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        const nextHeights = Object.fromEntries(
+          rows.map((row) => [row.dataset.settingId ?? "", Math.ceil(row.offsetHeight)]),
+        );
+        setSettingRowHeights((current) => {
+          const nextKeys = Object.keys(nextHeights);
+          const unchanged =
+            Object.keys(current).length === nextKeys.length &&
+            nextKeys.every((key) => current[key] === nextHeights[key]);
+          return unchanged ? current : nextHeights;
+        });
       });
     };
+
     const observer = new ResizeObserver(updateHeights);
     for (const row of rows) {
       observer.observe(row);
     }
     updateHeights();
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
   });
 
   return (
     <ViewShell
       className="h-full grid-rows-[auto_minmax(0,1fr)] overflow-hidden pb-0"
-      maxWidthClassName={showHelp ? "max-w-[1460px]" : "max-w-[1120px]"}
+      maxWidthClassName={showHelp ? "max-w-[1360px]" : "max-w-[1120px]"}
     >
       <div className="grid min-w-0 items-center gap-4 lg:grid-cols-[220px_minmax(0,1fr)_auto]">
         <ViewHeader title="App settings" className="items-center" />
@@ -321,7 +334,7 @@ export function SettingsView({
       <div
         className={cn(
           "grid min-h-0 min-w-0 items-start gap-4 overflow-hidden lg:grid-cols-[220px_minmax(0,1fr)]",
-          showHelp && "lg:grid-cols-[220px_minmax(0,1fr)_minmax(15rem,20rem)]",
+          showHelp && "lg:grid-cols-[220px_minmax(0,1fr)_minmax(18rem,24rem)]",
         )}
       >
         <nav className="sticky top-0 hidden max-h-full overflow-y-auto rounded-[22px] border border-[color:var(--border)] bg-[rgba(255,255,255,0.02)] p-2 lg:grid">
@@ -358,7 +371,7 @@ export function SettingsView({
           ref={settingsScrollRef}
           className={cn(
             "grid h-full min-h-0 min-w-0 content-start gap-4 overflow-x-hidden overflow-y-auto pr-1 pb-6",
-            showHelp && "lg:col-span-2 lg:grid-cols-[minmax(0,1fr)_minmax(15rem,20rem)] lg:gap-x-4",
+            showHelp && "lg:col-span-2 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)] lg:gap-x-4",
           )}
         >
           <div className="grid min-w-0 content-start gap-4 lg:hidden">
@@ -435,9 +448,7 @@ export function SettingsView({
                           className={settingsHelpRowClass}
                           style={
                             settingRowHeights[setting.id]
-                              ? {
-                                  height: `${settingRowHeights[setting.id]}px`,
-                                }
+                              ? { height: `${settingRowHeights[setting.id]}px` }
                               : undefined
                           }
                         >

--- a/src/app/views/settings/settingsClasses.ts
+++ b/src/app/views/settings/settingsClasses.ts
@@ -1,0 +1,5 @@
+export const settingRowClass =
+  "grid min-h-10 min-w-0 grid-cols-1 items-center gap-2 border-b border-[rgba(169,178,215,0.09)] px-1 py-1.5 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_minmax(0,auto)] sm:gap-5";
+
+export const settingsHelpRowClass =
+  "grid min-h-10 min-w-0 grid-cols-1 items-center gap-2 border-b border-transparent px-1 py-1.5 text-[12px] leading-5 text-[color:var(--muted)] last:border-b-0 sm:grid-cols-1 sm:gap-0";

--- a/src/app/views/settings/settingsDescriptorCommon.tsx
+++ b/src/app/views/settings/settingsDescriptorCommon.tsx
@@ -16,8 +16,7 @@ export function buildCommonSettingsDescriptors({
       id: "common.streaming-behavior",
       category: "pi-runtime",
       title: "Send while Pi is responding",
-      description:
-        "Desktop composer policy. Steer interrupts, Queue waits for the current turn, Stop aborts without sending.",
+      description: "Composer follow-up messages behavior.",
       keywords: "queue steer stop streaming responding send composer",
       render: () => (
         <div className="min-w-0 sm:min-w-[13rem]">
@@ -52,7 +51,7 @@ export function buildCommonSettingsDescriptors({
       id: "common.howcode-native-ask-questions",
       category: "pi-runtime",
       title: "Ask questions tool",
-      description: "Let Pi pause and ask structured questions in Howcode sessions.",
+      description: "Native ask questions tool (GUI+TUI).",
       keywords: "native extensions ask questions tool clarify",
       render: () => (
         <ToggleBox
@@ -66,8 +65,7 @@ export function buildCommonSettingsDescriptors({
       id: "common.pi-tui-takeover",
       category: "pi-runtime",
       title: "Open in TUI",
-      description:
-        "Use Pi takeover by default until a conversation is overridden for this app session.",
+      description: "Always use Pi TUI takeover.",
       keywords: "takeover terminal tui open conversations",
       render: () => (
         <ToggleBox
@@ -81,7 +79,7 @@ export function buildCommonSettingsDescriptors({
       id: "common.hover-to-focus",
       category: "pi-runtime",
       title: "Hover to type",
-      description: "Focus composer and terminal input when the mouse enters their typing surface.",
+      description: "Hover to input for composer and terminal.",
       keywords: "hover focus type composer terminal drawer input",
       render: () => (
         <ToggleBox
@@ -95,7 +93,7 @@ export function buildCommonSettingsDescriptors({
       id: "common.hover-to-blur",
       category: "pi-runtime",
       title: "Stop typing on hover leave",
-      description: "Blur composer and terminal input when the cursor leaves their hover area.",
+      description: "Instantly leave input when not in hover area.",
       keywords: "hover blur leave stop typing composer terminal drawer input",
       render: () => (
         <ToggleBox

--- a/src/app/views/settings/settingsDescriptorDictation.tsx
+++ b/src/app/views/settings/settingsDescriptorDictation.tsx
@@ -49,7 +49,7 @@ export function buildDictationSettingsDescriptors({
       id: "dictation.models",
       category: "dictation",
       title: "Speech-to-text model",
-      description: "Download and choose one of the curated sherpa-onnx int8 Whisper models.",
+      description: "Dictation model selection.",
       keywords: "dictation model whisper download tiny base small speech transcription",
       render: () => (
         <div className="grid w-[27rem] max-w-full gap-1.5">
@@ -127,7 +127,7 @@ export function buildDictationSettingsDescriptors({
       id: "dictation.max-duration",
       category: "dictation",
       title: "Max dictation length",
-      description: `Longer captures use more memory before transcription. Default is ${DEFAULT_DICTATION_MAX_DURATION_SECONDS / 60} minutes.`,
+      description: `Safety net in case you forget. Default is ${DEFAULT_DICTATION_MAX_DURATION_SECONDS / 60} minutes.`,
       keywords: "dictation duration length capture minutes seconds",
       render: () => (
         <select
@@ -150,7 +150,7 @@ export function buildDictationSettingsDescriptors({
       id: "dictation.show-button",
       category: "dictation",
       title: "Toggle dictation",
-      description: "If hidden, re-enable the composer microphone button here.",
+      description: "Hide if you have a preferred dictation system.",
       keywords: "dictation button composer microphone show hide",
       render: () => (
         <ToggleBox

--- a/src/app/views/settings/settingsDescriptorDictation.tsx
+++ b/src/app/views/settings/settingsDescriptorDictation.tsx
@@ -8,8 +8,9 @@ import type { AppSettings, DictationModelId } from "../../desktop/types";
 import { ActivitySpinner } from "../../components/common/ActivitySpinner";
 import { composerTextActionButtonClass, settingsInputClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
+import { normalizeManagedDictationModelId } from "./settingsDictationHelpers";
 import type { SettingDescriptor } from "./settingsTypes";
-import { InlineSelect, ToggleBox, normalizeManagedDictationModelId } from "./settingsUi";
+import { InlineSelect, ToggleBox } from "./settingsUi";
 import type { SettingsController } from "./settingsDescriptorTypes";
 
 export function buildDictationSettingsDescriptors({

--- a/src/app/views/settings/settingsDescriptorModels.tsx
+++ b/src/app/views/settings/settingsDescriptorModels.tsx
@@ -83,7 +83,10 @@ export function buildModelSettingsDescriptors({
       open={openSelectId === id}
       options={[
         { value: "composer-default", label: "Composer default" },
-        ...modelProviders.map((provider) => ({ value: provider, label: provider })),
+        ...modelProviders.map((provider) => ({
+          value: provider,
+          label: provider,
+        })),
       ]}
       onOpenChange={(open) => setOpenSelectId(open ? id : null)}
       onChange={(value) =>
@@ -186,7 +189,7 @@ export function buildModelSettingsDescriptors({
       id: "models.chat",
       category: "models",
       title: "Chat",
-      description: "Provider, model, and reasoning level for the Chat view.",
+      description: "Default settings for the Chat view.",
       keywords: "chat model provider reasoning thinking",
       render: () =>
         renderModelWorkflowControls(
@@ -208,7 +211,7 @@ export function buildModelSettingsDescriptors({
       id: "models.code",
       category: "models",
       title: "Code",
-      description: "Provider, model, and reasoning level for the Code view.",
+      description: "Default settings for the Code view.",
       keywords: "code model provider reasoning thinking composer",
       render: () =>
         renderModelWorkflowControls(
@@ -230,7 +233,7 @@ export function buildModelSettingsDescriptors({
       id: "models.git-commit",
       category: "models",
       title: "Git commit messages",
-      description: "Provider, model, and reasoning level for generated git commit messages.",
+      description: "Default settings for the GitOps view.",
       keywords: "git commit message model provider reasoning thinking",
       render: () =>
         renderModelWorkflowControls(
@@ -249,7 +252,7 @@ export function buildModelSettingsDescriptors({
       id: "models.skill-creator",
       category: "models",
       title: "Skill creator",
-      description: "Provider, model, and reasoning level for the skill creator workflow.",
+      description: "Default settings for the built-in skill creator.",
       keywords: "skill creator model provider reasoning thinking",
       render: () =>
         renderModelWorkflowControls(

--- a/src/app/views/settings/settingsDescriptorModels.tsx
+++ b/src/app/views/settings/settingsDescriptorModels.tsx
@@ -171,16 +171,28 @@ export function buildModelSettingsDescriptors({
     selectThinkingLevel: (value: ComposerThinkingLevel | null) => void,
     allowDefaultThinking = false,
   ) => (
-    <div className="grid w-full min-w-0 grid-cols-1 gap-2 xl:w-auto xl:grid-cols-3">
-      {buildProviderOptions(`${idPrefix}-provider`, selection, selectModel)}
-      {buildModelOptions(`${idPrefix}-model`, selection, selectModel)}
-      {renderThinkingSelector(
-        `${idPrefix}-thinking`,
-        thinkingLevel,
-        getWorkflowThinkingLevels(selection),
-        selectThinkingLevel,
-        allowDefaultThinking,
-      )}
+    <div className="grid w-full min-w-0 grid-cols-1 gap-2 xl:w-auto xl:grid-cols-3 xl:[--settings-model-select-width:10.4rem]">
+      <div className="min-w-0">
+        <div className="[&_[data-inline-select-root]]:w-full xl:[&_[data-inline-select-root]]:w-[var(--settings-model-select-width)]">
+          {buildProviderOptions(`${idPrefix}-provider`, selection, selectModel)}
+        </div>
+      </div>
+      <div className="min-w-0">
+        <div className="[&_[data-inline-select-root]]:w-full xl:[&_[data-inline-select-root]]:w-[var(--settings-model-select-width)]">
+          {buildModelOptions(`${idPrefix}-model`, selection, selectModel)}
+        </div>
+      </div>
+      <div className="min-w-0">
+        <div className="[&_[data-inline-select-root]]:w-full xl:[&_[data-inline-select-root]]:w-[var(--settings-model-select-width)]">
+          {renderThinkingSelector(
+            `${idPrefix}-thinking`,
+            thinkingLevel,
+            getWorkflowThinkingLevels(selection),
+            selectThinkingLevel,
+            allowDefaultThinking,
+          )}
+        </div>
+      </div>
     </div>
   );
 

--- a/src/app/views/settings/settingsDescriptorPiRuntime.tsx
+++ b/src/app/views/settings/settingsDescriptorPiRuntime.tsx
@@ -23,7 +23,7 @@ export function buildPiRuntimeSettingsDescriptors({
       id: "pi-runtime.theme",
       category: "pi-runtime",
       title: "Theme",
-      description: "Use a Pi JSON theme for the terminal and the full Howcode interface.",
+      description: "Select a theme to use. Syncs with Pi's JSON files.",
       keywords: "theme color json pi gui terminal appearance",
       render: () => {
         const themes = piTheme?.themes.length
@@ -75,7 +75,7 @@ export function buildPiRuntimeSettingsDescriptors({
       id: "pi-runtime.transport",
       category: "pi-runtime",
       title: "Transport",
-      description: "How Pi connects to providers that support multiple streaming transports.",
+      description: "Soon to be deprecated.",
       keywords: "transport sse websocket auto provider runtime",
       render: () => (
         <div className="grid grid-cols-3 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)]">
@@ -104,7 +104,7 @@ export function buildPiRuntimeSettingsDescriptors({
       id: "pi-runtime.auto-compact",
       category: "pi-runtime",
       title: "Auto compact context",
-      description: "Let Pi compact long sessions automatically when context gets tight.",
+      description: "Switch auto compaction on or off.",
       keywords: "auto compact context runtime",
       render: () => (
         <ToggleBox
@@ -118,8 +118,7 @@ export function buildPiRuntimeSettingsDescriptors({
       id: "pi-runtime.skill-commands",
       category: "pi-runtime",
       title: "Enable skill slash commands",
-      description:
-        "Expose installed skills as /skill:name commands in Pi and the desktop slash picker.",
+      description: "Expose installed skills as /commands.",
       keywords: "skills slash commands picker runtime",
       render: () => (
         <ToggleBox

--- a/src/app/views/settings/settingsDescriptorPiRuntime.tsx
+++ b/src/app/views/settings/settingsDescriptorPiRuntime.tsx
@@ -136,8 +136,8 @@ export function buildPiRuntimeSettingsDescriptors({
       title: key === "steeringMode" ? "Steering mode" : "Follow-up mode",
       description:
         key === "steeringMode"
-          ? "Advanced Pi queue-drain behavior after steering messages are already queued."
-          : "Advanced Pi queue-drain behavior after follow-up messages are already queued.",
+          ? "Send one queued steer, or drain them all."
+          : "Send one queued follow-up, or drain them all.",
       keywords: "queue drain steering follow-up mode runtime advanced",
       render: () => (
         <div className="grid grid-cols-2 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)]">
@@ -163,17 +163,9 @@ export function buildPiRuntimeSettingsDescriptors({
     })),
     ...(
       [
-        [
-          "autoResizeImages",
-          "Auto resize images",
-          "Resize images before sending them to providers for better compatibility.",
-        ],
-        ["blockImages", "Block images", "Prevent images from being sent to model providers."],
-        [
-          "enableInstallTelemetry",
-          "Install telemetry",
-          "Allow Pi's anonymous package update/version ping.",
-        ],
+        ["autoResizeImages", "Auto resize images", "Shrink images before upload."],
+        ["blockImages", "Block images", "Never send images to providers."],
+        ["enableInstallTelemetry", "Install telemetry", "Anonymous Pi version check."],
       ] as const
     ).map(([key, title, description]) => ({
       id: `pi-runtime.${key}`,
@@ -191,29 +183,13 @@ export function buildPiRuntimeSettingsDescriptors({
     })),
     ...(
       [
-        [
-          "doubleEscapeAction",
-          "Double Escape",
-          "Pi TUI action for double Escape on an empty editor.",
-        ],
-        ["showImages", "Show images", "Render supported image attachments in capable terminals."],
-        [
-          "hideThinkingBlock",
-          "Hide thinking blocks",
-          "Collapse model reasoning blocks in Pi TUI conversation output.",
-        ],
-        [
-          "showHardwareCursor",
-          "Hardware cursor",
-          "Show the terminal cursor while Pi still positions it for IME input.",
-        ],
-        [
-          "clearOnShrink",
-          "Clear on shrink",
-          "Clear empty terminal rows when rendered content shrinks.",
-        ],
-        ["quietStartup", "Quiet startup", "Reduce startup resource diagnostics in Pi TUI."],
-        ["collapseChangelog", "Condense changelog", "Show a shorter changelog after Pi updates."],
+        ["doubleEscapeAction", "Double Escape", "Double Escape in an empty editor."],
+        ["showImages", "Show images", "Show images in supported terminals."],
+        ["hideThinkingBlock", "Hide thinking blocks", "Hide reasoning blocks in TUI output."],
+        ["showHardwareCursor", "Hardware cursor", "Show the native terminal cursor."],
+        ["clearOnShrink", "Clear on shrink", "Clear stale rows after resize."],
+        ["quietStartup", "Quiet startup", "Hide startup diagnostics."],
+        ["collapseChangelog", "Condense changelog", "Show a shorter update changelog."],
       ] as const
     ).map(([key, title, description]) => ({
       id: `pi-tui.${key}`,
@@ -274,21 +250,9 @@ export function buildPiRuntimeSettingsDescriptors({
     })),
     ...(
       [
-        [
-          "imageWidthCells",
-          "Image width",
-          "Preferred inline image width in terminal cells.",
-          1,
-          200,
-        ],
-        ["editorPaddingX", "Editor padding", "Horizontal Pi TUI editor padding.", 0, 3],
-        [
-          "autocompleteMaxVisible",
-          "Autocomplete rows",
-          "Maximum visible Pi TUI autocomplete results.",
-          3,
-          20,
-        ],
+        ["imageWidthCells", "Image width", "Inline image width in terminal cells.", 1, 200],
+        ["editorPaddingX", "Editor padding", "Horizontal editor padding.", 0, 3],
+        ["autocompleteMaxVisible", "Autocomplete rows", "Visible autocomplete rows.", 3, 20],
       ] as const
     ).map(([key, title, description, min, max]) => ({
       id: `pi-tui.${key}`,

--- a/src/app/views/settings/settingsDescriptorProjects.tsx
+++ b/src/app/views/settings/settingsDescriptorProjects.tsx
@@ -18,7 +18,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.default-location",
       category: "projects",
       title: "Default project location",
-      description: "Folder where new howcode projects are created by default.",
+      description: "Default folder for new projects.",
       keywords: "project folder location path default",
       render: () => (
         <div className="relative w-[22rem] max-w-full">
@@ -48,7 +48,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.initialize-git",
       category: "projects",
       title: "Initialise git",
-      description: "Create a git repository for new projects so diffs work immediately.",
+      description: "Always git init when creating a new project.",
       keywords: "git init initialize projects diffs",
       render: () => (
         <ToggleBox
@@ -62,7 +62,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.gitops-default",
       category: "projects",
       title: "GitOps default",
-      description: "Default commit action for projects that do not have their own override.",
+      description: "Default global commit action.",
       keywords: "gitops commit push default project",
       render: () => (
         <div className="grid grid-cols-2 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)]">
@@ -92,7 +92,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.git-diff-baseline-default",
       category: "projects",
       title: "Diff comparison default",
-      description: "Default baseline for the files and lines changed summary.",
+      description: "Default baseline setting for git summary.",
       keywords: "git diff baseline comparison files lines default",
       render: () => (
         <div className="grid grid-cols-3 gap-1 rounded-2xl border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)] xl:grid-cols-5">
@@ -159,7 +159,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.git-diff-file-tree-default",
       category: "projects",
       title: "Diff file tree",
-      description: "Default visibility for the GitOps changed-file tree.",
+      description: "Default visibility for the GitOps file tree.",
       keywords: "git diff file tree changed files sidebar default",
       render: () => (
         <ToggleBox
@@ -175,7 +175,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.deletion-mode",
       category: "projects",
       title: "Project deletion cleanup",
-      description: "Delete only Pi session files, or nuke the full project folder from disk.",
+      description: "Delete only Pi session files, or nuke the full project folder.",
       keywords: "delete deletion cleanup project full clean pi only",
       render: () => (
         <div className="grid grid-cols-2 rounded-full border border-[color:var(--border)] bg-[rgba(255,255,255,0.03)] p-1 text-[12px] text-[color:var(--muted)]">
@@ -205,7 +205,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.import-ui",
       category: "projects",
       title: "Project UI import",
-      description: "Scan current projects for UI info like repo and origin status.",
+      description: "Scan projects for UI info like repo and origin status.",
       keywords: "project import ui scan repo origin first launch",
       render: () => (
         <div className="grid justify-items-end gap-1.5">
@@ -254,7 +254,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.favorite-folders",
       category: "projects",
       title: "Favorite folders",
-      description: "Pinned paths shown in the attachment picker alongside Home.",
+      description: "Paths shown in the attachment picker alongside Home.",
       keywords: "favorite folders attachment picker paths",
       render: () => (
         <div className="grid w-[28rem] max-w-full gap-2">
@@ -316,8 +316,7 @@ export function buildProjectsSettingsDescriptors({
       id: "projects.clipboard-images",
       category: "projects",
       title: "Clipboard images",
-      description:
-        "Delete temp images created when pasted clipboard screenshots become attachments.",
+      description: "Delete temp clipboard images.",
       keywords: "clipboard images screenshots attachments delete cleanup temp",
       render: () => (
         <div className="flex max-w-full items-center justify-end gap-2">

--- a/src/app/views/settings/settingsDictationHelpers.ts
+++ b/src/app/views/settings/settingsDictationHelpers.ts
@@ -1,0 +1,7 @@
+import type { DictationModelId } from "../../desktop/types";
+
+export function normalizeManagedDictationModelId(
+  modelId: string | null | undefined,
+): DictationModelId | null {
+  return modelId === "tiny.en" || modelId === "base.en" || modelId === "small.en" ? modelId : null;
+}

--- a/src/app/views/settings/settingsUi.tsx
+++ b/src/app/views/settings/settingsUi.tsx
@@ -5,11 +5,21 @@ import { popoverPanelClass, composerTextActionButtonClass } from "../../ui/class
 import { cn } from "../../utils/cn";
 import type { InlineSelectOption, SettingDescriptor } from "./settingsTypes";
 
+export const settingRowClass =
+  "grid min-h-10 min-w-0 grid-cols-1 items-center gap-2 border-b border-[rgba(169,178,215,0.09)] px-1 py-1.5 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_minmax(0,auto)] sm:gap-5";
+
+export const settingsHelpRowClass =
+  "grid min-h-10 min-w-0 grid-cols-1 items-center gap-2 border-b border-transparent px-1 py-1.5 text-[12px] leading-5 text-[color:var(--muted)] last:border-b-0 sm:grid-cols-1 sm:gap-0";
+
 export function ToggleBox({
   checked,
   label,
   onClick,
-}: { checked: boolean; label: string; onClick: () => void }) {
+}: {
+  checked: boolean;
+  label: string;
+  onClick: () => void;
+}) {
   return (
     <button
       type="button"
@@ -17,8 +27,6 @@ export function ToggleBox({
       onClick={onClick}
       aria-label={label}
       aria-pressed={checked}
-      data-tooltip={label}
-      data-tooltip-placement="left"
     >
       {checked ? <Check size={13} /> : null}
     </button>
@@ -27,12 +35,17 @@ export function ToggleBox({
 
 export function SettingRow({ setting }: { setting: SettingDescriptor }) {
   return (
-    <div
-      className="grid min-h-10 min-w-0 grid-cols-1 items-center gap-2 border-b border-[rgba(169,178,215,0.09)] px-1 py-1.5 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_minmax(0,auto)] sm:gap-5"
-      data-setting-id={setting.id}
-    >
-      <div className="min-w-0 truncate text-[13px] text-[color:var(--text)]">{setting.title}</div>
-      <div className="min-w-0 max-w-full justify-self-stretch sm:justify-self-end">
+    <div className={settingRowClass} data-setting-id={setting.id}>
+      <div
+        className="min-w-0 truncate text-[13px] text-[color:var(--text)]"
+        data-setting-tooltip={setting.description}
+      >
+        {setting.title}
+      </div>
+      <div
+        className="min-w-0 max-w-full justify-self-stretch sm:justify-self-end"
+        data-setting-tooltip={setting.description}
+      >
         {setting.render()}
       </div>
     </div>

--- a/src/app/views/settings/settingsUi.tsx
+++ b/src/app/views/settings/settingsUi.tsx
@@ -45,7 +45,12 @@ export function SettingRow({
       {showHelp ? (
         title
       ) : (
-        <Tooltip content={setting.description} delayMs={1000} className="block min-w-0">
+        <Tooltip
+          content={setting.description}
+          delayMs={1000}
+          className="block min-w-0"
+          tabIndex={0}
+        >
           {title}
         </Tooltip>
       )}

--- a/src/app/views/settings/settingsUi.tsx
+++ b/src/app/views/settings/settingsUi.tsx
@@ -31,7 +31,10 @@ export function ToggleBox({
 export function SettingRow({
   setting,
   showHelp,
-}: { setting: SettingDescriptor; showHelp: boolean }) {
+}: {
+  setting: SettingDescriptor;
+  showHelp: boolean;
+}) {
   const title = (
     <div className="min-w-0 truncate text-[12px] text-[color:var(--text)]">{setting.title}</div>
   );
@@ -46,17 +49,7 @@ export function SettingRow({
           {title}
         </Tooltip>
       )}
-      {showHelp ? (
-        <div className="min-w-0 max-w-full justify-self-stretch sm:justify-self-end">{control}</div>
-      ) : (
-        <Tooltip
-          content={setting.description}
-          delayMs={1000}
-          className="block min-w-0 max-w-full justify-self-stretch sm:justify-self-end"
-        >
-          {control}
-        </Tooltip>
-      )}
+      <div className="min-w-0 max-w-full justify-self-stretch sm:justify-self-end">{control}</div>
     </div>
   );
 }
@@ -111,7 +104,7 @@ export function InlineSelect({
 
   return (
     <span
-      className={cn("relative block max-w-full text-[12px]", className, "w-52")}
+      className={cn("relative block w-52 max-w-full text-[12px]", className)}
       data-inline-select-root
     >
       <button

--- a/src/app/views/settings/settingsUi.tsx
+++ b/src/app/views/settings/settingsUi.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronDown, Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { DictationModelId } from "../../desktop/types";
+import { Tooltip } from "../../components/common/Tooltip";
 import { popoverPanelClass, composerTextActionButtonClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
 import { settingRowClass } from "./settingsClasses";
@@ -28,21 +28,35 @@ export function ToggleBox({
   );
 }
 
-export function SettingRow({ setting }: { setting: SettingDescriptor }) {
+export function SettingRow({
+  setting,
+  showHelp,
+}: { setting: SettingDescriptor; showHelp: boolean }) {
+  const title = (
+    <div className="min-w-0 truncate text-[12px] text-[color:var(--text)]">{setting.title}</div>
+  );
+  const control = <div className="min-w-0 max-w-full">{setting.render()}</div>;
+
   return (
     <div className={settingRowClass} data-setting-id={setting.id}>
-      <div
-        className="min-w-0 truncate text-[12px] text-[color:var(--text)]"
-        data-setting-tooltip={setting.description}
-      >
-        {setting.title}
-      </div>
-      <div
-        className="min-w-0 max-w-full justify-self-stretch sm:justify-self-end"
-        data-setting-tooltip={setting.description}
-      >
-        {setting.render()}
-      </div>
+      {showHelp ? (
+        title
+      ) : (
+        <Tooltip content={setting.description} delayMs={1000} className="block min-w-0">
+          {title}
+        </Tooltip>
+      )}
+      {showHelp ? (
+        <div className="min-w-0 max-w-full justify-self-stretch sm:justify-self-end">{control}</div>
+      ) : (
+        <Tooltip
+          content={setting.description}
+          delayMs={1000}
+          className="block min-w-0 max-w-full justify-self-stretch sm:justify-self-end"
+        >
+          {control}
+        </Tooltip>
+      )}
     </div>
   );
 }
@@ -191,10 +205,4 @@ export function InlineSelect({
       ) : null}
     </span>
   );
-}
-
-export function normalizeManagedDictationModelId(
-  modelId: string | null | undefined,
-): DictationModelId | null {
-  return modelId === "tiny.en" || modelId === "base.en" || modelId === "small.en" ? modelId : null;
 }

--- a/src/app/views/settings/settingsUi.tsx
+++ b/src/app/views/settings/settingsUi.tsx
@@ -3,13 +3,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { DictationModelId } from "../../desktop/types";
 import { popoverPanelClass, composerTextActionButtonClass } from "../../ui/classes";
 import { cn } from "../../utils/cn";
+import { settingRowClass } from "./settingsClasses";
 import type { InlineSelectOption, SettingDescriptor } from "./settingsTypes";
-
-export const settingRowClass =
-  "grid min-h-10 min-w-0 grid-cols-1 items-center gap-2 border-b border-[rgba(169,178,215,0.09)] px-1 py-1.5 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_minmax(0,auto)] sm:gap-5";
-
-export const settingsHelpRowClass =
-  "grid min-h-10 min-w-0 grid-cols-1 items-center gap-2 border-b border-transparent px-1 py-1.5 text-[12px] leading-5 text-[color:var(--muted)] last:border-b-0 sm:grid-cols-1 sm:gap-0";
 
 export function ToggleBox({
   checked,
@@ -37,7 +32,7 @@ export function SettingRow({ setting }: { setting: SettingDescriptor }) {
   return (
     <div className={settingRowClass} data-setting-id={setting.id}>
       <div
-        className="min-w-0 truncate text-[13px] text-[color:var(--text)]"
+        className="min-w-0 truncate text-[12px] text-[color:var(--text)]"
         data-setting-tooltip={setting.description}
       >
         {setting.title}
@@ -102,7 +97,7 @@ export function InlineSelect({
 
   return (
     <span
-      className={cn("relative block max-w-full text-[13px]", className, "w-52")}
+      className={cn("relative block max-w-full text-[12px]", className, "w-52")}
       data-inline-select-root
     >
       <button
@@ -122,7 +117,7 @@ export function InlineSelect({
         aria-expanded={open}
         aria-controls={`${id}-menu`}
       >
-        <span className="min-w-0 truncate text-[13px] text-[color:var(--text)]">
+        <span className="min-w-0 truncate text-[12px] text-[color:var(--text)]">
           {selectedOption?.label ?? "Select"}
         </span>
       </button>
@@ -154,7 +149,7 @@ export function InlineSelect({
                 ref={searchInputRef}
                 value={search}
                 onChange={(event) => setSearch(event.currentTarget.value)}
-                className="h-8 w-full rounded-lg border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.055)] px-2.5 pl-8 text-[13px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
+                className="h-8 w-full rounded-lg border border-[rgba(169,178,215,0.14)] bg-[rgba(255,255,255,0.055)] px-2.5 pl-8 text-[12px] text-[color:var(--text)] outline-none placeholder:text-[color:var(--muted)]"
                 placeholder={`Search ${options.length} options…`}
                 aria-label="Search options"
               />
@@ -179,7 +174,7 @@ export function InlineSelect({
                   }}
                 >
                   <span className="min-w-0 flex-1">
-                    <span className="block truncate text-[13px] leading-4">{option.label}</span>
+                    <span className="block truncate text-[12px] leading-4">{option.label}</span>
                     {option.description ? (
                       <span className="block truncate text-[11px] leading-3 text-[color:var(--muted)]">
                         {option.description}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,5 +3,6 @@
 @import "./styles/base.css";
 @import "./styles/motion.css";
 @import "./styles/primitives.css";
+@import "./styles/settings.css";
 @import "./styles/sidebar.css";
 @import "./styles/vendor/wterm.css";

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -198,7 +198,6 @@ button[data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::
 
 .tooltip-anchor {
   position: relative;
-  display: inline-flex;
   min-width: 0;
 }
 

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -163,6 +163,39 @@ button[data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::
   transform: translate(-2px, -50%);
 }
 
+[data-setting-tooltip] {
+  position: relative;
+}
+
+[data-setting-tooltip]::after {
+  pointer-events: none;
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  z-index: 1000;
+  width: max-content;
+  max-width: 280px;
+  transform: translate(-50%, calc(-100% + 4px));
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--panel);
+  padding: 6px 10px;
+  color: var(--text);
+  box-shadow: var(--shadow);
+  content: attr(data-setting-tooltip);
+  font-size: 11.5px;
+  line-height: 16px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  opacity: 0;
+  transition: opacity 150ms ease-out 1s, transform 150ms ease-out 1s;
+}
+
+[data-setting-tooltip]:is(:hover, :focus-within)::after {
+  transform: translate(-50%, calc(-100% - 2px));
+  opacity: 1;
+}
+
 .tooltip-anchor {
   position: relative;
   display: inline-flex;

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -163,6 +163,11 @@ button[data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::
   transform: translate(-2px, -50%);
 }
 
+.settings-control-text {
+  font-size: 12px !important;
+  line-height: 16px !important;
+}
+
 [data-setting-tooltip] {
   position: relative;
 }

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -163,11 +163,6 @@ button[data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::
   transform: translate(-2px, -50%);
 }
 
-.settings-control-text {
-  font-size: 12px !important;
-  line-height: 16px !important;
-}
-
 [data-setting-tooltip] {
   position: relative;
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,0 +1,4 @@
+.settings-control-text {
+  font-size: 12px;
+  line-height: 16px;
+}


### PR DESCRIPTION
## Summary
- add a toggleable settings help column with row-aligned descriptions and narrow-window fallback tooltip copy
- route setting descriptions through shared delayed tooltips when help is hidden, while suppressing tooltips during help mode and over controls
- tighten settings copy, control typography, dropdown truncation, and Fast Refresh-safe helper exports

## Implementation notes
- settings descriptions stay descriptor-driven; `settings-descriptions.md` captures the editable copy export used for this pass
- help row heights are synced with setting rows via a guarded `ResizeObserver`
- settings-specific CSS now lives in `src/styles/settings.css`

## Validation
- pre-commit hooks passed on commits: Biome, typechecks, Vitest
- pre-push hooks passed: lint and typechecks
