### PR TITLE
Switch terminal drawer to xterm

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,10 +20,9 @@
         "@tanstack/react-pacer": "^0.21.1",
         "@tanstack/react-query": "^5.96.1",
         "@tanstack/react-virtual": "^3.13.23",
-        "@wterm/core": "0.3.0",
-        "@wterm/dom": "0.3.0",
-        "@wterm/ghostty": "0.3.0",
-        "@wterm/react": "0.3.0",
+        "@xterm/addon-fit": "0.10.0",
+        "@xterm/addon-web-links": "0.11.0",
+        "@xterm/xterm": "5.5.0",
         "better-sqlite3": "^12.2.0",
         "bindings": "^1.5.0",
         "clip-filepaths": "^0.3.0",
@@ -65,8 +64,6 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1036.0",
     "@aws-sdk/core": "^3.974.5",
     "@aws-sdk/xml-builder": "^3.972.19",
-    "@wterm/core": "0.3.0",
-    "@wterm/dom": "0.3.0",
     "uuid": "^14.0.0",
   },
   "packages": {
@@ -886,15 +883,13 @@
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
-    "@wterm/core": ["@wterm/core@0.3.0", "", {}, "sha512-aQ73QBP+eyA3kcn31mA7DmAi7qmEsQijZdmvgwxtSjCi2248EAOZgtkGDpjlspfrxyVxQbUl/IF+gCVcXt4nZQ=="],
-
-    "@wterm/dom": ["@wterm/dom@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ=="],
-
-    "@wterm/ghostty": ["@wterm/ghostty@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-TDjEmUSRD7IaFxq31P7+I3Inkp5mHCfBfO6LYj3/vbLbWOkOZOKPhjAcZ36AYFHe9Q0HLCFvLWmrxIO3aGCjDA=="],
-
-    "@wterm/react": ["@wterm/react@0.3.0", "", { "peerDependencies": { "@wterm/dom": "0.3.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-1rua/roQGCIGkNxjs9TVq+EkXJ0n2IK6aCoaGIQJpvzuHv7iU9/lngG3i1SCpX6deOOO/wpfhtjDTI+z9XF0aA=="],
-
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
+
+    "@xterm/addon-web-links": ["@xterm/addon-web-links@0.11.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q=="],
+
+    "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 

--- a/package.json
+++ b/package.json
@@ -67,10 +67,9 @@
     "@tanstack/react-pacer": "^0.21.1",
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-virtual": "^3.13.23",
-    "@wterm/core": "0.3.0",
-    "@wterm/dom": "0.3.0",
-    "@wterm/ghostty": "0.3.0",
-    "@wterm/react": "0.3.0",
+    "@xterm/addon-fit": "0.10.0",
+    "@xterm/addon-web-links": "0.11.0",
+    "@xterm/xterm": "5.5.0",
     "better-sqlite3": "^12.2.0",
     "bindings": "^1.5.0",
     "clip-filepaths": "^0.3.0",
@@ -110,8 +109,6 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1036.0",
     "@aws-sdk/core": "^3.974.5",
     "@aws-sdk/xml-builder": "^3.972.19",
-    "@wterm/core": "0.3.0",
-    "@wterm/dom": "0.3.0",
     "uuid": "^14.0.0"
   }
 }

--- a/src/app/app-shell/usePiGuiTheme.ts
+++ b/src/app/app-shell/usePiGuiTheme.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import type { PiThemeState } from '../desktop/types'
 
 const storageKey = 'howcode:pi-gui-theme:v1'
+export const piGuiThemeUpdatedEvent = 'howcode:pi-gui-theme-updated'
 
 const managedVars = [
   '--bg',
@@ -180,6 +181,7 @@ function applyValues(values: GuiThemeValues) {
   for (const property of managedVars) {
     root.style.setProperty(property, values[property])
   }
+  window.dispatchEvent(new CustomEvent(piGuiThemeUpdatedEvent))
 }
 
 export function applyStoredPiGuiTheme() {

--- a/src/app/components/workspace/terminal-panel.tsx
+++ b/src/app/components/workspace/terminal-panel.tsx
@@ -124,10 +124,10 @@ function TerminalPanelComponent({
   return (
     <section
       aria-label="Terminal drawer"
-      className="absolute inset-0 grid min-h-0 grid-rows-[minmax(0,1fr)_auto] overflow-hidden border-l border-[color:var(--border)] bg-[color:var(--workspace)]"
+      className="absolute inset-0 flex min-h-0 flex-col overflow-hidden border-l border-[color:var(--border)] bg-[color:var(--workspace)]"
       {...getFeatureStatusDataAttributes(statusId)}
     >
-      <div className="relative min-h-0 min-w-0 overflow-hidden bg-[color:var(--sidebar)]">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden bg-[color:var(--sidebar)]">
         <TerminalViewport
           projectId={projectId}
           sessionPath={sessionPath}
@@ -136,10 +136,11 @@ function TerminalPanelComponent({
           backgroundCssVar="--sidebar"
           hoverToFocus={hoverToFocus}
           hoverToBlur={hoverToBlur}
-          className="terminal-viewport--flush terminal-viewport--bottom-reserve absolute inset-0 h-auto min-h-0 rounded-none bg-[color:var(--sidebar)]"
+          bottomAlignInitialContent
+          className="terminal-viewport--flush !min-h-0 rounded-none bg-[color:var(--sidebar)]"
         />
       </div>
-      <div className="flex h-[3.75rem] items-start justify-end gap-3 border-t border-[color:var(--border)] px-3 pt-1.5">
+      <div className="flex h-[3.75rem] shrink-0 items-start justify-end gap-3 border-t border-[color:var(--border)] bg-[color:var(--workspace)] px-3 pt-1.5">
         <button
           type="button"
           className="box-border inline-flex h-8 min-h-8 w-8 min-w-8 shrink-0 items-center justify-center rounded-full text-[color:var(--muted)] text-[15px] leading-none transition-colors duration-150 ease-out hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] [&>svg]:h-[15px] [&>svg]:w-[15px]"

--- a/src/app/components/workspace/terminal/terminal-viewport.tsx
+++ b/src/app/components/workspace/terminal/terminal-viewport.tsx
@@ -71,6 +71,14 @@ const XTERM_THEME_COLOR_KEYS = [
   'brightCyan',
   'brightWhite',
 ] as const
+const XTERM_STICKY_BOTTOM_THRESHOLD_ROWS = 2
+
+function isXtermNearBottom(terminal: XTerm) {
+  return (
+    terminal.buffer.active.baseY - terminal.buffer.active.viewportY <=
+    XTERM_STICKY_BOTTOM_THRESHOLD_ROWS
+  )
+}
 
 function resolveCssColor(element: HTMLElement, value: string, fallback: string) {
   const trimmedValue = value.trim()
@@ -170,6 +178,7 @@ export function TerminalViewport({
   const terminalResizeTimerRefs = useRef<number[]>([])
   const pendingScrollFrameRef = useRef<number | null>(null)
   const pendingBottomAlignFrameRef = useRef<number | null>(null)
+  const terminalInitialFitTimerRef = useRef<number | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const attachFailedRef = useRef(false)
   const pendingEventsRef = useRef<TerminalEvent[]>([])
@@ -273,8 +282,7 @@ export function TerminalViewport({
     (data: string | Uint8Array) => {
       const terminal = terminalInstanceRef.current
       const shouldStickToBottom =
-        stickToBottomOnOutput &&
-        (!terminal || terminal.buffer.active.viewportY >= terminal.buffer.active.baseY)
+        stickToBottomOnOutput && (!terminal || isXtermNearBottom(terminal))
 
       terminal?.write(data, () => {
         scheduleXtermBottomAlign()
@@ -304,6 +312,9 @@ export function TerminalViewport({
       }
       if (pendingBottomAlignFrameRef.current !== null) {
         window.cancelAnimationFrame(pendingBottomAlignFrameRef.current)
+      }
+      if (terminalInitialFitTimerRef.current !== null) {
+        window.clearTimeout(terminalInitialFitTimerRef.current)
       }
     },
     [],
@@ -440,7 +451,8 @@ export function TerminalViewport({
       }
       setTerminalInitError(null)
       setTerminalReadyRevision((current) => current + 1)
-      window.setTimeout(() => {
+      terminalInitialFitTimerRef.current = window.setTimeout(() => {
+        terminalInitialFitTimerRef.current = null
         fitAddon.fit()
         scheduleXtermBottomAlign()
         terminal.scrollToBottom()
@@ -450,6 +462,10 @@ export function TerminalViewport({
     }
 
     return () => {
+      if (terminalInitialFitTimerRef.current !== null) {
+        window.clearTimeout(terminalInitialFitTimerRef.current)
+        terminalInitialFitTimerRef.current = null
+      }
       fitAddonRef.current = null
       terminalInstanceRef.current?.dispose()
       terminalInstanceRef.current = null
@@ -463,6 +479,7 @@ export function TerminalViewport({
   ])
 
   useEffect(() => {
+    void terminalStyle
     const terminal = terminalInstanceRef.current
     const mount = terminalMountRef.current
     if (!(terminal && mount)) {
@@ -470,7 +487,7 @@ export function TerminalViewport({
     }
 
     terminal.options.theme = buildXtermTheme(mount)
-  })
+  }, [terminalStyle])
 
   const resizeTerminalToContainer = useCallback(() => {
     const terminal = terminalInstanceRef.current
@@ -479,8 +496,7 @@ export function TerminalViewport({
       return
     }
 
-    const shouldStickToBottom =
-      stickToBottomOnOutput && terminal.buffer.active.viewportY >= terminal.buffer.active.baseY
+    const shouldStickToBottom = stickToBottomOnOutput && isXtermNearBottom(terminal)
     fitAddonRef.current?.fit()
     const cols = normalizeTerminalDimension(terminal.cols, lastKnownSizeRef.current.cols)
     const rows = normalizeTerminalDimension(terminal.rows, lastKnownSizeRef.current.rows)

--- a/src/app/components/workspace/terminal/terminal-viewport.tsx
+++ b/src/app/components/workspace/terminal/terminal-viewport.tsx
@@ -1,4 +1,6 @@
-import { Terminal, type TerminalHandle, type WTerm } from '@wterm/react'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { type ITheme, Terminal as XTerm } from '@xterm/xterm'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getPersistedSessionPath } from '../../../../../shared/session-paths'
 import type { TerminalEvent } from '../../../desktop/types'
@@ -22,15 +24,11 @@ import {
   DEFAULT_MAX_KEEP_ALIVE_MS_ON_UNMOUNT,
   DEFAULT_TERMINAL_COLS,
   DEFAULT_TERMINAL_ROWS,
-  findTerminalLinkAtPoint,
-  hasSelectionInside,
   hasVisibleTerminalHistory,
-  isTerminalElementNearBottom,
   isUsableTerminalSize,
   MAX_PENDING_TERMINAL_EVENTS,
   MIN_INITIAL_TERMINAL_COLS,
   MIN_INITIAL_TERMINAL_ROWS,
-  measureTerminalSize,
   normalizeTerminalDimension,
   type TerminalBackgroundCssVar,
   terminalStyleVars,
@@ -51,7 +49,62 @@ type TerminalViewportProps = {
   hoverToFocus?: boolean | undefined
   hoverToBlur?: boolean | undefined
   stickToBottomOnOutput?: boolean | undefined
+  bottomAlignInitialContent?: boolean | undefined
   className?: string | undefined
+}
+
+const XTERM_THEME_COLOR_KEYS = [
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite',
+] as const
+
+function resolveCssColor(element: HTMLElement, value: string, fallback: string) {
+  const trimmedValue = value.trim()
+  if (!trimmedValue) return fallback
+
+  const probe = element.ownerDocument.createElement('span')
+  probe.style.color = trimmedValue
+  probe.style.display = 'none'
+  element.appendChild(probe)
+  const resolvedColor = getComputedStyle(probe).color
+  probe.remove()
+
+  return resolvedColor || trimmedValue || fallback
+}
+
+function buildXtermTheme(element: HTMLElement): ITheme {
+  const styles = getComputedStyle(element)
+  const resolve = (value: string, fallback: string) => resolveCssColor(element, value, fallback)
+  const color = (cssVar: string, fallback: string) =>
+    resolve(styles.getPropertyValue(cssVar), fallback)
+  const theme: ITheme = {
+    background: color('--term-bg', '#171923'),
+    foreground: color('--term-fg', '#d5daed'),
+    cursor: color('--term-cursor', '#b9bff3'),
+    cursorAccent: color('--term-bg', '#171923'),
+    selectionBackground: color('--terminal-selection', 'rgba(185, 191, 243, 0.18)'),
+    selectionInactiveBackground: color('--terminal-selection', 'rgba(185, 191, 243, 0.18)'),
+  }
+
+  for (const [index, key] of XTERM_THEME_COLOR_KEYS.entries()) {
+    theme[key] = color(`--term-color-${index}`, theme.foreground ?? '#d5daed')
+  }
+
+  return theme
 }
 
 function cleanupTerminalSessionOnUnmount(input: {
@@ -106,14 +159,17 @@ export function TerminalViewport({
   hoverToFocus = true,
   hoverToBlur = false,
   stickToBottomOnOutput = true,
+  bottomAlignInitialContent = false,
   className,
 }: TerminalViewportProps) {
   const viewportRef = useRef<HTMLDivElement | null>(null)
-  const terminalHandleRef = useRef<TerminalHandle | null>(null)
-  const terminalInstanceRef = useRef<WTerm | null>(null)
+  const terminalMountRef = useRef<HTMLDivElement | null>(null)
+  const terminalInstanceRef = useRef<XTerm | null>(null)
+  const fitAddonRef = useRef<FitAddon | null>(null)
   const terminalResizeFrameRef = useRef<number | null>(null)
   const terminalResizeTimerRefs = useRef<number[]>([])
   const pendingScrollFrameRef = useRef<number | null>(null)
+  const pendingBottomAlignFrameRef = useRef<number | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const attachFailedRef = useRef(false)
   const pendingEventsRef = useRef<TerminalEvent[]>([])
@@ -136,7 +192,7 @@ export function TerminalViewport({
   const viewportStyle = useMemo(() => terminalWrapperStyle(backgroundCssVar), [backgroundCssVar])
   const terminalStyle = useMemo(() => terminalStyleVars(backgroundCssVar), [backgroundCssVar])
   const focusTerminal = useCallback(() => {
-    terminalHandleRef.current?.focus()
+    terminalInstanceRef.current?.focus()
   }, [])
   const blurTerminal = useCallback(() => {
     const activeElement = document.activeElement
@@ -159,12 +215,7 @@ export function TerminalViewport({
   })
 
   const scrollTerminalToBottom = useCallback(() => {
-    const terminalElement = terminalInstanceRef.current?.element
-    if (!terminalElement) {
-      return
-    }
-
-    terminalElement.scrollTop = terminalElement.scrollHeight
+    terminalInstanceRef.current?.scrollToBottom()
   }, [])
 
   const scheduleTerminalScrollToBottom = useCallback(() => {
@@ -181,19 +232,62 @@ export function TerminalViewport({
     })
   }, [scrollTerminalToBottom])
 
+  const applyXtermBottomAlign = useCallback(() => {
+    const terminal = terminalInstanceRef.current
+    const screen = terminal?.element?.querySelector<HTMLElement>('.xterm-screen')
+    if (!(terminal && screen)) {
+      return
+    }
+
+    if (!bottomAlignInitialContent || terminal.buffer.active.baseY > 0) {
+      screen.style.transform = ''
+      return
+    }
+
+    const screenHeight = screen.getBoundingClientRect().height
+    const rowHeight = terminal.rows > 0 ? screenHeight / terminal.rows : 0
+    if (!(Number.isFinite(rowHeight) && rowHeight > 0)) {
+      screen.style.transform = ''
+      return
+    }
+
+    const cursorY = terminal.buffer.active.cursorY
+    const offsetRows = Math.max(0, terminal.rows - cursorY - 1)
+    screen.style.transform = offsetRows > 0 ? `translateY(${offsetRows * rowHeight}px)` : ''
+  }, [bottomAlignInitialContent])
+
+  const scheduleXtermBottomAlign = useCallback(() => {
+    if (pendingBottomAlignFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingBottomAlignFrameRef.current)
+    }
+
+    pendingBottomAlignFrameRef.current = window.requestAnimationFrame(() => {
+      pendingBottomAlignFrameRef.current = window.requestAnimationFrame(() => {
+        pendingBottomAlignFrameRef.current = null
+        applyXtermBottomAlign()
+      })
+    })
+  }, [applyXtermBottomAlign])
+
   const writeToTerminal = useCallback(
     (data: string | Uint8Array) => {
-      const terminalElement = terminalInstanceRef.current?.element
+      const terminal = terminalInstanceRef.current
       const shouldStickToBottom =
-        stickToBottomOnOutput && (!terminalElement || isTerminalElementNearBottom(terminalElement))
+        stickToBottomOnOutput &&
+        (!terminal || terminal.buffer.active.viewportY >= terminal.buffer.active.baseY)
 
-      terminalHandleRef.current?.write(data)
+      terminal?.write(data, () => {
+        scheduleXtermBottomAlign()
+        if (shouldStickToBottom) {
+          terminal.scrollToBottom()
+        }
+      })
 
       if (shouldStickToBottom) {
         scheduleTerminalScrollToBottom()
       }
     },
-    [scheduleTerminalScrollToBottom, stickToBottomOnOutput],
+    [scheduleTerminalScrollToBottom, scheduleXtermBottomAlign, stickToBottomOnOutput],
   )
 
   useEffect(
@@ -208,6 +302,9 @@ export function TerminalViewport({
       if (pendingScrollFrameRef.current !== null) {
         window.cancelAnimationFrame(pendingScrollFrameRef.current)
       }
+      if (pendingBottomAlignFrameRef.current !== null) {
+        window.cancelAnimationFrame(pendingBottomAlignFrameRef.current)
+      }
     },
     [],
   )
@@ -220,8 +317,9 @@ export function TerminalViewport({
       if (nextHistory) {
         writeToTerminal(nextHistory)
       }
+      scheduleXtermBottomAlign()
     },
-    [writeToTerminal],
+    [scheduleXtermBottomAlign, writeToTerminal],
   )
 
   const appendTerminalHistory = useCallback(
@@ -242,17 +340,6 @@ export function TerminalViewport({
     },
     [writeToTerminal],
   )
-
-  const handleTerminalReady = useCallback((terminal: WTerm) => {
-    terminalInstanceRef.current = terminal
-    setTerminalInitError(null)
-    const measuredSize = measureTerminalSize(terminal)
-    lastKnownSizeRef.current = {
-      cols: normalizeTerminalDimension(measuredSize?.cols ?? terminal.cols, DEFAULT_TERMINAL_COLS),
-      rows: normalizeTerminalDimension(measuredSize?.rows ?? terminal.rows, DEFAULT_TERMINAL_ROWS),
-    }
-    setTerminalReadyRevision((current) => current + 1)
-  }, [])
 
   const handleTerminalError = useCallback((error: unknown) => {
     const message = error instanceof Error ? error.message : 'Unable to initialize terminal.'
@@ -310,6 +397,81 @@ export function TerminalViewport({
     [writeToTerminal],
   )
 
+  useEffect(() => {
+    const mount = terminalMountRef.current
+    if (!mount || terminalInstanceRef.current) {
+      return
+    }
+
+    try {
+      const terminal = new XTerm({
+        cols: DEFAULT_TERMINAL_COLS,
+        rows: DEFAULT_TERMINAL_ROWS,
+        cursorBlink: true,
+        scrollback: 5_000,
+        convertEol: false,
+        fontFamily: '"Liberation Mono", Consolas, Menlo, monospace',
+        fontSize: 12,
+        lineHeight: 1.2,
+        theme: buildXtermTheme(mount),
+      })
+      const fitAddon = new FitAddon()
+      terminal.loadAddon(fitAddon)
+      terminal.loadAddon(
+        new WebLinksAddon((event, uri) => {
+          terminal.focus()
+          event.preventDefault()
+          void window.piDesktop?.openExternal?.(uri).then((opened) => {
+            if (!opened) {
+              writeSystemMessage((message) => writeToTerminal(message), `Unable to open ${uri}`)
+            }
+          })
+        }),
+      )
+      terminal.open(mount)
+      terminal.onData((data) => handleTerminalData(data))
+      terminal.onResize(({ cols, rows }) => handleTerminalResize(cols, rows))
+      terminalInstanceRef.current = terminal
+      fitAddonRef.current = fitAddon
+      fitAddon.fit()
+      lastKnownSizeRef.current = {
+        cols: normalizeTerminalDimension(terminal.cols, DEFAULT_TERMINAL_COLS),
+        rows: normalizeTerminalDimension(terminal.rows, DEFAULT_TERMINAL_ROWS),
+      }
+      setTerminalInitError(null)
+      setTerminalReadyRevision((current) => current + 1)
+      window.setTimeout(() => {
+        fitAddon.fit()
+        scheduleXtermBottomAlign()
+        terminal.scrollToBottom()
+      }, 30)
+    } catch (error) {
+      handleTerminalError(error)
+    }
+
+    return () => {
+      fitAddonRef.current = null
+      terminalInstanceRef.current?.dispose()
+      terminalInstanceRef.current = null
+    }
+  }, [
+    handleTerminalData,
+    handleTerminalError,
+    handleTerminalResize,
+    scheduleXtermBottomAlign,
+    writeToTerminal,
+  ])
+
+  useEffect(() => {
+    const terminal = terminalInstanceRef.current
+    const mount = terminalMountRef.current
+    if (!(terminal && mount)) {
+      return
+    }
+
+    terminal.options.theme = buildXtermTheme(mount)
+  })
+
   const resizeTerminalToContainer = useCallback(() => {
     const terminal = terminalInstanceRef.current
     const terminalElement = terminal?.element
@@ -318,27 +480,20 @@ export function TerminalViewport({
     }
 
     const shouldStickToBottom =
-      stickToBottomOnOutput && isTerminalElementNearBottom(terminalElement)
-    const measuredSize = measureTerminalSize(terminal)
-    if (!measuredSize) {
-      return
-    }
-
-    const cols = normalizeTerminalDimension(measuredSize.cols, lastKnownSizeRef.current.cols)
-    const rows = normalizeTerminalDimension(measuredSize.rows, lastKnownSizeRef.current.rows)
+      stickToBottomOnOutput && terminal.buffer.active.viewportY >= terminal.buffer.active.baseY
+    fitAddonRef.current?.fit()
+    const cols = normalizeTerminalDimension(terminal.cols, lastKnownSizeRef.current.cols)
+    const rows = normalizeTerminalDimension(terminal.rows, lastKnownSizeRef.current.rows)
     if (!isUsableTerminalSize(cols, rows)) {
       return
-    }
-
-    if (terminal.cols !== cols || terminal.rows !== rows) {
-      terminal.resize(cols, rows)
     }
     handleTerminalResize(cols, rows)
 
     if (shouldStickToBottom) {
-      scheduleTerminalScrollToBottom()
+      terminal.scrollToBottom()
     }
-  }, [handleTerminalResize, scheduleTerminalScrollToBottom, stickToBottomOnOutput])
+    scheduleXtermBottomAlign()
+  }, [handleTerminalResize, scheduleXtermBottomAlign, stickToBottomOnOutput])
 
   const scheduleTerminalResizeToContainer = useCallback(() => {
     if (terminalResizeFrameRef.current !== null) {
@@ -404,43 +559,6 @@ export function TerminalViewport({
       return
     }
 
-    const terminalElement = terminalInstanceRef.current?.element
-    if (!terminalElement) {
-      return
-    }
-
-    const handleClick = (event: MouseEvent) => {
-      if (hasSelectionInside(terminalElement)) {
-        return
-      }
-
-      const match = findTerminalLinkAtPoint(terminalElement, event.clientX, event.clientY)
-      if (!match) {
-        return
-      }
-
-      terminalHandleRef.current?.focus()
-      event.preventDefault()
-
-      void window.piDesktop?.openExternal?.(match.text).then((opened) => {
-        if (!opened) {
-          writeSystemMessage((message) => writeToTerminal(message), `Unable to open ${match.text}`)
-        }
-      })
-    }
-
-    terminalElement.addEventListener('click', handleClick, true)
-
-    return () => {
-      terminalElement.removeEventListener('click', handleClick, true)
-    }
-  }, [terminalReadyRevision, writeToTerminal])
-
-  useEffect(() => {
-    if (terminalReadyRevision === 0) {
-      return
-    }
-
     const terminal = terminalInstanceRef.current
     if (!terminal) {
       return
@@ -483,6 +601,7 @@ export function TerminalViewport({
         case 'cleared':
           terminalHistoryRef.current = ''
           clearTerminal((message) => writeToTerminal(message))
+          scheduleXtermBottomAlign()
           break
         case 'started':
         case 'restarted':
@@ -529,17 +648,11 @@ export function TerminalViewport({
     })
 
     const getCurrentSize = () => {
-      const measuredSize = measureTerminalSize(terminal)
+      fitAddonRef.current?.fit()
 
       return {
-        cols: normalizeTerminalDimension(
-          measuredSize?.cols ?? terminal.cols,
-          lastKnownSizeRef.current.cols,
-        ),
-        rows: normalizeTerminalDimension(
-          measuredSize?.rows ?? terminal.rows,
-          lastKnownSizeRef.current.rows,
-        ),
+        cols: normalizeTerminalDimension(terminal.cols, lastKnownSizeRef.current.cols),
+        rows: normalizeTerminalDimension(terminal.rows, lastKnownSizeRef.current.rows),
       }
     }
 
@@ -579,7 +692,7 @@ export function TerminalViewport({
       }
 
       replayBufferedEvents(snapshot.sessionId)
-      terminalHandleRef.current?.focus()
+      terminalInstanceRef.current?.focus()
 
       const resizedSize = getCurrentSize()
       if (resizedSize.cols !== snapshot.cols || resizedSize.rows !== snapshot.rows) {
@@ -630,6 +743,7 @@ export function TerminalViewport({
     projectId,
     resetTerminal,
     scheduleTerminalResizeSettlingPasses,
+    scheduleXtermBottomAlign,
     terminalReadyRevision,
     terminalSessionPath,
     writeToTerminal,
@@ -645,17 +759,7 @@ export function TerminalViewport({
         className,
       )}
     >
-      <Terminal
-        ref={terminalHandleRef}
-        autoResize
-        cursorBlink
-        onReady={handleTerminalReady}
-        onError={handleTerminalError}
-        onResize={handleTerminalResize}
-        onData={handleTerminalData}
-        className="h-full w-full"
-        style={{ height: '100%', width: '100%', ...terminalStyle }}
-      />
+      <div ref={terminalMountRef} className="h-full w-full" style={terminalStyle} />
       {terminalInitError ? (
         <div className="pointer-events-none absolute inset-0 z-10 flex items-start bg-[color:var(--terminal-surface)]/92 px-4 py-3 text-[12px] leading-5 text-[color:var(--text)]">
           <span>[terminal] {terminalInitError}</span>

--- a/src/app/components/workspace/terminal/terminal-viewport.tsx
+++ b/src/app/components/workspace/terminal/terminal-viewport.tsx
@@ -3,6 +3,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { type ITheme, Terminal as XTerm } from '@xterm/xterm'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getPersistedSessionPath } from '../../../../../shared/session-paths'
+import { piGuiThemeUpdatedEvent } from '../../../app-shell/usePiGuiTheme'
 import type { TerminalEvent } from '../../../desktop/types'
 import {
   closeDesktopTerminal,
@@ -488,6 +489,23 @@ export function TerminalViewport({
 
     terminal.options.theme = buildXtermTheme(mount)
   }, [terminalStyle])
+
+  useEffect(() => {
+    const handleThemeUpdate = () => {
+      const terminal = terminalInstanceRef.current
+      const mount = terminalMountRef.current
+      if (!(terminal && mount)) {
+        return
+      }
+
+      terminal.options.theme = buildXtermTheme(mount)
+    }
+
+    window.addEventListener(piGuiThemeUpdatedEvent, handleThemeUpdate)
+    return () => {
+      window.removeEventListener(piGuiThemeUpdatedEvent, handleThemeUpdate)
+    }
+  }, [])
 
   const resizeTerminalToContainer = useCallback(() => {
     const terminal = terminalInstanceRef.current

--- a/src/app/components/workspace/terminal/terminalViewportUtils.ts
+++ b/src/app/components/workspace/terminal/terminalViewportUtils.ts
@@ -1,15 +1,8 @@
 const ansiControlSequencePattern = /^\[[0-?]*[ -/]*[@-~]/
 
-import type { WTerm } from '@wterm/react'
 import type { CSSProperties } from 'react'
 
 export type TerminalBackgroundCssVar = '--terminal-bg' | '--workspace' | '--sidebar'
-
-type TerminalLinkMatch = {
-  text: string
-  start: number
-  end: number
-}
 
 export const MAX_PENDING_TERMINAL_EVENTS = 200
 export const DEFAULT_TERMINAL_COLS = 80
@@ -21,7 +14,6 @@ export const DEFAULT_MAX_KEEP_ALIVE_MS_ON_UNMOUNT = 12 * 60 * 60 * 1_000
 const CLEAR_TERMINAL_SEQUENCE = '\u001b[2J\u001b[3J\u001b[H'
 const MAX_FRONTEND_HISTORY_CHARS = 200_000
 const TRIMMED_FRONTEND_HISTORY_CHARS = 160_000
-const TERMINAL_LINK_PATTERN = /https?:\/\/[^\s)\]}]+/g
 const MIN_USABLE_TERMINAL_COLS = 2
 const MIN_USABLE_TERMINAL_ROWS = 2
 const TERMINAL_STICKY_BOTTOM_THRESHOLD_PX = 24
@@ -53,157 +45,12 @@ export function clampTerminalHistory(history: string) {
     : history
 }
 
-export function extractTerminalLinks(line: string): TerminalLinkMatch[] {
-  const matches = [...line.matchAll(TERMINAL_LINK_PATTERN)]
-  return matches.map((match) => ({
-    text: match[0],
-    start: match.index ?? 0,
-    end: (match.index ?? 0) + match[0].length,
-  }))
-}
-
-function getCaretPositionFromPoint(document: Document, clientX: number, clientY: number) {
-  const documentWithCaretApi = document as Document & {
-    caretPositionFromPoint?: (
-      x: number | undefined,
-      y: number,
-    ) => { offsetNode: Node; offset: number } | null
-    caretRangeFromPoint?: ((x: number, y: number) => Range | null) | undefined
-  }
-
-  const caretPosition = documentWithCaretApi.caretPositionFromPoint?.(clientX, clientY)
-  if (caretPosition) {
-    return {
-      node: caretPosition.offsetNode,
-      offset: caretPosition.offset,
-    }
-  }
-
-  const caretRange = documentWithCaretApi.caretRangeFromPoint?.(clientX, clientY)
-  if (caretRange) {
-    return {
-      node: caretRange.startContainer,
-      offset: caretRange.startOffset,
-    }
-  }
-
-  return null
-}
-
-function findTerminalRow(container: HTMLElement, node: Node | null) {
-  let current: Node | null = node
-
-  while (current) {
-    if (current instanceof HTMLElement && current.classList.contains('term-row')) {
-      return container.contains(current) ? current : null
-    }
-
-    current = current.parentNode
-  }
-
-  return null
-}
-
-function getRowTextOffset(row: HTMLElement, node: Node, offset: number) {
-  const range = row.ownerDocument.createRange()
-
-  try {
-    range.setStart(row, 0)
-    range.setEnd(node, offset)
-  } catch {
-    return null
-  }
-
-  return range.toString().length
-}
-
-export function findTerminalLinkAtPoint(container: HTMLElement, clientX: number, clientY: number) {
-  const caret = getCaretPositionFromPoint(container.ownerDocument, clientX, clientY)
-  if (!caret) {
-    return null
-  }
-
-  const row = findTerminalRow(container, caret.node)
-  if (!row) {
-    return null
-  }
-
-  const rowTextOffset = getRowTextOffset(row, caret.node, caret.offset)
-  if (rowTextOffset === null) {
-    return null
-  }
-
-  const lineText = row.textContent ?? ''
-  return (
-    extractTerminalLinks(lineText).find(
-      (match) => rowTextOffset >= match.start && rowTextOffset < match.end,
-    ) ?? null
-  )
-}
-
-export function hasSelectionInside(container: HTMLElement) {
-  const selection = window.getSelection()
-  if (!selection || selection.isCollapsed || selection.toString().trim().length === 0) {
-    return false
-  }
-
-  const anchorNode = selection.anchorNode
-  const focusNode = selection.focusNode
-
-  return Boolean(
-    (anchorNode && container.contains(anchorNode)) || (focusNode && container.contains(focusNode)),
-  )
-}
-
 export function normalizeTerminalDimension(value: number, fallback: number) {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback
 }
 
 export function isUsableTerminalSize(cols: number, rows: number) {
   return cols >= MIN_USABLE_TERMINAL_COLS && rows >= MIN_USABLE_TERMINAL_ROWS
-}
-
-export function measureTerminalSize(terminal: WTerm) {
-  const element = terminal.element
-  const grid = element.querySelector<HTMLElement>('.term-grid')
-  if (!grid) {
-    return null
-  }
-
-  const row = element.ownerDocument.createElement('div')
-  row.className = 'term-row'
-  row.style.visibility = 'hidden'
-  row.style.position = 'absolute'
-
-  const probe = element.ownerDocument.createElement('span')
-  probe.textContent = 'W'
-  row.appendChild(probe)
-  grid.appendChild(row)
-
-  const charWidth = probe.getBoundingClientRect().width
-  const rowHeight = row.getBoundingClientRect().height
-  row.remove()
-
-  if (charWidth <= 0 || rowHeight <= 0) {
-    return null
-  }
-
-  const styles = getComputedStyle(element)
-  const paddingLeft = Number.parseFloat(styles.paddingLeft) || 0
-  const paddingRight = Number.parseFloat(styles.paddingRight) || 0
-  const paddingTop = Number.parseFloat(styles.paddingTop) || 0
-  const paddingBottom = Number.parseFloat(styles.paddingBottom) || 0
-  const contentWidth = element.clientWidth - paddingLeft - paddingRight
-  const contentHeight = element.clientHeight - paddingTop - paddingBottom
-
-  if (contentWidth <= 0 || contentHeight <= 0) {
-    return null
-  }
-
-  return {
-    cols: Math.max(1, Math.floor(contentWidth / charWidth)),
-    rows: Math.max(1, Math.floor(contentHeight / rowHeight)),
-  }
 }
 
 export function terminalWrapperStyle(backgroundCssVar: TerminalBackgroundCssVar): CSSProperties {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import '@wterm/react/css'
+import '@xterm/xterm/css/xterm.css'
 import '@fontsource-variable/inter'
 import './styles.css'
 import App from './app'

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,4 +5,4 @@
 @import "./styles/primitives.css";
 @import "./styles/settings.css";
 @import "./styles/sidebar.css";
-@import "./styles/vendor/wterm.css";
+@import "./styles/vendor/xterm.css";

--- a/src/styles/vendor/xterm.css
+++ b/src/styles/vendor/xterm.css
@@ -1,47 +1,52 @@
-.terminal-viewport .wterm {
+.terminal-viewport .xterm {
+  box-sizing: border-box;
   height: 100%;
   padding: 8px 10px;
   border-radius: 10px;
   background: var(--terminal-surface, var(--terminal-bg));
   box-shadow: none;
   cursor: text;
-  overflow-y: scroll;
-  overflow-x: hidden;
   overscroll-behavior: contain;
   overflow-anchor: none;
   scrollbar-gutter: stable;
   scrollbar-width: auto;
 }
 
+.terminal-viewport .xterm .xterm-viewport {
+  background: var(--terminal-surface, var(--terminal-bg)) !important;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+}
+
+.terminal-viewport .xterm .xterm-screen {
+  background: var(--terminal-surface, var(--terminal-bg));
+}
+
 .terminal-viewport--flush,
-.terminal-viewport--flush .wterm {
+.terminal-viewport--flush .xterm {
   border-radius: 0;
 }
 
-.terminal-viewport--flush .wterm {
+.terminal-viewport--flush .xterm {
   padding: 0 0 0 14px;
 }
 
-.terminal-viewport--bottom-reserve .wterm {
+.terminal-viewport--bottom-reserve .xterm {
   padding-bottom: var(--term-row-height, 17px);
 }
 
-.terminal-viewport .wterm .term-grid {
-  min-height: 100%;
-}
-
-.terminal-viewport .wterm::-webkit-scrollbar {
+.terminal-viewport .xterm .xterm-viewport::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
 
-.terminal-viewport .wterm::-webkit-scrollbar-thumb {
+.terminal-viewport .xterm .xterm-viewport::-webkit-scrollbar-thumb {
   border: 1px solid transparent;
   border-radius: 999px;
   background: rgba(140, 148, 181, 0.22);
   background-clip: padding-box;
 }
 
-.terminal-viewport .wterm ::selection {
+.terminal-viewport .xterm ::selection {
   background: var(--terminal-selection, rgba(185, 191, 243, 0.18));
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,5 +10,4 @@ declare module '*.md?raw' {
   export default content
 }
 
-declare module '@wterm/react/css'
 declare module '@fontsource-variable/inter'


### PR DESCRIPTION
## Summary
- Replace the drawer terminal renderer with xterm.js plus FitAddon.
- Remove the wterm dependencies and import xterm's stylesheet instead.
- Keep the drawer/footer in a simple non-overlapping flex layout.
- Add xterm web-link handling and theme xterm from the app's CSS variables.
- Preserve bottom-stickiness via xterm buffer state and add a visual-only initial bottom alignment before scrollback exists.

## Validation
- `bun run ai:check`
- push hook reran `bun run ai:check`
