### PR TITLE
Fix utility sidebar controls

### DIFF
--- a/src/app/app-shell/AppShellLayout.tsx
+++ b/src/app/app-shell/AppShellLayout.tsx
@@ -149,6 +149,11 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
       : null;
   const takeoverVisible = state.takeoverVisible;
   const terminalDrawerVisible = state.activeView === "thread" && state.terminalVisible;
+  const utilityViewActive =
+    state.activeView === "settings" ||
+    state.activeView === "extensions" ||
+    state.activeView === "skills" ||
+    state.activeView === "archived";
   const compactSidebarButtonEdgeMode = terminalDrawerVisible || artifactDrawerOverlayVisible;
   const terminalDrawerPresent = useAnimatedPresence(terminalDrawerVisible);
   const diffBaseline =
@@ -515,7 +520,22 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
           />
         ) : null}
 
-        {sidebarCompactMode && !sidebarOverlayOpen ? (
+        {sidebarCompactMode && !sidebarOverlayOpen && utilityViewActive ? (
+          <div className="pointer-events-none absolute bottom-5 left-5 z-[45]">
+            <button
+              type="button"
+              className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--panel)] text-[color:var(--muted)] opacity-70 shadow-[0_10px_28px_rgba(0,0,0,0.22)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
+              onClick={handleToggleSidebar}
+              aria-label="Show sidebar"
+              data-tooltip="Show sidebar"
+              data-tooltip-placement="right"
+            >
+              <PanelLeftOpen size={15} />
+            </button>
+          </div>
+        ) : null}
+
+        {sidebarCompactMode && !sidebarOverlayOpen && !utilityViewActive ? (
           <div
             className={cn(
               "pointer-events-none absolute inset-x-0 bottom-0 z-[45] pb-4",
@@ -532,7 +552,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
                 <button
                   type="button"
                   className={cn(
-                    "inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]",
+                    "inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--panel)] text-[color:var(--muted)] shadow-[0_10px_28px_rgba(0,0,0,0.22)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]",
                     !artifactDrawerOverlayVisible && "opacity-70 hover:opacity-100",
                   )}
                   onClick={handleToggleSidebar}

--- a/src/app/components/workspace/composer/ComposerFilePicker.tsx
+++ b/src/app/components/workspace/composer/ComposerFilePicker.tsx
@@ -202,7 +202,7 @@ export function ComposerFilePicker({
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, true);
     };
-  }, [anchorRef, panelRef, picker, searchExpanded, sidePlacementEnabled]);
+  }, [anchorRef, panelRef, sidePlacementEnabled]);
 
   const panelContents = (
     <>

--- a/src/app/components/workspace/inbox/InboxComposer.tsx
+++ b/src/app/components/workspace/inbox/InboxComposer.tsx
@@ -458,6 +458,7 @@ export function InboxComposer({
             favoriteFolders={favoriteFolders}
             pickerLoading={pickerLoading}
             pickerOpen={openMenu === "picker"}
+            pickerButtonRef={pickerButtonRef}
             pickerPanelRef={pickerPanelRef}
             pickerState={pickerState}
             placeholderText={errorMessage ?? "Reply to this thread…"}

--- a/src/app/features/code/CodeWorkspaceView.tsx
+++ b/src/app/features/code/CodeWorkspaceView.tsx
@@ -89,6 +89,12 @@ export function CodeWorkspaceView({
   } = controller;
   const showWorkspaceFooter = state.activeView === "thread" || state.activeView === "gitops";
   const showThreadFooter = state.activeView === "thread";
+  const showCodeSidebarFooter = state.activeView === "code";
+  const showUtilitySidebarButton =
+    state.activeView === "settings" ||
+    state.activeView === "extensions" ||
+    state.activeView === "skills" ||
+    state.activeView === "archived";
   const showDiffInMainView = state.activeView === "gitops";
   const showDesktopTerminalDrawer =
     state.activeView === "thread" && terminalDrawerVisible && !terminalDrawerOverlay;
@@ -454,7 +460,7 @@ export function CodeWorkspaceView({
             />
           </div>
         </footer>
-      ) : state.activeView === "code" ? (
+      ) : showCodeSidebarFooter ? (
         <footer className="pointer-events-none absolute inset-x-0 bottom-0 z-10 px-5 pb-4">
           <div className="pointer-events-auto grid gap-2.5">
             <WorkspaceComposerDock
@@ -464,7 +470,7 @@ export function CodeWorkspaceView({
                 !sidebarCompactMode ? (
                   <button
                     type="button"
-                    className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full text-[color:var(--muted)] opacity-70 transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
+                    className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--panel)] text-[color:var(--muted)] opacity-70 shadow-[0_10px_28px_rgba(0,0,0,0.22)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
                     onClick={onToggleSidebar}
                     aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
                     data-tooltip={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
@@ -477,6 +483,19 @@ export function CodeWorkspaceView({
             />
           </div>
         </footer>
+      ) : showUtilitySidebarButton && !sidebarCompactMode ? (
+        <div className="pointer-events-none absolute bottom-5 left-5 z-10">
+          <button
+            type="button"
+            className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--panel)] text-[color:var(--muted)] opacity-70 shadow-[0_10px_28px_rgba(0,0,0,0.22)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
+            onClick={onToggleSidebar}
+            aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+            data-tooltip={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+            data-tooltip-placement="right"
+          >
+            {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
+          </button>
+        </div>
       ) : null}
     </div>
   );

--- a/src/app/views/SettingsView.tsx
+++ b/src/app/views/SettingsView.tsx
@@ -272,7 +272,7 @@ export function SettingsView({
 
   return (
     <ViewShell
-      className="h-full grid-rows-[auto_minmax(0,1fr)] overflow-hidden pb-0"
+      className="h-full content-stretch grid-rows-[auto_minmax(0,1fr)] overflow-hidden !pb-0"
       maxWidthClassName={showHelp ? "max-w-[1360px]" : "max-w-[1120px]"}
     >
       <div className="grid min-w-0 items-center gap-4 lg:grid-cols-[220px_minmax(0,1fr)_auto]">
@@ -333,7 +333,7 @@ export function SettingsView({
 
       <div
         className={cn(
-          "grid min-h-0 min-w-0 items-start gap-4 overflow-hidden lg:grid-cols-[220px_minmax(0,1fr)]",
+          "grid h-full min-h-0 min-w-0 items-start gap-4 overflow-hidden lg:grid-cols-[220px_minmax(0,1fr)]",
           showHelp && "lg:grid-cols-[220px_minmax(0,1fr)_minmax(18rem,24rem)]",
         )}
       >


### PR DESCRIPTION
## Summary
- Add utility-view sidebar fold controls for Settings, Extensions, Skills, and Archived threads without using composer dock geometry.
- Keep the utility fold button as a small left/bottom anchored control instead of a full-width footer layer.
- Fix Settings layout clipping by forcing the Settings `ViewShell` content to stretch and removing the inherited bottom padding.

## Details
- Code view keeps the existing `WorkspaceComposerDock` footer path because it has composer geometry.
- Utility views use a simple absolute button aligned to the workspace edge.
- Settings now overrides `ViewShell` with `content-stretch` and `!pb-0`, and its inner grid fills the available height.
- Includes two small compiler/lint fixes encountered while running hooks: passing `pickerButtonRef` in the inbox composer and removing stale hook deps in the file picker.

## Validation
- Commit hook passed: Biome staged check, web/desktop/electron/scripts typechecks, and Vitest.
- Push hook passed: full Biome check and typechecks.
