### PR TITLE
Improve chat artifact drawer responsiveness

### DIFF
--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -360,8 +360,11 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
 
   const handleArtifactDrawerOverlayChange = useCallback(
     (visible: boolean, onClose?: () => void) => {
-      setArtifactDrawerOverlayVisible(visible);
-      setCloseArtifactDrawerOverlay(() => (visible && onClose ? onClose : null));
+      setArtifactDrawerOverlayVisible((current) => (current === visible ? current : visible));
+      setCloseArtifactDrawerOverlay((current) => {
+        const next = visible && onClose ? onClose : null;
+        return current === next ? current : next;
+      });
     },
     [],
   );
@@ -528,34 +531,61 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
               >
                 <button
                   type="button"
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] opacity-70 transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
+                  className={cn(
+                    "inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]",
+                    !artifactDrawerOverlayVisible && "opacity-70 hover:opacity-100",
+                  )}
                   onClick={handleToggleSidebar}
                   aria-label="Show sidebar"
                   data-tooltip="Show sidebar"
                   data-tooltip-placement="right"
                 >
-                  <PanelLeftOpen size={15} />
+                  <PanelLeftOpen
+                    size={15}
+                    className={cn(
+                      artifactDrawerOverlayVisible &&
+                        "[&_*]:fill-[color:var(--workspace)] [&_*]:stroke-[color:var(--muted)]",
+                    )}
+                  />
+                </button>
+              </div>
+              <div
+                className={cn(
+                  "pointer-events-none col-start-3 mb-1.5 min-w-0 justify-self-end self-end transition-opacity duration-150 ease-out",
+                  !sidebarOverlayOpen && artifactDrawerOverlayVisible && closeArtifactDrawerOverlay
+                    ? "opacity-100"
+                    : "opacity-0",
+                )}
+              >
+                <button
+                  type="button"
+                  className={cn(
+                    "inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]",
+                    !sidebarOverlayOpen &&
+                      artifactDrawerOverlayVisible &&
+                      closeArtifactDrawerOverlay
+                      ? "pointer-events-auto"
+                      : "pointer-events-none",
+                  )}
+                  onClick={() => closeArtifactDrawerOverlay?.()}
+                  aria-label="Hide artifacts"
+                  data-tooltip="Hide artifacts"
+                  data-tooltip-placement="left"
+                  tabIndex={
+                    !sidebarOverlayOpen &&
+                    artifactDrawerOverlayVisible &&
+                    closeArtifactDrawerOverlay
+                      ? 0
+                      : -1
+                  }
+                >
+                  <PanelRightClose
+                    size={15}
+                    className="[&_*]:fill-[color:var(--workspace)] [&_*]:stroke-[color:var(--muted)]"
+                  />
                 </button>
               </div>
             </div>
-          </div>
-        ) : null}
-
-        {sidebarCompactMode &&
-        !sidebarOverlayOpen &&
-        artifactDrawerOverlayVisible &&
-        closeArtifactDrawerOverlay ? (
-          <div className="pointer-events-none fixed right-3 bottom-[1.375rem] z-[45]">
-            <button
-              type="button"
-              className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] opacity-70 transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
-              onClick={closeArtifactDrawerOverlay}
-              aria-label="Hide artifacts"
-              data-tooltip="Hide artifacts"
-              data-tooltip-placement="left"
-            >
-              <PanelRightClose size={15} />
-            </button>
           </div>
         ) : null}
 

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { PanelLeftOpen } from "lucide-react";
+import { PanelLeftOpen, PanelRightClose } from "lucide-react";
 import { getPersistedSessionPath, isLocalSessionPath } from "../../../shared/session-paths";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import { TerminalPanel } from "../components/workspace/TerminalPanel";
@@ -86,6 +86,9 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
   const [sidebarCompactMode, setSidebarCompactMode] = useState(false);
   const [sidebarOverlayOpen, setSidebarOverlayOpen] = useState(false);
   const [artifactDrawerOverlayVisible, setArtifactDrawerOverlayVisible] = useState(false);
+  const [closeArtifactDrawerOverlay, setCloseArtifactDrawerOverlay] = useState<(() => void) | null>(
+    null,
+  );
   const [diffBaselineState, setDiffBaselineState] = useState<{
     projectId: string;
     threadId: string | null;
@@ -355,12 +358,19 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
     });
   }, []);
 
-  const handleArtifactDrawerOverlayChange = useCallback((visible: boolean) => {
-    setArtifactDrawerOverlayVisible(visible);
-  }, []);
+  const handleArtifactDrawerOverlayChange = useCallback(
+    (visible: boolean, onClose?: () => void) => {
+      setArtifactDrawerOverlayVisible(visible);
+      setCloseArtifactDrawerOverlay(() => (visible && onClose ? onClose : null));
+    },
+    [],
+  );
 
   useEffect(() => {
-    if (state.activeView !== "chat") setArtifactDrawerOverlayVisible(false);
+    if (state.activeView !== "chat") {
+      setArtifactDrawerOverlayVisible(false);
+      setCloseArtifactDrawerOverlay(null);
+    }
   }, [state.activeView]);
 
   useEffect(() => {
@@ -528,6 +538,24 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 </button>
               </div>
             </div>
+          </div>
+        ) : null}
+
+        {sidebarCompactMode &&
+        !sidebarOverlayOpen &&
+        artifactDrawerOverlayVisible &&
+        closeArtifactDrawerOverlay ? (
+          <div className="pointer-events-none fixed right-3 bottom-[1.375rem] z-[45]">
+            <button
+              type="button"
+              className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] opacity-70 transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
+              onClick={closeArtifactDrawerOverlay}
+              aria-label="Hide artifacts"
+              data-tooltip="Hide artifacts"
+              data-tooltip-placement="left"
+            >
+              <PanelRightClose size={15} />
+            </button>
           </div>
         ) : null}
 

--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -85,6 +85,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sidebarCompactMode, setSidebarCompactMode] = useState(false);
   const [sidebarOverlayOpen, setSidebarOverlayOpen] = useState(false);
+  const [artifactDrawerOverlayVisible, setArtifactDrawerOverlayVisible] = useState(false);
   const [diffBaselineState, setDiffBaselineState] = useState<{
     projectId: string;
     threadId: string | null;
@@ -145,6 +146,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
       : null;
   const takeoverVisible = state.takeoverVisible;
   const terminalDrawerVisible = state.activeView === "thread" && state.terminalVisible;
+  const compactSidebarButtonEdgeMode = terminalDrawerVisible || artifactDrawerOverlayVisible;
   const terminalDrawerPresent = useAnimatedPresence(terminalDrawerVisible);
   const diffBaseline =
     diffBaselineState.projectId === composerProjectId &&
@@ -353,6 +355,14 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
     });
   }, []);
 
+  const handleArtifactDrawerOverlayChange = useCallback((visible: boolean) => {
+    setArtifactDrawerOverlayVisible(visible);
+  }, []);
+
+  useEffect(() => {
+    if (state.activeView !== "chat") setArtifactDrawerOverlayVisible(false);
+  }, [state.activeView]);
+
   useEffect(() => {
     const updateSidebarCompactMode = () => setSidebarCompactMode(window.innerWidth <= 1236);
     updateSidebarCompactMode();
@@ -496,14 +506,14 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
           <div
             className={cn(
               "pointer-events-none absolute inset-x-0 bottom-0 z-[45] pb-4",
-              terminalDrawerVisible ? "px-3" : "px-5",
+              compactSidebarButtonEdgeMode ? "px-3" : "px-5",
             )}
           >
             <div className="grid w-full grid-cols-[minmax(2rem,1fr)_minmax(0,800px)_minmax(2rem,1fr)] items-end gap-2">
               <div
                 className={cn(
                   "pointer-events-auto mb-1.5 min-w-0 justify-self-end self-end",
-                  terminalDrawerVisible ? "justify-self-start" : "translate-x-10",
+                  compactSidebarButtonEdgeMode ? "justify-self-start" : "translate-x-10",
                 )}
               >
                 <button
@@ -638,6 +648,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 sidebarAutoHidden={sidebarCompactMode}
                 sidebarCompactMode={sidebarCompactMode}
                 onToggleSidebar={handleToggleSidebar}
+                onArtifactDrawerOverlayChange={handleArtifactDrawerOverlayChange}
               />
             </div>
 

--- a/src/app/app-shell/AppShellWorkspace.tsx
+++ b/src/app/app-shell/AppShellWorkspace.tsx
@@ -23,6 +23,7 @@ type AppShellWorkspaceProps = {
   sidebarAutoHidden: boolean;
   sidebarCompactMode: boolean;
   onToggleSidebar: () => void;
+  onArtifactDrawerOverlayChange?: (visible: boolean) => void;
 };
 
 export function AppShellWorkspace({
@@ -43,6 +44,7 @@ export function AppShellWorkspace({
   sidebarAutoHidden,
   sidebarCompactMode,
   onToggleSidebar,
+  onArtifactDrawerOverlayChange,
 }: AppShellWorkspaceProps) {
   const { state } = controller;
 
@@ -62,6 +64,7 @@ export function AppShellWorkspace({
         sidebarAutoHidden={sidebarAutoHidden}
         sidebarCompactMode={sidebarCompactMode}
         onToggleSidebar={onToggleSidebar}
+        onArtifactDrawerOverlayChange={onArtifactDrawerOverlayChange}
       />
     );
   }

--- a/src/app/app-shell/AppShellWorkspace.tsx
+++ b/src/app/app-shell/AppShellWorkspace.tsx
@@ -23,7 +23,7 @@ type AppShellWorkspaceProps = {
   sidebarAutoHidden: boolean;
   sidebarCompactMode: boolean;
   onToggleSidebar: () => void;
-  onArtifactDrawerOverlayChange?: (visible: boolean) => void;
+  onArtifactDrawerOverlayChange?: (visible: boolean, onClose?: () => void) => void;
 };
 
 export function AppShellWorkspace({

--- a/src/app/components/workspace/WorkspaceComposerDock.tsx
+++ b/src/app/components/workspace/WorkspaceComposerDock.tsx
@@ -41,8 +41,8 @@ export function WorkspaceComposerDock({
         <div
           className={cn(
             compactControls
-              ? "mb-1.5 min-w-0 translate-x-10 justify-self-end self-end"
-              : "mb-1.5 ml-3 min-w-0 self-end transition-transform duration-100 ease-out",
+              ? "relative z-20 mb-1.5 min-w-0 translate-x-10 justify-self-end self-end"
+              : "relative z-20 mb-1.5 ml-3 min-w-0 self-end transition-transform duration-100 ease-out",
             leftClassName,
           )}
           style={leftStyle}
@@ -50,13 +50,13 @@ export function WorkspaceComposerDock({
           {left}
         </div>
       ) : null}
-      <div className="relative col-start-2 w-full">{center}</div>
+      <div className="relative z-10 col-start-2 w-full">{center}</div>
       {right ? (
         <div
           className={cn(
             compactControls
-              ? "col-start-3 mb-1.5 min-w-0 self-end"
-              : "col-start-3 mb-1.5 min-w-0 self-end transition-transform duration-100 ease-out",
+              ? "relative z-20 col-start-3 mb-1.5 min-w-0 self-end"
+              : "relative z-20 col-start-3 mb-1.5 min-w-0 self-end transition-transform duration-100 ease-out",
             rightClassName,
           )}
           style={rightStyle}

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -9,6 +9,7 @@ import { Composer } from "../../components/workspace/Composer";
 import { WorkspaceComposerDock } from "../../components/workspace/WorkspaceComposerDock";
 import { QueuedPromptsCard } from "../../components/workspace/composer/QueuedPromptsCard";
 import type { ProjectDiffBaseline, ProjectDiffRenderMode } from "../../desktop/types";
+import { useAnimatedPresence } from "../../hooks/useAnimatedPresence";
 import type { Message } from "../../types";
 import { cn } from "../../utils/cn";
 import { ChatView } from "./ChatView";
@@ -31,9 +32,10 @@ type ChatWorkspaceViewProps = {
   sidebarAutoHidden: boolean;
   sidebarCompactMode: boolean;
   onToggleSidebar: () => void;
+  onArtifactDrawerOverlayChange?: (visible: boolean) => void;
 };
 
-const ARTIFACT_DRAWER_WIDTH = "min(760px, max(0px, calc(100% - 900px)))";
+const ARTIFACT_DRAWER_WIDTH = "clamp(420px, calc(100% - 820px), 760px)";
 
 function getReplyActivityKey(messages: readonly Message[]) {
   return messages
@@ -56,6 +58,7 @@ export function ChatWorkspaceView({
   sidebarAutoHidden,
   sidebarCompactMode,
   onToggleSidebar,
+  onArtifactDrawerOverlayChange,
 }: ChatWorkspaceViewProps) {
   const [composerPromptResetKey] = useState(0);
   const [composerLayoutVersion, setComposerLayoutVersion] = useState(0);
@@ -83,7 +86,16 @@ export function ChatWorkspaceView({
   const artifactsVisible = conversationId
     ? (artifactsVisibleByConversation[conversationId] ?? false)
     : false;
-  const artifactDrawerInsetStyle = artifactsVisible ? { right: ARTIFACT_DRAWER_WIDTH } : undefined;
+  const artifactDrawerVisible = artifactsVisible && !artifactsFullscreen;
+  const artifactDrawerOverlay = sidebarCompactMode;
+  const showDesktopArtifactDrawer = artifactDrawerVisible && !artifactDrawerOverlay;
+  const artifactDrawerPresent = useAnimatedPresence(artifactDrawerVisible);
+  const artifactDrawerInsetStyle = showDesktopArtifactDrawer
+    ? { right: ARTIFACT_DRAWER_WIDTH }
+    : undefined;
+  const artifactDrawerStyle = artifactDrawerPresent
+    ? { width: artifactDrawerOverlay ? "100%" : ARTIFACT_DRAWER_WIDTH }
+    : undefined;
   const [conversationContentVisible, setConversationContentVisible] = useState(hasConversation);
   const previousHasConversationRef = useRef(hasConversation);
   const previousConversationIdRef = useRef<string | null | undefined>(conversationId);
@@ -128,6 +140,34 @@ export function ChatWorkspaceView({
   useEffect(() => {
     if (!artifactsVisible) setArtifactsFullscreen(false);
   }, [artifactsVisible]);
+
+  useEffect(() => {
+    const overlayVisible = artifactDrawerVisible && artifactDrawerOverlay;
+    onArtifactDrawerOverlayChange?.(overlayVisible);
+    return () => onArtifactDrawerOverlayChange?.(false);
+  }, [artifactDrawerOverlay, artifactDrawerVisible, onArtifactDrawerOverlayChange]);
+
+  useEffect(() => {
+    if (!artifactsVisible || (!artifactDrawerOverlay && !artifactsFullscreen)) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      if (artifactsFullscreen) {
+        setArtifactsFullscreen(false);
+        return;
+      }
+      if (!conversationId) return;
+      setArtifactsVisibleByConversation((current) => ({
+        ...current,
+        [conversationId]: false,
+      }));
+    };
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  }, [artifactsFullscreen, artifactDrawerOverlay, artifactsVisible, conversationId]);
   const {
     handleEditQueuedPrompt,
     handleRemoveQueuedPrompt,
@@ -144,7 +184,7 @@ export function ChatWorkspaceView({
     <div className="relative min-h-0 flex-1 overflow-hidden">
       <div
         className={cn(
-          "absolute inset-0 min-h-0 overflow-hidden transition-[right] duration-200 ease-out",
+          "motion-terminal-drawer-offset absolute inset-0 min-h-0 overflow-hidden",
           artifactsFullscreen && "hidden",
         )}
         style={!artifactsFullscreen ? artifactDrawerInsetStyle : undefined}
@@ -174,7 +214,7 @@ export function ChatWorkspaceView({
         <footer
           ref={footerRef}
           className={cn(
-            "pointer-events-none absolute inset-x-0 z-10 px-5 pb-4",
+            "motion-terminal-drawer-offset pointer-events-none absolute inset-x-0 z-10 px-5 pb-4",
             hasConversation
               ? "bottom-0 translate-y-0"
               : "top-1/2 -translate-y-1/2 transition-[top,transform] duration-300 ease-out",
@@ -183,7 +223,6 @@ export function ChatWorkspaceView({
           <div className="pointer-events-auto grid gap-2.5">
             <WorkspaceComposerDock
               compactControls={sidebarAutoHidden}
-              leftClassName={cn(artifactsVisible && !artifactsFullscreen && "invisible")}
               left={
                 sidebarCompactMode ? null : (
                   <button
@@ -288,7 +327,7 @@ export function ChatWorkspaceView({
               }
               rightClassName={cn(
                 "opacity-0 min-[1400px]:opacity-100",
-                artifactsVisible && !artifactsFullscreen && "invisible",
+                showDesktopArtifactDrawer && "invisible",
               )}
               right={
                 <DesktopComposerStatus
@@ -301,32 +340,52 @@ export function ChatWorkspaceView({
           </div>
         </footer>
       </div>
-      <div
-        className={cn(
-          "absolute top-0 right-0 bottom-0 min-h-0 overflow-hidden transition-[width] duration-200 ease-out",
-          !artifactsVisible && "w-0",
-          artifactsFullscreen && "left-0 w-auto",
-        )}
-        style={
-          artifactsVisible && !artifactsFullscreen ? { width: ARTIFACT_DRAWER_WIDTH } : undefined
-        }
-      >
-        <ArtifactPanel
-          conversationId={conversationId}
-          visible={artifactsVisible}
-          fullscreen={artifactsFullscreen}
-          onToggleFullscreen={() => setArtifactsFullscreen((fullscreen) => !fullscreen)}
-          onClose={() => {
-            if (conversationId) {
-              setArtifactsVisibleByConversation((current) => ({
-                ...current,
-                [conversationId]: false,
-              }));
-            }
-            setArtifactsFullscreen(false);
-          }}
-        />
-      </div>
+      {artifactDrawerPresent ? (
+        <div
+          className="pointer-events-none absolute top-0 right-0 bottom-0 z-20 max-w-full overflow-hidden"
+          style={artifactDrawerStyle}
+        >
+          <div
+            data-open={artifactDrawerVisible ? "true" : "false"}
+            className={`motion-terminal-drawer absolute inset-0 min-h-0 min-w-0 ${artifactDrawerVisible ? "pointer-events-auto" : "pointer-events-none"}`}
+          >
+            <ArtifactPanel
+              conversationId={conversationId}
+              visible={artifactDrawerPresent}
+              fullscreen={false}
+              onToggleFullscreen={() => setArtifactsFullscreen(true)}
+              onClose={() => {
+                if (conversationId) {
+                  setArtifactsVisibleByConversation((current) => ({
+                    ...current,
+                    [conversationId]: false,
+                  }));
+                }
+              }}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {artifactsFullscreen ? (
+        <div className="absolute inset-0 z-20 min-h-0 overflow-hidden">
+          <ArtifactPanel
+            conversationId={conversationId}
+            visible={artifactsVisible}
+            fullscreen={artifactsFullscreen}
+            onToggleFullscreen={() => setArtifactsFullscreen(false)}
+            onClose={() => {
+              if (conversationId) {
+                setArtifactsVisibleByConversation((current) => ({
+                  ...current,
+                  [conversationId]: false,
+                }));
+              }
+              setArtifactsFullscreen(false);
+            }}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -35,8 +35,7 @@ type ChatWorkspaceViewProps = {
   onArtifactDrawerOverlayChange?: (visible: boolean, onClose?: () => void) => void;
 };
 
-const ARTIFACT_DRAWER_WIDTH = "clamp(420px, calc(100% - 820px), 760px)";
-const ARTIFACT_DRAWER_OVERLAY_WORKSPACE_WIDTH = 1220;
+const ARTIFACT_DRAWER_WIDTH = "clamp(320px, calc(100% - 820px), 760px)";
 
 function getReplyActivityKey(messages: readonly Message[]) {
   return messages
@@ -68,7 +67,6 @@ export function ChatWorkspaceView({
     Record<string, boolean>
   >({});
   const [artifactsFullscreen, setArtifactsFullscreen] = useState(false);
-  const [artifactWorkspaceOverlay, setArtifactWorkspaceOverlay] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const desktopContentRef = useRef<HTMLDivElement>(null);
   const artifactDrawerRef = useRef<HTMLDivElement>(null);
@@ -92,7 +90,7 @@ export function ChatWorkspaceView({
     ? (artifactsVisibleByConversation[conversationId] ?? false)
     : false;
   const artifactDrawerVisible = artifactsVisible && !artifactsFullscreen;
-  const artifactDrawerOverlay = sidebarCompactMode || artifactWorkspaceOverlay;
+  const artifactDrawerOverlay = sidebarCompactMode;
   const showDesktopArtifactDrawer = artifactDrawerVisible && !artifactDrawerOverlay;
   const artifactDrawerPresent = useAnimatedPresence(artifactDrawerVisible);
   const artifactDrawerInsetStyle = showDesktopArtifactDrawer
@@ -114,21 +112,6 @@ export function ChatWorkspaceView({
     }
     setArtifactsFullscreen(false);
   }, [conversationId]);
-
-  useEffect(() => {
-    const rootElement = rootRef.current;
-    if (!rootElement) return;
-
-    const updateWorkspaceOverlay = () => {
-      const nextOverlay = rootElement.clientWidth <= ARTIFACT_DRAWER_OVERLAY_WORKSPACE_WIDTH;
-      setArtifactWorkspaceOverlay((current) => (current === nextOverlay ? current : nextOverlay));
-    };
-    updateWorkspaceOverlay();
-
-    const resizeObserver = new ResizeObserver(updateWorkspaceOverlay);
-    resizeObserver.observe(rootElement);
-    return () => resizeObserver.disconnect();
-  }, []);
 
   useEffect(() => {
     const desktopContentElement = desktopContentRef.current;

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import {
   getLocalDraftChatGroupId,
@@ -32,7 +32,7 @@ type ChatWorkspaceViewProps = {
   sidebarAutoHidden: boolean;
   sidebarCompactMode: boolean;
   onToggleSidebar: () => void;
-  onArtifactDrawerOverlayChange?: (visible: boolean) => void;
+  onArtifactDrawerOverlayChange?: (visible: boolean, onClose?: () => void) => void;
 };
 
 const ARTIFACT_DRAWER_WIDTH = "clamp(420px, calc(100% - 820px), 760px)";
@@ -100,6 +100,15 @@ export function ChatWorkspaceView({
   const previousHasConversationRef = useRef(hasConversation);
   const previousConversationIdRef = useRef<string | null | undefined>(conversationId);
   const shouldShowConversationContent = conversationContentVisible || activeThreadData?.isStreaming;
+  const handleCloseArtifacts = useCallback(() => {
+    if (conversationId) {
+      setArtifactsVisibleByConversation((current) => ({
+        ...current,
+        [conversationId]: false,
+      }));
+    }
+    setArtifactsFullscreen(false);
+  }, [conversationId]);
 
   useEffect(() => {
     if (!hasConversation) {
@@ -143,9 +152,17 @@ export function ChatWorkspaceView({
 
   useEffect(() => {
     const overlayVisible = artifactDrawerVisible && artifactDrawerOverlay;
-    onArtifactDrawerOverlayChange?.(overlayVisible);
+    onArtifactDrawerOverlayChange?.(
+      overlayVisible,
+      overlayVisible ? handleCloseArtifacts : undefined,
+    );
     return () => onArtifactDrawerOverlayChange?.(false);
-  }, [artifactDrawerOverlay, artifactDrawerVisible, onArtifactDrawerOverlayChange]);
+  }, [
+    artifactDrawerOverlay,
+    artifactDrawerVisible,
+    handleCloseArtifacts,
+    onArtifactDrawerOverlayChange,
+  ]);
 
   useEffect(() => {
     if (!artifactsVisible || (!artifactDrawerOverlay && !artifactsFullscreen)) return;
@@ -354,14 +371,7 @@ export function ChatWorkspaceView({
               visible={artifactDrawerPresent}
               fullscreen={false}
               onToggleFullscreen={() => setArtifactsFullscreen(true)}
-              onClose={() => {
-                if (conversationId) {
-                  setArtifactsVisibleByConversation((current) => ({
-                    ...current,
-                    [conversationId]: false,
-                  }));
-                }
-              }}
+              onClose={handleCloseArtifacts}
             />
           </div>
         </div>
@@ -374,15 +384,7 @@ export function ChatWorkspaceView({
             visible={artifactsVisible}
             fullscreen={artifactsFullscreen}
             onToggleFullscreen={() => setArtifactsFullscreen(false)}
-            onClose={() => {
-              if (conversationId) {
-                setArtifactsVisibleByConversation((current) => ({
-                  ...current,
-                  [conversationId]: false,
-                }));
-              }
-              setArtifactsFullscreen(false);
-            }}
+            onClose={handleCloseArtifacts}
           />
         </div>
       ) : null}

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -36,6 +36,7 @@ type ChatWorkspaceViewProps = {
 };
 
 const ARTIFACT_DRAWER_WIDTH = "clamp(420px, calc(100% - 820px), 760px)";
+const ARTIFACT_DRAWER_OVERLAY_WORKSPACE_WIDTH = 1220;
 
 function getReplyActivityKey(messages: readonly Message[]) {
   return messages
@@ -67,6 +68,10 @@ export function ChatWorkspaceView({
     Record<string, boolean>
   >({});
   const [artifactsFullscreen, setArtifactsFullscreen] = useState(false);
+  const [artifactWorkspaceOverlay, setArtifactWorkspaceOverlay] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const desktopContentRef = useRef<HTMLDivElement>(null);
+  const artifactDrawerRef = useRef<HTMLDivElement>(null);
   const footerRef = useRef<HTMLElement>(null);
   const mainViewRef = useRef<HTMLElement>(null);
   const {
@@ -87,7 +92,7 @@ export function ChatWorkspaceView({
     ? (artifactsVisibleByConversation[conversationId] ?? false)
     : false;
   const artifactDrawerVisible = artifactsVisible && !artifactsFullscreen;
-  const artifactDrawerOverlay = sidebarCompactMode;
+  const artifactDrawerOverlay = sidebarCompactMode || artifactWorkspaceOverlay;
   const showDesktopArtifactDrawer = artifactDrawerVisible && !artifactDrawerOverlay;
   const artifactDrawerPresent = useAnimatedPresence(artifactDrawerVisible);
   const artifactDrawerInsetStyle = showDesktopArtifactDrawer
@@ -109,6 +114,53 @@ export function ChatWorkspaceView({
     }
     setArtifactsFullscreen(false);
   }, [conversationId]);
+
+  useEffect(() => {
+    const rootElement = rootRef.current;
+    if (!rootElement) return;
+
+    const updateWorkspaceOverlay = () => {
+      const nextOverlay = rootElement.clientWidth <= ARTIFACT_DRAWER_OVERLAY_WORKSPACE_WIDTH;
+      setArtifactWorkspaceOverlay((current) => (current === nextOverlay ? current : nextOverlay));
+    };
+    updateWorkspaceOverlay();
+
+    const resizeObserver = new ResizeObserver(updateWorkspaceOverlay);
+    resizeObserver.observe(rootElement);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const desktopContentElement = desktopContentRef.current;
+    if (!desktopContentElement) return;
+    const shouldInertDesktopContent = artifactDrawerOverlay && artifactDrawerVisible;
+    if (shouldInertDesktopContent) {
+      desktopContentElement.setAttribute("inert", "");
+      desktopContentElement.setAttribute("aria-hidden", "true");
+      return () => {
+        desktopContentElement.removeAttribute("inert");
+        desktopContentElement.removeAttribute("aria-hidden");
+      };
+    }
+
+    desktopContentElement.removeAttribute("inert");
+    desktopContentElement.removeAttribute("aria-hidden");
+  }, [artifactDrawerOverlay, artifactDrawerVisible]);
+
+  useEffect(() => {
+    if (!artifactDrawerOverlay || !artifactDrawerVisible) return;
+    const drawerElement = artifactDrawerRef.current;
+    if (!drawerElement) return;
+    if (document.activeElement && drawerElement.contains(document.activeElement)) return;
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      const focusTarget = drawerElement.querySelector<HTMLElement>(
+        'button:not([disabled]), select:not([disabled]), textarea:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      focusTarget?.focus();
+    });
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [artifactDrawerOverlay, artifactDrawerVisible]);
 
   useEffect(() => {
     if (!hasConversation) {
@@ -198,8 +250,9 @@ export function ChatWorkspaceView({
   });
 
   return (
-    <div className="relative min-h-0 flex-1 overflow-hidden">
+    <div ref={rootRef} className="relative min-h-0 flex-1 overflow-hidden">
       <div
+        ref={desktopContentRef}
         className={cn(
           "motion-terminal-drawer-offset absolute inset-0 min-h-0 overflow-hidden",
           artifactsFullscreen && "hidden",
@@ -357,12 +410,13 @@ export function ChatWorkspaceView({
           </div>
         </footer>
       </div>
-      {artifactDrawerPresent ? (
+      {artifactDrawerPresent && !artifactsFullscreen ? (
         <div
           className="pointer-events-none absolute top-0 right-0 bottom-0 z-20 max-w-full overflow-hidden"
           style={artifactDrawerStyle}
         >
           <div
+            ref={artifactDrawerRef}
             data-open={artifactDrawerVisible ? "true" : "false"}
             className={`motion-terminal-drawer absolute inset-0 min-h-0 min-w-0 ${artifactDrawerVisible ? "pointer-events-auto" : "pointer-events-none"}`}
           >

--- a/src/app/features/chat/ChatWorkspaceView.tsx
+++ b/src/app/features/chat/ChatWorkspaceView.tsx
@@ -70,6 +70,7 @@ export function ChatWorkspaceView({
   const rootRef = useRef<HTMLDivElement>(null);
   const desktopContentRef = useRef<HTMLDivElement>(null);
   const artifactDrawerRef = useRef<HTMLDivElement>(null);
+  const artifactOverlayPreviousFocusRef = useRef<HTMLElement | null>(null);
   const footerRef = useRef<HTMLElement>(null);
   const mainViewRef = useRef<HTMLElement>(null);
   const {
@@ -135,6 +136,8 @@ export function ChatWorkspaceView({
     const drawerElement = artifactDrawerRef.current;
     if (!drawerElement) return;
     if (document.activeElement && drawerElement.contains(document.activeElement)) return;
+    artifactOverlayPreviousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
 
     const animationFrame = window.requestAnimationFrame(() => {
       const focusTarget = drawerElement.querySelector<HTMLElement>(
@@ -142,7 +145,18 @@ export function ChatWorkspaceView({
       );
       focusTarget?.focus();
     });
-    return () => window.cancelAnimationFrame(animationFrame);
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      const previousFocus = artifactOverlayPreviousFocusRef.current;
+      artifactOverlayPreviousFocusRef.current = null;
+      if (!previousFocus?.isConnected) return;
+      if (
+        document.activeElement instanceof HTMLElement &&
+        drawerElement.contains(document.activeElement)
+      ) {
+        previousFocus.focus();
+      }
+    };
   }, [artifactDrawerOverlay, artifactDrawerVisible]);
 
   useEffect(() => {
@@ -204,8 +218,9 @@ export function ChatWorkspaceView({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
+      if (state.settingsOpen) return;
       event.preventDefault();
-      event.stopImmediatePropagation();
+      event.stopPropagation();
       if (artifactsFullscreen) {
         setArtifactsFullscreen(false);
         return;
@@ -219,7 +234,13 @@ export function ChatWorkspaceView({
 
     window.addEventListener("keydown", handleKeyDown, { capture: true });
     return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
-  }, [artifactsFullscreen, artifactDrawerOverlay, artifactsVisible, conversationId]);
+  }, [
+    artifactsFullscreen,
+    artifactDrawerOverlay,
+    artifactsVisible,
+    conversationId,
+    state.settingsOpen,
+  ]);
   const {
     handleEditQueuedPrompt,
     handleRemoveQueuedPrompt,

--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -76,8 +76,8 @@ export function ArtifactPanel({
       aria-label="Artifacts drawer"
       className="flex h-full min-h-0 flex-1 flex-col overflow-hidden border-l border-[color:var(--border)] bg-[color:var(--workspace)]"
     >
-      <div className="flex h-11 items-center justify-between gap-3 border-b border-[color:var(--border)] px-3">
-        <div className="flex min-w-0 items-center gap-2 text-[13px] text-[color:var(--text)]">
+      <div className="flex min-h-11 items-center justify-between gap-2 border-b border-[color:var(--border)] px-2 py-2 min-[420px]:gap-3 min-[420px]:px-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2 text-[13px] text-[color:var(--text)]">
           <FileCode2 size={15} className="shrink-0 text-[color:var(--muted)]" />
           {selectedArtifact ? (
             <span className="truncate font-medium">
@@ -85,10 +85,10 @@ export function ArtifactPanel({
             </span>
           ) : null}
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex min-w-0 shrink items-center gap-1 overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {selectedArtifact ? (
             <select
-              className="h-7 rounded-md border border-[color:var(--border)] bg-[color:var(--panel-2)] px-2 text-[11px] text-[color:var(--muted)] outline-none transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
+              className="h-7 max-w-28 shrink-0 rounded-md border border-[color:var(--border)] bg-[color:var(--panel-2)] px-2 text-[11px] text-[color:var(--muted)] outline-none transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
               value={selectedVersion}
               onChange={(event) => {
                 const value = event.target.value;

--- a/src/app/features/chat/artifacts/ArtifactPanel.tsx
+++ b/src/app/features/chat/artifacts/ArtifactPanel.tsx
@@ -11,6 +11,7 @@ import {
   Save,
 } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
+import { Tooltip } from "../../../components/common/Tooltip";
 import { compactIconButtonClass } from "../../../ui/classes";
 import { cn } from "../../../utils/cn";
 import { createMarkdownEditorPlugins, HistoricalMarkdownPreview } from "./ArtifactMarkdown";
@@ -149,18 +150,24 @@ export function ArtifactPanel({
           >
             <Save size={14} />
           </button>
-          <button
-            type="button"
-            className={cn(compactIconButtonClass, "h-7 w-7")}
-            onClick={() => void downloadArtifact()}
-            disabled={!selectedArtifact}
-            aria-label={downloadStatus ?? "Download artifact"}
-            data-tooltip={downloadStatus ?? "Download"}
-            data-tooltip-placement="left"
-            data-tooltip-size={downloadStatus ? "wide" : undefined}
+          <Tooltip
+            content={downloadStatus ?? "Download"}
+            placement="left"
+            className="inline-flex shrink-0"
+            contentClassName={
+              downloadStatus ? "max-w-[min(520px,calc(100vw-3rem))] whitespace-nowrap" : undefined
+            }
           >
-            <Download size={14} />
-          </button>
+            <button
+              type="button"
+              className={cn(compactIconButtonClass, "h-7 w-7")}
+              onClick={() => void downloadArtifact()}
+              disabled={!selectedArtifact}
+              aria-label={downloadStatus ?? "Download artifact"}
+            >
+              <Download size={14} />
+            </button>
+          </Tooltip>
           <button
             type="button"
             className={cn(


### PR DESCRIPTION
## Summary
- Makes the chat artifacts panel responsive like the terminal drawer: desktop drawer, compact full-width overlay, and explicit fullscreen only via the fullscreen toggle.
- Adds compact bottom controls for artifact overlays, including a stable hide-artifacts button alongside the sidebar fold affordance.
- Improves artifact toolbar behavior on narrow widths and moves the artifact download status tooltip to the shared portal tooltip so it is not clipped.

## Details
- Keeps chat/composer content inert while the artifact overlay is active and moves focus into the drawer when opened.
- Avoids duplicate artifact panel rendering when entering artifact fullscreen.
- Preserves user intent: resizing no longer promotes a drawer into the explicit fullscreen state.
- Ensures compact bottom controls remain clickable and visually legible in artifact overlay mode.

## Validation
- Pre-commit hooks passed across commits.
- Pre-push hooks passed.
- Typechecks passed.
- Vitest passed: 13 files, 50 tests.
