### PR TITLE
Modernize inbox composer responsiveness

### DIFF
--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -100,6 +100,7 @@ export function InboxComposer({
   onStop,
 }: InboxComposerProps) {
   const [openMenu, setOpenMenu] = useState<"model" | "picker" | null>(null);
+  const composerSurfaceRef = useRef<HTMLDivElement>(null);
   const composerPanelRef = useRef<HTMLDivElement>(null);
   const pickerButtonRef = useRef<HTMLButtonElement>(null);
   const pickerPanelRef = useRef<HTMLDivElement>(null);
@@ -158,7 +159,7 @@ export function InboxComposer({
         return;
       }
 
-      if (composerPanelRef.current?.contains(target)) {
+      if (composerSurfaceRef.current?.contains(target)) {
         return;
       }
 
@@ -276,7 +277,7 @@ export function InboxComposer({
 
       if (
         slashCommandPanelRef.current?.contains(target) ||
-        composerPanelRef.current?.contains(target)
+        composerSurfaceRef.current?.contains(target)
       ) {
         return;
       }
@@ -395,7 +396,10 @@ export function InboxComposer({
   };
 
   return (
-    <div className="relative grid w-full grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible">
+    <div
+      ref={composerSurfaceRef}
+      className="relative grid w-full grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible"
+    >
       <div className="relative h-full min-h-[7rem] w-8 shrink-0 self-stretch text-[color:var(--muted)]">
         <div className="absolute bottom-[3.55rem] left-0 flex w-7 flex-col-reverse items-center gap-1">
           {attachments.length > 0 ? (
@@ -466,7 +470,7 @@ export function InboxComposer({
             handlePaste={handlePaste}
             hoverToFocus={appSettings.hoverToFocus}
             hoverToBlur={appSettings.hoverToBlur}
-            hoverBoundaryRef={composerPanelRef}
+            hoverBoundaryRef={composerSurfaceRef}
             onAction={onAction}
             onOpenSettingsView={onOpenSettingsView}
             openPickerDirectory={openPickerDirectory}

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Bot, Paperclip, Send, Square, X } from "lucide-react";
+import { ArrowUpRight, Bot, Paperclip, Square, X } from "lucide-react";
 import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { getDesktopActionErrorMessage } from "../../../desktop/action-results";
 import { getErrorMessage } from "../../../desktop/error-messages";
@@ -19,16 +19,16 @@ import { IconButton } from "../../common/IconButton";
 import { ToolbarButton } from "../../common/ToolbarButton";
 import { Tooltip } from "../../common/Tooltip";
 import { ComposerContextMeter } from "../composer/ComposerContextMeter";
-import { ComposerDictationControls } from "../composer/ComposerDictationControls";
-import { ComposerFilePicker } from "../composer/ComposerFilePicker";
 import { ComposerModelPopover } from "../composer/ComposerModelPopover";
-import { ComposerTextField } from "../composer/ComposerTextField";
+import { ComposerPromptInputPanel } from "../composer/ComposerPromptInputPanel";
 import {
-  getComposerSlashCommandGroupLabel,
-  getComposerSlashCommandOptionId,
-  useComposerSlashCommands,
-} from "../composer/useComposerSlashCommands";
+  workspaceFooterRowClass,
+  workspaceFooterTextClass,
+  workspaceFooterTrailingGroupClass,
+} from "../footer/WorkspaceFooterPrimitives";
+import { useComposerSlashCommands } from "../composer/useComposerSlashCommands";
 import { useComposerAttachmentPicker } from "../composer/useComposerAttachmentPicker";
+import { useComposerClipboardHandlers } from "../composer/useComposerClipboardHandlers";
 import { useComposerDictation } from "../composer/useComposerDictation";
 
 const thinkingLevelLabels: Record<ComposerThinkingLevel, string> = {
@@ -110,12 +110,6 @@ export function InboxComposer({
   const attachmentsRef = useRef(attachments);
   const sendLockRef = useRef(false);
   const [localActionPending, setLocalActionPending] = useState(false);
-  const canSend =
-    (draft.trim().length > 0 || attachments.length > 0) &&
-    !isSending &&
-    !isCompacting &&
-    !localActionPending;
-
   useEffect(() => {
     draftValueRef.current = draft;
   }, [draft]);
@@ -256,6 +250,11 @@ export function InboxComposer({
   const slashCommandListSignature = slashCommands.commands
     .map((command) => `${command.source}:${command.name}`)
     .join("|");
+  const { handlePaste } = useComposerClipboardHandlers({
+    setAttachments: setAttachmentValue,
+    setDraftValue,
+    setErrorMessage: onChangeErrorMessage,
+  });
 
   useEffect(() => {
     if (slashCommands.open) {
@@ -396,277 +395,186 @@ export function InboxComposer({
   };
 
   return (
-    <div
-      ref={composerPanelRef}
-      className="grid gap-0 overflow-visible rounded-[20px] border border-[color:var(--accent-border)] bg-[color:var(--panel)] shadow-none"
-      aria-label="Inbox composer panel"
-    >
-      <div className="relative">
-        {openMenu === "picker" ? (
-          <ComposerFilePicker
+    <div className="relative grid w-full grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible">
+      <div className="relative h-full min-h-[7rem] w-8 shrink-0 self-stretch text-[color:var(--muted)]">
+        <div className="absolute bottom-[3.55rem] left-0 flex w-7 flex-col-reverse items-center gap-1">
+          {attachments.length > 0 ? (
+            <>
+              <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[color:var(--accent-bg-subtle)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
+                {attachments.length}
+              </span>
+              <button
+                type="button"
+                className={cn(compactIconButtonClass, "h-5 w-5 shrink-0 rounded-full")}
+                onClick={clearAttachments}
+                aria-label="Clear attachments"
+                data-tooltip="Clear attachments"
+              >
+                <X size={12} />
+              </button>
+            </>
+          ) : null}
+          <button
+            ref={pickerButtonRef}
+            type="button"
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+            onClick={() => {
+              if (slashCommands.open) {
+                slashCommands.dismiss({ clearDraft: true });
+              }
+              void pickAttachments();
+            }}
+            aria-label={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
+            data-tooltip={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
+          >
+            <span className={cn(compactIconButtonClass, "h-7 w-7 shrink-0 rounded-full")}>
+              <Paperclip size={15} />
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <div className="relative grid gap-0 overflow-visible">
+        <div
+          ref={composerPanelRef}
+          className="grid gap-0 overflow-visible rounded-[20px] border border-[color:var(--accent-border)] bg-[color:var(--panel)] shadow-none"
+          aria-label="Inbox composer panel"
+        >
+          <ComposerPromptInputPanel
             attachments={attachments}
+            clearError={() => onChangeErrorMessage(null)}
+            dictationActive={dictationActive}
+            dictationMissingModel={dictationMissingModel}
+            dictationSupported={dictationSupported}
+            dictationTranscribing={dictationInterimText.length > 0 && !dictationActive}
+            draft={draft}
             errorMessage={errorMessage}
+            extensionRunning={false}
+            inputLocked={isSending || localActionPending}
             favoriteFolders={favoriteFolders}
-            loading={pickerLoading}
-            picker={pickerState}
-            panelRef={pickerPanelRef}
-            projectRootPath={thread.projectId}
-            onAttachAttachments={attachPickerAttachments}
-            onOpenRoot={openPickerRoot}
-            onOpenDirectory={openPickerDirectory}
-            onRemoveAttachment={removeAttachment}
-            onToggleFile={togglePendingPickerAttachment}
+            pickerLoading={pickerLoading}
+            pickerOpen={openMenu === "picker"}
+            pickerPanelRef={pickerPanelRef}
+            pickerState={pickerState}
+            placeholderText={errorMessage ?? "Reply to this thread…"}
+            projectId={thread.projectId}
+            slashCommandPanelRef={slashCommandPanelRef}
+            slashCommands={slashCommands}
+            showDictationButton={showDictationButton}
+            attachPickerAttachments={attachPickerAttachments}
+            cancelDictation={cancelDictation}
+            handlePaste={handlePaste}
+            hoverToFocus={appSettings.hoverToFocus}
+            hoverToBlur={appSettings.hoverToBlur}
+            hoverBoundaryRef={composerPanelRef}
+            onAction={onAction}
+            onOpenSettingsView={onOpenSettingsView}
+            openPickerDirectory={openPickerDirectory}
+            openPickerRoot={openPickerRoot}
+            removeAttachment={removeAttachment}
+            setDraft={setDraftValue}
+            toggleDictation={toggleDictation}
+            togglePendingPickerAttachment={togglePendingPickerAttachment}
           />
-        ) : null}
-        <div className="grid content-end px-4 py-3">
-          <div className="flex items-end justify-between gap-2">
-            <div className="flex min-w-0 flex-1 items-end gap-2">
-              <div className="inline-flex h-6 shrink-0 items-center gap-1.5">
-                <button
-                  ref={pickerButtonRef}
-                  type="button"
-                  className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md"
-                  onClick={() => {
-                    if (slashCommands.open) {
-                      slashCommands.dismiss({ clearDraft: true });
-                    }
-                    void pickAttachments();
-                  }}
-                  aria-label={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
-                  data-tooltip={attachments.length > 0 ? "Manage attachments" : "Add attachment"}
-                >
-                  <span className={cn(compactIconButtonClass, "shrink-0")}>
-                    <Paperclip size={16} />
-                  </span>
-                  {attachments.length > 0 ? (
-                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-[color:var(--accent-bg-subtle)] px-1.5 py-0.5 text-[11px] text-[color:var(--text)]">
-                      {attachments.length}
-                    </span>
-                  ) : null}
-                </button>
-                {attachments.length > 0 ? (
-                  <button
-                    type="button"
-                    className={cn(compactIconButtonClass, "h-5 w-5 shrink-0")}
-                    onClick={clearAttachments}
-                    aria-label="Clear attachments"
-                    data-tooltip="Clear attachments"
-                  >
-                    <X size={12} />
-                  </button>
-                ) : null}
-              </div>
-              <div className="min-w-0 flex-1">
-                {slashCommands.open ? (
-                  <div
-                    ref={slashCommandPanelRef}
-                    id={slashCommands.listboxId}
-                    // biome-ignore lint/a11y/useSemanticElements: This is a textarea-owned combobox popup, not a native select.
-                    role="listbox"
-                    tabIndex={-1}
-                    aria-label="Composer slash commands"
-                    className="absolute right-0 bottom-full left-0 z-20 max-h-64 scroll-py-1.5 overflow-auto rounded-xl border border-[color:var(--border-strong)] bg-[color:var(--panel)] p-1.5 shadow-[var(--shadow)]"
-                  >
-                    {slashCommands.commands.length > 0 ? (
-                      slashCommands.commands.map((command, index) => {
-                        const selected = index === slashCommands.selectedIndex;
-                        const previous = slashCommands.commands[index - 1];
-                        const groupLabel = getComposerSlashCommandGroupLabel(command);
-                        const previousGroupLabel = previous
-                          ? getComposerSlashCommandGroupLabel(previous)
-                          : null;
-                        return (
-                          <div key={`${command.source}:${command.name}`}>
-                            {previousGroupLabel !== groupLabel ? (
-                              <div className="px-2 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--muted-2)]">
-                                {groupLabel}
-                              </div>
-                            ) : null}
-                            <button
-                              id={getComposerSlashCommandOptionId(index)}
-                              type="button"
-                              // biome-ignore lint/a11y/useSemanticElements: Command options remain clickable buttons inside the textarea-owned listbox.
-                              role="option"
-                              aria-selected={selected}
-                              className={cn(
-                                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left",
-                                selected
-                                  ? "bg-[color:var(--accent-bg)] text-[color:var(--text)]"
-                                  : "text-[color:var(--muted)] hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]",
-                              )}
-                              onPointerEnter={() => slashCommands.setSelectedIndex(index)}
-                              onMouseDown={(event) => event.preventDefault()}
-                              onClick={() => slashCommands.selectCommand(command)}
-                            >
-                              <span className="shrink-0 font-mono text-[12px] text-[color:var(--text)]">
-                                /{command.name}
-                              </span>
-                              {command.description ? (
-                                <span className="min-w-0 truncate text-[12px]">
-                                  {command.description}
-                                </span>
-                              ) : null}
-                            </button>
-                          </div>
-                        );
-                      })
-                    ) : (
-                      <div className="px-2 py-2 text-[12px] text-[color:var(--muted)]">
-                        {slashCommands.loading ? "Loading commands…" : "No matching commands"}
-                      </div>
-                    )}
-                  </div>
-                ) : null}
-                <ComposerTextField
-                  value={draft}
-                  onChange={setDraftValue}
-                  onInput={() => {
-                    if (errorMessage) {
-                      onChangeErrorMessage(null);
-                    }
-                  }}
-                  onKeyDown={(event) => {
-                    if (slashCommands.handleKeyDown(event)) {
-                      return;
-                    }
 
-                    if (event.key === "Escape" && (dictationActive || dictationInterimText)) {
-                      event.preventDefault();
-                      void cancelDictation();
-                      return;
-                    }
+          {errorMessage ? (
+            <output className="sr-only" aria-live="polite">
+              {errorMessage}
+            </output>
+          ) : null}
 
-                    if (event.key === "Enter" && !event.shiftKey) {
-                      event.preventDefault();
-                      slashCommands.submit();
-                    }
-                  }}
-                  ariaLabel="Inbox prompt composer"
-                  ariaActiveDescendant={slashCommands.activeDescendantId}
-                  ariaControls={slashCommands.open ? slashCommands.listboxId : undefined}
-                  ariaExpanded={slashCommands.open}
-                  placeholder={errorMessage ?? "Reply to this thread…"}
-                  placeholderTone={errorMessage ? "error" : "muted"}
-                  statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
-                  reservedLineCount={1}
-                  hoverToFocus={appSettings.hoverToFocus}
-                  hoverToBlur={appSettings.hoverToBlur}
-                  hoverBoundaryRef={composerPanelRef}
+          <div className="h-px bg-[color:var(--border)]" />
+
+          <div className={workspaceFooterRowClass}>
+            <div className="relative inline-flex h-7 items-center">
+              <ToolbarButton
+                ref={modelButtonRef}
+                label="Agent"
+                tooltip="Model settings"
+                icon={<Bot size={14} />}
+                className={cn(workspaceFooterTextClass, "pr-8")}
+                onClick={() => setOpenMenu((current) => (current === "model" ? null : "model"))}
+                aria-haspopup="menu"
+                aria-expanded={openMenu === "model"}
+                aria-controls="composer-model-menu"
+              />
+              <div className="absolute top-0 right-0">
+                <ComposerContextMeter
+                  contextUsage={contextUsage}
+                  compactDisabled={
+                    isStreaming || isCompacting || localActionPending || !thread.sessionPath
+                  }
+                  isCompacting={isCompacting}
+                  onCompact={() => void compact()}
                 />
               </div>
+              {openMenu === "model" ? (
+                <ComposerModelPopover
+                  anchorRef={modelButtonRef}
+                  availableModels={availableModels}
+                  availableThinkingLevels={availableThinkingLevels}
+                  currentModel={currentModel}
+                  currentThinkingLevel={currentThinkingLevel}
+                  panelRef={modelMenuRef}
+                  thinkingLevelLabels={thinkingLevelLabels}
+                  onSelectModel={(availableModel) => {
+                    void updateComposerOption("composer.model", {
+                      provider: availableModel.provider,
+                      modelId: availableModel.id,
+                      projectId: thread.projectId,
+                      sessionPath: thread.sessionPath,
+                    });
+                  }}
+                  onSelectThinkingLevel={(level) => {
+                    void updateComposerOption("composer.thinking", {
+                      level,
+                      projectId: thread.projectId,
+                      sessionPath: thread.sessionPath,
+                    });
+                  }}
+                />
+              ) : null}
             </div>
-
-            <div className="inline-flex h-8 items-center justify-end gap-2">
-              <ComposerDictationControls
-                dictationActive={dictationActive}
-                dictationMissingModel={dictationMissingModel}
-                dictationSupported={dictationSupported}
-                dictationTranscribing={dictationInterimText.length > 0 && !dictationActive}
-                onAction={onAction}
-                onOpenSettingsView={onOpenSettingsView}
-                showDictationButton={showDictationButton}
-                toggleDictation={toggleDictation}
-              />
-              <button
-                type="button"
-                className={cn(
-                  compactIconButtonClass,
-                  "h-6 w-6 shrink-0 rounded-full bg-[color:var(--danger-bg)] text-[color:var(--danger)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)] disabled:cursor-not-allowed disabled:opacity-45",
-                )}
-                onClick={onStop}
-                disabled={!isStreaming || isSending || localActionPending}
-                aria-label="Stop Pi"
-                data-tooltip="Stop Pi"
-              >
-                <Square size={11} fill="currentColor" />
-              </button>
-              <button
-                type="button"
-                className={cn(
-                  compactIconButtonClass,
-                  "h-6 w-6 shrink-0 rounded-full bg-[color:var(--accent)] text-[color:var(--accent-contrast)] hover:bg-[color:var(--accent)] hover:text-[color:var(--accent-contrast)] disabled:cursor-not-allowed disabled:opacity-45",
-                )}
-                onClick={() => slashCommands.submit()}
-                disabled={!canSend}
-                aria-label="Send"
-                data-tooltip="Send"
-              >
-                <Send size={14} />
-              </button>
+            <div className={workspaceFooterTrailingGroupClass}>
+              <Tooltip content="Dismiss">
+                <IconButton
+                  tooltip={null}
+                  label="Dismiss"
+                  icon={<X size={14} />}
+                  onClick={onDismiss}
+                />
+              </Tooltip>
+              <Tooltip content="Open thread">
+                <IconButton
+                  tooltip={null}
+                  label="Open thread"
+                  icon={<ArrowUpRight size={14} />}
+                  onClick={onOpenThread}
+                />
+              </Tooltip>
             </div>
           </div>
         </div>
       </div>
-
-      {errorMessage ? (
-        <output className="sr-only" aria-live="polite">
-          {errorMessage}
-        </output>
-      ) : null}
-
-      <div className="h-px bg-[color:var(--border)]" />
-
-      <div className="flex items-center justify-end gap-1.5 px-4 pt-2 pb-3 text-[color:var(--muted)] max-md:flex-wrap">
-        <div className="relative mr-auto inline-flex h-7 items-center">
-          <ToolbarButton
-            ref={modelButtonRef}
-            label="Agent"
-            tooltip="Model settings"
-            icon={<Bot size={14} />}
-            className="pr-8"
-            onClick={() => setOpenMenu((current) => (current === "model" ? null : "model"))}
-            aria-haspopup="menu"
-            aria-expanded={openMenu === "model"}
-            aria-controls="composer-model-menu"
-          />
-          <div className="absolute top-0 right-0">
-            <ComposerContextMeter
-              contextUsage={contextUsage}
-              compactDisabled={
-                isStreaming || isCompacting || localActionPending || !thread.sessionPath
-              }
-              isCompacting={isCompacting}
-              onCompact={() => void compact()}
-            />
-          </div>
-          {openMenu === "model" ? (
-            <ComposerModelPopover
-              anchorRef={modelButtonRef}
-              availableModels={availableModels}
-              availableThinkingLevels={availableThinkingLevels}
-              currentModel={currentModel}
-              currentThinkingLevel={currentThinkingLevel}
-              panelRef={modelMenuRef}
-              thinkingLevelLabels={thinkingLevelLabels}
-              onSelectModel={(availableModel) => {
-                void updateComposerOption("composer.model", {
-                  provider: availableModel.provider,
-                  modelId: availableModel.id,
-                  projectId: thread.projectId,
-                  sessionPath: thread.sessionPath,
-                });
-              }}
-              onSelectThinkingLevel={(level) => {
-                void updateComposerOption("composer.thinking", {
-                  level,
-                  projectId: thread.projectId,
-                  sessionPath: thread.sessionPath,
-                });
-              }}
-            />
-          ) : null}
+      <div className="relative h-full min-h-[7rem] w-8 shrink-0 self-stretch text-[color:var(--muted)]">
+        <div className="absolute right-0 bottom-[3.55rem] flex w-7 items-center justify-center">
+          <button
+            type="button"
+            className={cn(
+              compactIconButtonClass,
+              "h-7 w-7 shrink-0 rounded-full text-[color:var(--danger)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]",
+              isStreaming && !isSending && !localActionPending
+                ? "bg-[color:var(--danger-bg)] opacity-80"
+                : "bg-transparent opacity-25 hover:opacity-45",
+            )}
+            onClick={onStop}
+            disabled={!isStreaming || isSending || localActionPending}
+            aria-label="Stop Pi"
+            data-tooltip="Stop Pi"
+          >
+            <Square size={11} fill="currentColor" />
+          </button>
         </div>
-        <Tooltip content="Dismiss">
-          <IconButton tooltip={null} label="Dismiss" icon={<X size={14} />} onClick={onDismiss} />
-        </Tooltip>
-        <Tooltip content="Open thread">
-          <IconButton
-            tooltip={null}
-            label="Open thread"
-            icon={<ArrowUpRight size={14} />}
-            onClick={onOpenThread}
-          />
-        </Tooltip>
       </div>
     </div>
   );

--- a/src/app/features/code/CodeWorkspaceMainView.tsx
+++ b/src/app/features/code/CodeWorkspaceMainView.tsx
@@ -60,6 +60,9 @@ type CodeWorkspaceMainViewProps = {
   onCloseUtilityView: () => void;
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
   onOpenSettingsView: () => void;
+  sidebarCollapsed: boolean;
+  sidebarCompactMode: boolean;
+  onToggleSidebar: () => void;
   onLoadEarlierMessages: () => void;
   onSetExtensionsProjectScopeActive: (active: boolean) => void;
   onSetSkillsProjectScopeActive: (active: boolean) => void;
@@ -93,6 +96,9 @@ export function CodeWorkspaceMainView({
   onCloseUtilityView,
   onOpenThread,
   onOpenSettingsView,
+  sidebarCollapsed,
+  sidebarCompactMode,
+  onToggleSidebar,
   onLoadEarlierMessages,
   onSetExtensionsProjectScopeActive,
   onSetSkillsProjectScopeActive,
@@ -133,6 +139,9 @@ export function CodeWorkspaceMainView({
         onListAttachmentEntries={onListAttachmentEntries}
         onOpenThread={onOpenThread}
         onOpenSettingsView={onOpenSettingsView}
+        sidebarCollapsed={sidebarCollapsed}
+        sidebarCompactMode={sidebarCompactMode}
+        onToggleSidebar={onToggleSidebar}
       />
     );
   }

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -165,7 +165,10 @@ export function CodeWorkspaceView({
           <main
             ref={mainViewRef}
             className={
-              state.activeView === "thread" || state.activeView === "code" || showDiffInMainView
+              state.activeView === "thread" ||
+              state.activeView === "code" ||
+              state.activeView === "inbox" ||
+              showDiffInMainView
                 ? "min-h-0 overflow-hidden pt-1.5"
                 : mainPanelClass
             }
@@ -239,6 +242,9 @@ export function CodeWorkspaceView({
                 onListAttachmentEntries={listComposerAttachmentEntries}
                 onOpenThread={controller.handleThreadOpen}
                 onOpenSettingsView={() => controller.handleShowView("settings")}
+                sidebarCollapsed={sidebarCollapsed}
+                sidebarCompactMode={sidebarCompactMode}
+                onToggleSidebar={onToggleSidebar}
                 onCloseUtilityView={controller.handleCloseUtilityView}
                 onLoadEarlierMessages={handleLoadEarlierMessages}
                 onSetExtensionsProjectScopeActive={controller.handleSetExtensionsProjectScopeActive}

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -3,6 +3,7 @@ import { getDesktopActionErrorMessage } from "../desktop/action-results";
 import { getErrorMessage } from "../desktop/error-messages";
 import { EmptyStateCard } from "../components/common/EmptyStateCard";
 import { MarkdownContent } from "../components/common/MarkdownContent";
+import { WorkspaceComposerDock } from "../components/workspace/WorkspaceComposerDock";
 import { InboxComposer } from "../components/workspace/inbox/InboxComposer";
 import { isCompactSlashCommand } from "../../../shared/composer-slash-commands";
 import type {
@@ -160,8 +161,8 @@ export function InboxView({
   const messageMarkdown = thread.content.join("\n\n").trim();
 
   return (
-    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] px-6 pt-6 pb-4">
-      <div className="w-full pb-5">
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] px-4 pt-4 pb-4 min-[900px]:px-6 min-[900px]:pt-6">
+      <div className="mx-auto w-full max-w-[92ch] pb-4 min-[900px]:pb-5">
         <div className="grid w-full gap-2 rounded-[18px] border border-[color:var(--border)] bg-[color:var(--panel)] px-4 py-3 shadow-[var(--shadow)]">
           <div className="flex min-w-0 items-center gap-2 text-[11px] leading-4 text-[color:var(--muted-2)]">
             <span className="truncate">{thread.projectName}</span>
@@ -181,8 +182,8 @@ export function InboxView({
       </div>
 
       <div className="min-h-0 overflow-y-auto">
-        <div className="grid h-full w-full content-start pb-5">
-          <div className="min-h-0 max-w-[92ch] text-pretty">
+        <div className="grid h-full w-full content-start justify-items-center pb-4 min-[900px]:pb-5">
+          <div className="min-h-0 w-full max-w-[92ch] text-pretty">
             {messageMarkdown ? (
               <MarkdownContent
                 markdown={messageMarkdown}
@@ -198,35 +199,40 @@ export function InboxView({
       </div>
 
       <div className="pt-1">
-        <div className="w-full">
-          <InboxComposer
-            appSettings={appSettings}
-            attachments={attachments}
-            availableModels={availableModels}
-            availableThinkingLevels={availableThinkingLevels}
-            contextUsage={contextUsage}
-            currentModel={currentModel}
-            currentThinkingLevel={currentThinkingLevel}
-            draft={draft}
-            errorMessage={errorMessage}
-            favoriteFolders={favoriteFolders}
-            isCompacting={isCompacting}
-            isStreaming={thread.running}
-            isSending={isSending}
-            showDictationButton={showDictationButton}
-            thread={thread}
-            onChangeDraft={setDraft}
-            onChangeAttachments={setAttachments}
-            onChangeErrorMessage={setErrorMessage}
-            onAction={onAction}
-            onDismiss={() => onDismissThread(thread)}
-            onListAttachmentEntries={onListAttachmentEntries}
-            onOpenThread={() => onOpenThread(thread.projectId, thread.threadId, thread.sessionPath)}
-            onOpenSettingsView={onOpenSettingsView}
-            onSend={(sendInput) => handleSend(sendInput)}
-            onStop={handleStop}
-          />
-        </div>
+        <WorkspaceComposerDock
+          compactControls
+          center={
+            <InboxComposer
+              appSettings={appSettings}
+              attachments={attachments}
+              availableModels={availableModels}
+              availableThinkingLevels={availableThinkingLevels}
+              contextUsage={contextUsage}
+              currentModel={currentModel}
+              currentThinkingLevel={currentThinkingLevel}
+              draft={draft}
+              errorMessage={errorMessage}
+              favoriteFolders={favoriteFolders}
+              isCompacting={isCompacting}
+              isStreaming={thread.running}
+              isSending={isSending}
+              showDictationButton={showDictationButton}
+              thread={thread}
+              onChangeDraft={setDraft}
+              onChangeAttachments={setAttachments}
+              onChangeErrorMessage={setErrorMessage}
+              onAction={onAction}
+              onDismiss={() => onDismissThread(thread)}
+              onListAttachmentEntries={onListAttachmentEntries}
+              onOpenThread={() =>
+                onOpenThread(thread.projectId, thread.threadId, thread.sessionPath)
+              }
+              onOpenSettingsView={onOpenSettingsView}
+              onSend={(sendInput) => handleSend(sendInput)}
+              onStop={handleStop}
+            />
+          }
+        />
       </div>
     </div>
   );

--- a/src/app/views/InboxView.tsx
+++ b/src/app/views/InboxView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { getDesktopActionErrorMessage } from "../desktop/action-results";
 import { getErrorMessage } from "../desktop/error-messages";
 import { EmptyStateCard } from "../components/common/EmptyStateCard";
@@ -6,6 +7,7 @@ import { MarkdownContent } from "../components/common/MarkdownContent";
 import { WorkspaceComposerDock } from "../components/workspace/WorkspaceComposerDock";
 import { InboxComposer } from "../components/workspace/inbox/InboxComposer";
 import { isCompactSlashCommand } from "../../../shared/composer-slash-commands";
+import { WORKSPACE_CONTENT_MAX_WIDTH_CLASS } from "../ui/layout";
 import type {
   AppSettings,
   ComposerAttachment,
@@ -37,6 +39,9 @@ type InboxViewProps = {
   }) => Promise<ComposerFilePickerState | null>;
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void;
   onOpenSettingsView: () => void;
+  sidebarCollapsed: boolean;
+  sidebarCompactMode: boolean;
+  onToggleSidebar: () => void;
 };
 
 export function InboxView({
@@ -55,6 +60,9 @@ export function InboxView({
   onListAttachmentEntries,
   onOpenThread,
   onOpenSettingsView,
+  sidebarCollapsed,
+  sidebarCompactMode,
+  onToggleSidebar,
 }: InboxViewProps) {
   const [draft, setDraft] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
@@ -161,8 +169,8 @@ export function InboxView({
   const messageMarkdown = thread.content.join("\n\n").trim();
 
   return (
-    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] px-4 pt-4 pb-4 min-[900px]:px-6 min-[900px]:pt-6">
-      <div className="mx-auto w-full max-w-[92ch] pb-4 min-[900px]:pb-5">
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] pt-6 pb-4">
+      <div className={`mx-auto w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} pb-5`}>
         <div className="grid w-full gap-2 rounded-[18px] border border-[color:var(--border)] bg-[color:var(--panel)] px-4 py-3 shadow-[var(--shadow)]">
           <div className="flex min-w-0 items-center gap-2 text-[11px] leading-4 text-[color:var(--muted-2)]">
             <span className="truncate">{thread.projectName}</span>
@@ -182,8 +190,8 @@ export function InboxView({
       </div>
 
       <div className="min-h-0 overflow-y-auto">
-        <div className="grid h-full w-full content-start justify-items-center pb-4 min-[900px]:pb-5">
-          <div className="min-h-0 w-full max-w-[92ch] text-pretty">
+        <div className="grid h-full w-full content-start justify-items-center pb-5">
+          <div className={`min-h-0 w-full ${WORKSPACE_CONTENT_MAX_WIDTH_CLASS} text-pretty`}>
             {messageMarkdown ? (
               <MarkdownContent
                 markdown={messageMarkdown}
@@ -200,7 +208,21 @@ export function InboxView({
 
       <div className="pt-1">
         <WorkspaceComposerDock
-          compactControls
+          compactControls={sidebarCompactMode}
+          left={
+            !sidebarCompactMode ? (
+              <button
+                type="button"
+                className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] opacity-70 transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
+                onClick={onToggleSidebar}
+                aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                data-tooltip={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                data-tooltip-placement="right"
+              >
+                {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
+              </button>
+            ) : null
+          }
           center={
             <InboxComposer
               appSettings={appSettings}


### PR DESCRIPTION
## Summary
- Modernizes the inbox composer to use the current composer prompt surface instead of the legacy inline composer layout.
- Aligns inbox composer placement with the shared workspace composer dock and sidebar fold-button behavior.
- Updates inbox content sizing so prompt/message/composer geometry shares the same workspace lane.

## Details
- Reuses `ComposerPromptInputPanel` for the inbox prompt body, slash commands, dictation placement, file picker, and paste/attachment behavior.
- Keeps inbox-specific behavior: send follow-up/dismiss, dismiss inbox item, open thread, and inbox model/context controls.
- Renders inbox through the same non-guttered workspace main path as thread/code so dock positioning matches other views.
- Intentionally does not add a visible send button; inbox now follows the current composer contract where Enter submits and side rails are reserved for attachment/stop controls.

## Validation
- Biome passed on touched files.
- Typecheck passed.
- Pre-commit hooks passed.
- Pre-push hooks passed.
- Vitest passed: 13 files, 50 tests.

## Review notes
- Dismissed the review suggestion to restore a visible send button as intentional: the current composer design does not expose a send button, and inbox should stay aligned with that interaction model rather than reintroduce the legacy affordance.
