### PR TITLE
Clarify artifact download destination

### DIFF
--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -157,6 +157,7 @@ export function ArtifactPanel({
             aria-label={downloadStatus ?? "Download artifact"}
             data-tooltip={downloadStatus ?? "Download"}
             data-tooltip-placement="left"
+            data-tooltip-size={downloadStatus ? "wide" : undefined}
           >
             <Download size={14} />
           </button>

--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -48,6 +48,7 @@ export function ArtifactPanel({
     previewError,
     previewRevision,
     saveDisabled,
+    downloadStatus,
     saveDraft,
     downloadArtifact,
     setDraft,
@@ -151,7 +152,7 @@ export function ArtifactPanel({
           <button
             type="button"
             className={cn(compactIconButtonClass, "h-7 w-7")}
-            onClick={downloadArtifact}
+            onClick={() => void downloadArtifact()}
             disabled={!selectedArtifact}
             aria-label="Download artifact"
             data-tooltip="Download"
@@ -185,6 +186,11 @@ export function ArtifactPanel({
           </button>
         </div>
       </div>
+      {downloadStatus ? (
+        <div className="border-b border-[color:var(--border)] bg-[color:var(--panel)] px-3 py-1.5 text-[11px] text-[color:var(--muted)]">
+          {downloadStatus}
+        </div>
+      ) : null}
 
       <div className="relative min-h-0 flex-1 overflow-hidden bg-[color:var(--sidebar)]">
         {artifacts.length === 0 ? (

--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -154,8 +154,8 @@ export function ArtifactPanel({
             className={cn(compactIconButtonClass, "h-7 w-7")}
             onClick={() => void downloadArtifact()}
             disabled={!selectedArtifact}
-            aria-label="Download artifact"
-            data-tooltip="Download"
+            aria-label={downloadStatus ?? "Download artifact"}
+            data-tooltip={downloadStatus ?? "Download"}
             data-tooltip-placement="left"
           >
             <Download size={14} />
@@ -186,11 +186,6 @@ export function ArtifactPanel({
           </button>
         </div>
       </div>
-      {downloadStatus ? (
-        <div className="border-b border-[color:var(--border)] bg-[color:var(--panel)] px-3 py-1.5 text-[11px] text-[color:var(--muted)]">
-          {downloadStatus}
-        </div>
-      ) : null}
 
       <div className="relative min-h-0 flex-1 overflow-hidden bg-[color:var(--sidebar)]">
         {artifacts.length === 0 ? (

--- a/src/app/features/chat/artifacts/useArtifactPanelState.ts
+++ b/src/app/features/chat/artifacts/useArtifactPanelState.ts
@@ -19,6 +19,7 @@ export function useArtifactPanelState(conversationId: string | null) {
   const [versions, setVersions] = useState<ArtifactVersion[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<number | "latest">("latest");
   const [saving, setSaving] = useState(false);
+  const [downloadStatus, setDownloadStatus] = useState<string | null>(null);
   const [previewHtml, setPreviewHtml] = useState("");
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [previewRevision, setPreviewRevision] = useState(0);
@@ -100,6 +101,7 @@ export function useArtifactPanelState(conversationId: string | null) {
     if (previousSelectedArtifactSlugRef.current === selectedArtifactSlug) return;
     previousSelectedArtifactSlugRef.current = selectedArtifactSlug;
     draftDirtyRef.current = false;
+    setDownloadStatus(null);
     setDraft(displayedContentRef.current);
     setSelectedVersion("latest");
   }, [selectedArtifactSlug]);
@@ -190,13 +192,22 @@ export function useArtifactPanelState(conversationId: string | null) {
     }
   };
 
-  const downloadArtifact = () => {
+  const downloadArtifact = async () => {
     if (!selectedArtifact) return;
     const content = showingHistoricalVersion ? displayedContent : draft;
-    void window.piDesktop?.saveTextToDownloads?.(
-      `${selectedArtifact.slug}.${getArtifactExtension(selectedArtifact.kind)}`,
-      content,
-    );
+    const fileName = `${selectedArtifact.slug}.${getArtifactExtension(selectedArtifact.kind)}`;
+    try {
+      const result = await window.piDesktop?.saveTextToDownloads?.(fileName, content);
+      if (result?.ok) {
+        setDownloadStatus(`Saved ${fileName} to Downloads.`);
+      } else {
+        setDownloadStatus(result?.error ?? "Could not save artifact to Downloads.");
+      }
+    } catch (error) {
+      setDownloadStatus(
+        error instanceof Error ? error.message : "Could not save artifact to Downloads.",
+      );
+    }
   };
 
   return {
@@ -213,6 +224,7 @@ export function useArtifactPanelState(conversationId: string | null) {
     previewError,
     previewRevision,
     saveDisabled,
+    downloadStatus,
     saveDraft,
     downloadArtifact,
     setDraft,

--- a/src/app/features/chat/artifacts/useArtifactPanelState.ts
+++ b/src/app/features/chat/artifacts/useArtifactPanelState.ts
@@ -11,6 +11,11 @@ import { getArtifactExtension } from "./artifactFormat";
 
 export type ArtifactView = "list" | "code" | "preview";
 
+function getPathBaseName(filePath: string) {
+  const segments = filePath.split(/[\\/]/).filter(Boolean);
+  return segments[segments.length - 1] ?? filePath;
+}
+
 export function useArtifactPanelState(conversationId: string | null) {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
@@ -27,6 +32,7 @@ export function useArtifactPanelState(conversationId: string | null) {
   const draftDirtyRef = useRef(false);
   const previewSourceRef = useRef<MessageEventSource | null>(null);
   const displayedContentRef = useRef("");
+  const selectedArtifactSlugRef = useRef<string | null>(null);
 
   const selectedArtifact = useMemo(
     () =>
@@ -38,6 +44,7 @@ export function useArtifactPanelState(conversationId: string | null) {
       ? null
       : (versions.find((version) => version.version === selectedVersion) ?? null);
   const selectedArtifactSlug = selectedArtifact?.slug ?? null;
+  selectedArtifactSlugRef.current = selectedArtifactSlug;
   const selectedArtifactVersion = selectedArtifact?.version ?? null;
   const displayedContent = selectedHistoricalVersion?.content ?? selectedArtifact?.content ?? "";
   displayedContentRef.current = displayedContent;
@@ -194,17 +201,23 @@ export function useArtifactPanelState(conversationId: string | null) {
 
   const downloadArtifact = async () => {
     if (!selectedArtifact) return;
+    const downloadArtifactSlug = selectedArtifact.slug;
     const content = showingHistoricalVersion ? displayedContent : draft;
     const fileName = `${selectedArtifact.slug}.${getArtifactExtension(selectedArtifact.kind)}`;
+    const setCurrentDownloadStatus = (message: string) => {
+      if (selectedArtifactSlugRef.current === downloadArtifactSlug) {
+        setDownloadStatus(message);
+      }
+    };
     try {
       const result = await window.piDesktop?.saveTextToDownloads?.(fileName, content);
       if (result?.ok) {
-        setDownloadStatus(`Saved ${fileName} to Downloads.`);
+        setCurrentDownloadStatus(`Saved ${getPathBaseName(result.path ?? fileName)} to Downloads.`);
       } else {
-        setDownloadStatus(result?.error ?? "Could not save artifact to Downloads.");
+        setCurrentDownloadStatus(result?.error ?? "Could not save artifact to Downloads.");
       }
     } catch (error) {
-      setDownloadStatus(
+      setCurrentDownloadStatus(
         error instanceof Error ? error.message : "Could not save artifact to Downloads.",
       );
     }

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -163,6 +163,11 @@ button[data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::
   transform: translate(-2px, -50%);
 }
 
+button[data-tooltip][data-tooltip-size="wide"]::after {
+  max-width: 320px;
+  white-space: normal;
+}
+
 [data-setting-tooltip] {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- Keep artifact downloads on the existing silent save-to-Downloads flow (no system file picker).
- Show an inline confirmation/error message after the download button runs so users can tell where the artifact went.
- Clear the download message when switching artifacts.

## Investigation
The current flow is: artifact panel download button → `useArtifactPanelState.downloadArtifact()` → preload `window.piDesktop.saveTextToDownloads()` → Electron main `saveTextToDownloads` IPC handler → sanitized filename written under `app.getPath("downloads")` with a unique suffix on collisions. The main/preload/export plumbing is intact and no dialog is involved.

The confusing part was renderer-side: the click completed silently, so saving directly to Downloads could look like nothing happened. Per product clarification, system dialogs are not desired here; Downloads remains the default destination.

## Validation
- Pre-commit hook: `biome check --organize-imports-enabled=false --no-errors-on-unmatched`
- Pre-commit hook: `bun run typecheck:web && bun run typecheck:desktop && bun run typecheck:electron && bun run typecheck:scripts`
- Pre-commit hook: `vitest run`
- Pre-push hook: `bun run lint && bun run typecheck`

Closes #200
