### PR TITLE
Add attachment-scoped chat read and list tools

### DIFF
--- a/desktop/runtime-host/live-runtime-registry.cts
+++ b/desktop/runtime-host/live-runtime-registry.cts
@@ -9,6 +9,7 @@ import {
 } from "../runtime/agent-session-extensions.cts";
 import { buildComposerState } from "../runtime/composer-state.cts";
 import { createArtifactTools } from "../runtime/artifact-tools.cts";
+import { createAttachmentFileTools } from "../runtime/attachment-file-tools.cts";
 import { ensureAskQuestionsExtensionRuntimePath } from "../native-extensions/ask-questions-extension-path.cts";
 import { createNativeAskQuestionsTools } from "./native-ask-questions-tool.cts";
 import { invokeMainRequest } from "./main-request-client.cts";
@@ -160,6 +161,12 @@ async function createRuntime(options: {
         },
       })
     : [];
+  const attachmentFileTools = options.settingsCwd
+    ? createAttachmentFileTools({
+        cwd: options.cwd,
+        autoResizeImages: settingsManager.getImageAutoResize(),
+      })
+    : null;
   const { session } = await createAgentSession({
     cwd: options.cwd,
     agentDir,
@@ -172,6 +179,7 @@ async function createRuntime(options: {
       ? {
           noTools: "builtin" as const,
           customTools: [
+            ...(attachmentFileTools?.tools ?? []),
             ...createArtifactTools({
               createArtifact: (input) => invokeMainRequest("createArtifact", input),
               editArtifact: (input) => invokeMainRequest("editArtifact", input),
@@ -191,6 +199,7 @@ async function createRuntime(options: {
     cwd: options.cwd,
     session,
     chatGroupId: options.chatGroupId ?? null,
+    attachmentFileAccess: attachmentFileTools?.access,
   } satisfies PiRuntime;
 
   if (!options.sessionManager) {

--- a/desktop/runtime-host/live-runtime-service.cts
+++ b/desktop/runtime-host/live-runtime-service.cts
@@ -322,6 +322,7 @@ export async function sendComposerPrompt(
         }
         const promptStreamingBehavior =
           streamingBehavior === "stop" ? "followUp" : streamingBehavior;
+        await runtime.attachmentFileAccess?.grantAttachments(request.attachments ?? []);
         await promptAndReturnAfterPreflight({
           runtime,
           message,
@@ -329,6 +330,7 @@ export async function sendComposerPrompt(
           request: { ...request, sessionPath: persistedSessionPath },
         });
       } else {
+        await runtime.attachmentFileAccess?.grantAttachments(request.attachments ?? []);
         await promptAndReturnAfterPreflight({
           runtime,
           message,

--- a/desktop/runtime/attachment-file-tools.cts
+++ b/desktop/runtime/attachment-file-tools.cts
@@ -1,0 +1,131 @@
+import { realpath, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createLsToolDefinition,
+  createReadToolDefinition,
+  type ToolDefinition,
+} from "@mariozechner/pi-coding-agent";
+import type { ComposerAttachment } from "../../shared/desktop-contracts.ts";
+
+type AttachmentGrant = {
+  files: Set<string>;
+  directories: Set<string>;
+};
+
+const unicodeSpacesPattern = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+const narrowNoBreakSpace = "\u202F";
+
+export type AttachmentFileAccess = {
+  grantAttachments(attachments: ComposerAttachment[]): Promise<void>;
+};
+
+function isExternalReference(filePath: string) {
+  return /^https?:\/\//i.test(filePath);
+}
+
+function isWithinDirectory(candidate: string, directory: string) {
+  const relative = path.relative(directory, candidate);
+  return relative.length === 0 || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function tryRealpath(filePath: string) {
+  try {
+    return await realpath(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+async function existingPathVariant(filePath: string) {
+  const candidates = [
+    filePath,
+    filePath.replace(/ (AM|PM)\./gi, `${narrowNoBreakSpace}$1.`),
+    filePath.normalize("NFD"),
+    filePath.replace(/'/g, "’"),
+    filePath.normalize("NFD").replace(/'/g, "’"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      await stat(candidate);
+      return candidate;
+    } catch {
+      // Try the next Pi-compatible path variant.
+    }
+  }
+  return filePath;
+}
+
+function resolveToolPath(filePath: string, cwd: string) {
+  const withoutAt = filePath.startsWith("@") ? filePath.slice(1) : filePath;
+  const normalized = withoutAt.replace(unicodeSpacesPattern, " ");
+  const expanded =
+    normalized === "~"
+      ? os.homedir()
+      : normalized.startsWith("~/")
+        ? path.join(os.homedir(), normalized.slice(2))
+        : normalized;
+  return path.isAbsolute(expanded) ? expanded : path.resolve(cwd, expanded);
+}
+
+async function isGrantedPath(filePath: string, grants: AttachmentGrant, cwd: string) {
+  const resolved = await tryRealpath(await existingPathVariant(resolveToolPath(filePath, cwd)));
+  if (grants.files.has(resolved)) return true;
+  for (const directory of grants.directories) {
+    if (isWithinDirectory(resolved, directory)) return true;
+  }
+  return false;
+}
+
+async function assertGrantedPath(filePath: string, grants: AttachmentGrant, cwd: string) {
+  if (await isGrantedPath(filePath, grants, cwd)) return;
+  throw new Error(`Path is not an attached file or inside an attached folder: ${filePath}`);
+}
+
+function createAttachmentFileAccess(grants: AttachmentGrant): AttachmentFileAccess {
+  return {
+    async grantAttachments(attachments) {
+      for (const attachment of attachments) {
+        const attachmentPath = attachment.path.trim();
+        if (!attachmentPath || isExternalReference(attachmentPath)) continue;
+        try {
+          const resolved = await realpath(attachmentPath);
+          const metadata = await stat(resolved);
+          if (metadata.isDirectory()) {
+            grants.directories.add(resolved);
+          } else if (metadata.isFile()) {
+            grants.files.add(resolved);
+          }
+        } catch {
+          // Invalid attachments are already rejected in the composer path; ignore stale paths here.
+        }
+      }
+    },
+  };
+}
+
+export function createAttachmentFileTools(options: {
+  cwd: string;
+  autoResizeImages: boolean;
+}): { tools: ToolDefinition[]; access: AttachmentFileAccess } {
+  const grants: AttachmentGrant = { files: new Set(), directories: new Set() };
+  const attachmentAccess = createAttachmentFileAccess(grants);
+
+  const readTool = createReadToolDefinition(options.cwd, {
+    autoResizeImages: options.autoResizeImages,
+  });
+  const readExecute = readTool.execute.bind(readTool);
+  readTool.execute = async (toolCallId, params, signal, onUpdate, ctx) => {
+    await assertGrantedPath(params.path, grants, options.cwd);
+    return await readExecute(toolCallId, params, signal, onUpdate, ctx);
+  };
+
+  const lsTool = createLsToolDefinition(options.cwd);
+  const lsExecute = lsTool.execute.bind(lsTool);
+  lsTool.execute = async (toolCallId, params, signal, onUpdate, ctx) => {
+    await assertGrantedPath(params.path ?? ".", grants, options.cwd);
+    return await lsExecute(toolCallId, params, signal, onUpdate, ctx);
+  };
+
+  return { tools: [readTool, lsTool] as unknown as ToolDefinition[], access: attachmentAccess };
+}

--- a/desktop/runtime/attachment-file-tools.test.ts
+++ b/desktop/runtime/attachment-file-tools.test.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createAttachmentFileTools } from "./attachment-file-tools.cts";
+
+async function createFixture() {
+  const cwd = await mkdtemp(path.join(tmpdir(), "howcode-attachment-tools-"));
+  const attachedFile = path.join(cwd, "attached.txt");
+  const outsideFile = path.join(cwd, "outside.txt");
+  const attachedDir = path.join(cwd, "folder");
+  await mkdir(attachedDir);
+  await writeFile(attachedFile, "attached file");
+  await writeFile(outsideFile, "outside file");
+  await writeFile(path.join(attachedDir, "nested.txt"), "nested file");
+  return { cwd, attachedFile, outsideFile, attachedDir };
+}
+
+function getTool(tools: ReturnType<typeof createAttachmentFileTools>["tools"], name: string) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Missing tool ${name}`);
+  return tool;
+}
+
+describe("attachment file tools", () => {
+  it("allows read for attached files and files inside attached folders only", async () => {
+    const { cwd, attachedFile, outsideFile, attachedDir } = await createFixture();
+    const { tools, access } = createAttachmentFileTools({ cwd, autoResizeImages: true });
+    const read = getTool(tools, "read");
+
+    await access.grantAttachments([
+      { path: attachedFile, name: "attached.txt", kind: "text" },
+      { path: attachedDir, name: "folder", kind: "directory" },
+    ]);
+
+    await expect(
+      read.execute("call", { path: "attached.txt" }, undefined, undefined, {
+        cwd,
+        model: { input: ["text"] },
+      } as never),
+    ).resolves.toMatchObject({ content: [{ type: "text", text: "attached file" }] });
+    await expect(
+      read.execute("call", { path: path.join("folder", "nested.txt") }, undefined, undefined, {
+        cwd,
+        model: { input: ["text"] },
+      } as never),
+    ).resolves.toMatchObject({ content: [{ type: "text", text: "nested file" }] });
+    await expect(
+      read.execute("call", { path: outsideFile }, undefined, undefined, {
+        cwd,
+        model: { input: ["text"] },
+      } as never),
+    ).rejects.toThrow(/not an attached file/);
+  });
+
+  it("allows ls inside attached folders and blocks symlink escapes", async () => {
+    const { cwd, outsideFile, attachedDir } = await createFixture();
+    await symlink(outsideFile, path.join(attachedDir, "escape.txt"));
+    const { tools, access } = createAttachmentFileTools({ cwd, autoResizeImages: true });
+    const ls = getTool(tools, "ls");
+    const read = getTool(tools, "read");
+
+    await access.grantAttachments([{ path: attachedDir, name: "folder", kind: "directory" }]);
+
+    await expect(
+      ls.execute("call", { path: "folder" }, undefined, undefined, { cwd } as never),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("nested.txt") }],
+    });
+    await expect(
+      ls.execute("call", { path: "." }, undefined, undefined, { cwd } as never),
+    ).rejects.toThrow(/not an attached file/);
+    await expect(
+      read.execute("call", { path: path.join("folder", "escape.txt") }, undefined, undefined, {
+        cwd,
+        model: { input: ["text"] },
+      } as never),
+    ).rejects.toThrow(/not an attached file/);
+  });
+
+  it("authorizes Pi-compatible read path variants", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "howcode-attachment-tools-"));
+    const screenshotPath = path.join(cwd, "Screenshot 1:00 PM.png");
+    await writeFile(screenshotPath, "screenshot text");
+    const { tools, access } = createAttachmentFileTools({ cwd, autoResizeImages: true });
+    const read = getTool(tools, "read");
+
+    await access.grantAttachments([{ path: screenshotPath, name: "screenshot.png", kind: "text" }]);
+
+    await expect(
+      read.execute("call", { path: "Screenshot 1:00 PM.png" }, undefined, undefined, {
+        cwd,
+        model: { input: ["text"] },
+      } as never),
+    ).resolves.toMatchObject({ content: [{ type: "text", text: "screenshot text" }] });
+  });
+});

--- a/desktop/runtime/composer-service.cts
+++ b/desktop/runtime/composer-service.cts
@@ -346,6 +346,7 @@ export async function sendComposerPrompt(
 
         const promptStreamingBehavior =
           streamingBehavior === "stop" ? "followUp" : streamingBehavior;
+        await runtime.attachmentFileAccess?.grantAttachments(request.attachments ?? []);
         await promptAndReturnAfterPreflight({
           runtime,
           message,
@@ -353,6 +354,7 @@ export async function sendComposerPrompt(
           request: { ...request, sessionPath: persistedSessionPath },
         });
       } else {
+        await runtime.attachmentFileAccess?.grantAttachments(request.attachments ?? []);
         await promptAndReturnAfterPreflight({
           runtime,
           message,

--- a/desktop/runtime/runtime-registry.cts
+++ b/desktop/runtime/runtime-registry.cts
@@ -14,6 +14,7 @@ import {
 } from "./agent-session-extensions.cts";
 import { buildComposerState } from "./composer-state.cts";
 import { createArtifactTools } from "./artifact-tools.cts";
+import { createAttachmentFileTools } from "./attachment-file-tools.cts";
 import { rememberSessionPath } from "./session-path-index.cts";
 import { createRuntimeSettingsRefreshController, isRuntimeBusy } from "./settings-refresh.ts";
 import {
@@ -145,6 +146,12 @@ async function createRuntime(options: {
     settingsCwd: options.settingsCwd,
     settingsManager,
   });
+  const attachmentFileTools = options.settingsCwd
+    ? createAttachmentFileTools({
+        cwd: options.cwd,
+        autoResizeImages: settingsManager.getImageAutoResize(),
+      })
+    : null;
   const { session } = await createAgentSession({
     cwd: options.cwd,
     agentDir,
@@ -156,12 +163,15 @@ async function createRuntime(options: {
     ...(options.settingsCwd
       ? {
           noTools: "builtin" as const,
-          customTools: createArtifactTools({
-            createArtifact,
-            editArtifact,
-            getArtifact: ({ conversationId, slug }) => getArtifact(slug, conversationId),
-            listArtifacts,
-          }),
+          customTools: [
+            ...(attachmentFileTools?.tools ?? []),
+            ...createArtifactTools({
+              createArtifact,
+              editArtifact,
+              getArtifact: ({ conversationId, slug }) => getArtifact(slug, conversationId),
+              listArtifacts,
+            }),
+          ],
         }
       : {}),
   });
@@ -169,6 +179,7 @@ async function createRuntime(options: {
     cwd: options.cwd,
     session,
     chatGroupId: options.chatGroupId ?? null,
+    attachmentFileAccess: attachmentFileTools?.access,
   } satisfies PiRuntime;
 
   rememberSessionPath(session.sessionFile, options.cwd);

--- a/desktop/runtime/types.cts
+++ b/desktop/runtime/types.cts
@@ -1,10 +1,12 @@
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { DesktopEvent } from "../../shared/desktop-contracts.ts";
+import type { AttachmentFileAccess } from "./attachment-file-tools.cts";
 
 export type PiRuntime = {
   cwd: string;
   session: AgentSession;
   chatGroupId?: string | null;
+  attachmentFileAccess?: AttachmentFileAccess;
 };
 
 export type RuntimeThreadReason = Extract<DesktopEvent, { type: "thread-update" }>["reason"];


### PR DESCRIPTION
## Summary
- Replace the separate chat `view_image` tool with Pi's native `read` and `ls` tool definitions in chat runtimes.
- Keep chat runtimes on `noTools: "builtin"`, exposing only attachment-scoped `read`/`ls` plus artifact tools.
- Grant read/list access from composer attachments so files can be read directly and folders can be listed/read recursively without exposing unrelated filesystem paths.

## Implementation notes
- Attachment grants are realpathed and checked before delegating to Pi's native read/list execution, preserving Pi's text, image, truncation, and rendering behavior.
- Reads are allowed for attached files and files under attached folders; listing is allowed only for attached folders/subfolders.
- Symlink escapes from attached folders are blocked by resolving the requested path before checking grants.

## Validation
- Pre-commit hooks passed: Biome, typechecks, Vitest.
- Pre-push hooks passed: lint and full typecheck.

Closes #197
