### PR TITLE
Add dollar skill mentions in composer

### DIFF
--- a/desktop/pi-desktop-runtime.ts
+++ b/desktop/pi-desktop-runtime.ts
@@ -193,6 +193,12 @@ export function getComposerSlashCommands(request: ComposerStateRequest = {}) {
   })
 }
 
+export function getComposerSkills(request: ComposerStateRequest = {}) {
+  return invokeRuntimeHost('getComposerSkills', {
+    request: withComposerModeSettings(request),
+  })
+}
+
 export function getComposerState(request = {}) {
   return invokeRuntimeHost('getComposerState', { request: withComposerModeSettings(request) })
 }

--- a/desktop/pi-threads.ts
+++ b/desktop/pi-threads.ts
@@ -24,6 +24,7 @@ export {
   installDictationModel,
   listDictationModels,
   listProjectCommits,
+  loadComposerSkills,
   loadComposerSlashCommands,
   loadComposerState,
   loadProjectDiff,

--- a/desktop/pi-threads/shell-loader.ts
+++ b/desktop/pi-threads/shell-loader.ts
@@ -17,6 +17,7 @@ import {
   transcribeDictation as transcribeSherpaDictation,
 } from '../dictation/sherpa-onnx.ts'
 import {
+  getComposerSkills,
   getComposerSlashCommands,
   getComposerState,
   subscribeDesktopEvents as subscribeRuntimeEvents,
@@ -43,6 +44,10 @@ export async function loadComposerState(
 
 export async function loadComposerSlashCommands(request: ComposerStateRequest = {}) {
   return getComposerSlashCommands(request)
+}
+
+export async function loadComposerSkills(request: ComposerStateRequest = {}) {
+  return getComposerSkills(request)
 }
 
 export async function getDictationState(): Promise<DictationState> {

--- a/desktop/runtime-host/client-bridge.ts
+++ b/desktop/runtime-host/client-bridge.ts
@@ -442,7 +442,11 @@ function shouldUseThreadHost<TName extends RuntimeHostRequestName>(
 ) {
   if (name === 'startNewThread' || name === 'selectProjectRuntime') return false
   if (name === 'loadThreadSnapshot') return false
-  if (name === 'getComposerSlashCommands' && !getRequestSessionPath(name, payload)) return false
+  if (
+    (name === 'getComposerSlashCommands' || name === 'getComposerSkills') &&
+    !getRequestSessionPath(name, payload)
+  )
+    return false
   return Boolean(getPersistedSessionPath(getRequestSessionPath(name, payload)))
 }
 

--- a/desktop/runtime-host/host-service.ts
+++ b/desktop/runtime-host/host-service.ts
@@ -14,6 +14,7 @@ export {
 export {
   answerNativeAskQuestions,
   dequeueComposerPrompt,
+  getComposerSkills,
   getComposerSlashCommands,
   getComposerState,
   openThreadRuntime,

--- a/desktop/runtime-host/live-runtime-service.ts
+++ b/desktop/runtime-host/live-runtime-service.ts
@@ -1,8 +1,10 @@
 const whitespaceRunPattern = /\s+/
+const dollarSkillTokenPattern = /(^|\s)\$([\w./-]+)/g
 
 import { parseCompactSlashCommand } from '../../shared/composer-slash-commands.ts'
 import type {
   ComposerAttachment,
+  ComposerSkillReference,
   ComposerStateRequest,
   ComposerStreamingBehavior,
   ComposerThinkingLevel,
@@ -61,6 +63,53 @@ function isExtensionCommandPrompt(runtime: PiRuntime, text: string) {
   if (!text.startsWith('/')) return false
   const commandName = text.slice(1).split(whitespaceRunPattern, 1)[0] ?? ''
   return Boolean(runtime.session.extensionRunner.getCommand(commandName))
+}
+
+function mapSessionSkills(session: PiRuntime['session']): ComposerSkillReference[] {
+  return session.resourceLoader.getSkills().skills.map((skill) => ({
+    name: skill.name,
+    description: skill.description,
+    filePath: skill.filePath,
+    sourceInfo: skill.sourceInfo,
+  }))
+}
+
+function buildSkillReferencePrompt(input: {
+  skills: ComposerSkillReference[]
+  userRequest: string
+}) {
+  return [
+    'The user asked you to use the following skills. Read their SKILL.md files if available.',
+    '',
+    ...input.skills.map((skill) => `- $${skill.name}: ${skill.filePath}`),
+    '',
+    'User request:',
+    input.userRequest,
+  ].join('\n')
+}
+
+function expandDollarSkillReferences(runtime: PiRuntime, text: string) {
+  const skillsByName = new Map(
+    mapSessionSkills(runtime.session).map((skill) => [skill.name, skill]),
+  )
+  const skills: ComposerSkillReference[] = []
+  const seenSkillNames = new Set<string>()
+
+  for (const match of text.matchAll(dollarSkillTokenPattern)) {
+    const skillName = match[2]
+    if (!skillName || seenSkillNames.has(skillName)) continue
+    const skill = skillsByName.get(skillName)
+    if (!skill) continue
+    seenSkillNames.add(skillName)
+    skills.push(skill)
+  }
+
+  if (skills.length === 0) return text
+
+  return buildSkillReferencePrompt({
+    skills,
+    userRequest: text,
+  })
 }
 
 async function selectRequestedComposerModel(runtime: PiRuntime, request: ComposerStateRequest) {
@@ -171,6 +220,35 @@ export async function getComposerSlashCommands(request: ComposerStateRequest = {
       console.warn('Pi extension resource discovery failed', error)
     })
     return mapSessionCommands(snapshot.session)
+  } finally {
+    snapshot.session.dispose()
+  }
+}
+
+export async function getComposerSkills(request: ComposerStateRequest = {}) {
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath)
+  if (persistedSessionPath) {
+    const runtime = await getOrCreateRuntimeForSessionPath(persistedSessionPath, {
+      suspendDisposal: true,
+      settingsCwd: request.composerSessionDir ?? null,
+      chatGroupId: request.chatGroupId ?? null,
+    })
+    await reloadRuntimeSettingsIfSafe(persistedSessionPath)
+    scheduleRuntimeDisposal(persistedSessionPath)
+    return mapSessionSkills(runtime.session)
+  }
+
+  const snapshot = await createComposerSnapshotSession({
+    ...request,
+    projectId: request.projectId ?? getDesktopWorkingDirectory(),
+    sessionPath: persistedSessionPath,
+  })
+
+  try {
+    await discoverHeadlessAgentSessionResources(snapshot.session).catch((error) => {
+      console.warn('Pi extension resource discovery failed', error)
+    })
+    return mapSessionSkills(snapshot.session)
   } finally {
     snapshot.session.dispose()
   }
@@ -360,13 +438,14 @@ export async function sendComposerPrompt(
         })
       }
       const attachmentPrompt = buildComposerAttachmentPrompt(request.attachments ?? [])
+      const skillExpandedText = expandDollarSkillReferences(runtime, request.text)
       const message = `${
         attachmentPrompt
           ? `${attachmentPrompt}
 
 `
           : ''
-      }${request.text}`
+      }${skillExpandedText}`
       const streamingBehavior =
         request.streamingBehavior ?? request.composerStreamingBehavior ?? 'followUp'
       return await promptComposerRuntime({

--- a/desktop/runtime-host/protocol.ts
+++ b/desktop/runtime-host/protocol.ts
@@ -2,6 +2,7 @@ import type {
   Artifact,
   ArtifactKind,
   ComposerAttachment,
+  ComposerSkillReference,
   ComposerSlashCommand,
   ComposerState,
   ComposerStateRequest,
@@ -22,6 +23,7 @@ import type { CommitMessageContext } from '../project-git.ts'
 export type RuntimeHostRequestMap = {
   getComposerState: { request: ComposerStateRequest }
   getComposerSlashCommands: { request: ComposerStateRequest }
+  getComposerSkills: { request: ComposerStateRequest }
   startNewThread: { request: ComposerStateRequest }
   selectProjectRuntime: { request: ComposerStateRequest }
   openThreadRuntime: { request: ComposerStateRequest }
@@ -122,6 +124,7 @@ export type RuntimeHostRequestMap = {
 export type RuntimeHostResponseMap = {
   getComposerState: ComposerState
   getComposerSlashCommands: ComposerSlashCommand[]
+  getComposerSkills: ComposerSkillReference[]
   startNewThread: {
     composer: ComposerState
     projectId: string

--- a/desktop/runtime-host/worker.ts
+++ b/desktop/runtime-host/worker.ts
@@ -5,6 +5,7 @@ import {
   dequeueComposerPrompt,
   disposeAllRuntimeHosts,
   generateGitCommitMessage,
+  getComposerSkills,
   getComposerSlashCommands,
   getComposerState,
   getPiSessionStorage,
@@ -54,6 +55,11 @@ async function handleRequest<TName extends RuntimeHostRequestName>(
       const payload =
         message.payload as unknown as RuntimeHostRequestMessage<'getComposerSlashCommands'>['payload']
       return (await getComposerSlashCommands(payload.request)) as RuntimeHostResponseMap[TName]
+    }
+    case 'getComposerSkills': {
+      const payload =
+        message.payload as unknown as RuntimeHostRequestMessage<'getComposerSkills'>['payload']
+      return (await getComposerSkills(payload.request)) as RuntimeHostResponseMap[TName]
     }
     case 'startNewThread': {
       const payload =

--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -137,6 +137,7 @@ const handlers: DesktopRequestHandlerMap = {
   listComposerAttachmentEntries: (request) => listComposerAttachmentEntries(request),
   getComposerState: (request) => piThreads.loadComposerState(request),
   getComposerSlashCommands: (request) => piThreads.loadComposerSlashCommands(request),
+  getComposerSkills: (request) => piThreads.loadComposerSkills(request),
   getDictationState: () => piThreads.getDictationState(),
   listDictationModels: () => piThreads.listDictationModels(),
   installDictationModel: (request) => piThreads.installDictationModel(request),

--- a/shared/desktop-composer-contracts.ts
+++ b/shared/desktop-composer-contracts.ts
@@ -93,3 +93,10 @@ export type ComposerSlashCommand = {
   source: ComposerSlashCommandSource
   sourceInfo?: unknown | undefined
 }
+
+export type ComposerSkillReference = {
+  name: string
+  description: string
+  filePath: string
+  sourceInfo?: unknown | undefined
+}

--- a/shared/desktop-contracts.ts
+++ b/shared/desktop-contracts.ts
@@ -29,6 +29,7 @@ export type {
   ComposerFilePickerState,
   ComposerModel,
   ComposerQueuedPrompt,
+  ComposerSkillReference,
   ComposerSlashCommand,
   ComposerSlashCommandSource,
   ComposerState,

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -17,6 +17,7 @@ export type {
   ComposerFilePickerState,
   ComposerModel,
   ComposerQueuedPrompt,
+  ComposerSkillReference,
   ComposerSlashCommand,
   ComposerSlashCommandSource,
   ComposerState,

--- a/shared/desktop-ipc.ts
+++ b/shared/desktop-ipc.ts
@@ -8,6 +8,7 @@ import type {
   ChatSidebarState,
   ComposerAttachment,
   ComposerFilePickerState,
+  ComposerSkillReference,
   ComposerSlashCommand,
   ComposerState,
   ComposerStateRequest,
@@ -187,6 +188,7 @@ export type DesktopRequestMap = {
   }
   getComposerState: { params: ComposerStateRequest; response: ComposerState }
   getComposerSlashCommands: { params: ComposerStateRequest; response: ComposerSlashCommand[] }
+  getComposerSkills: { params: ComposerStateRequest; response: ComposerSkillReference[] }
   getDictationState: { params: Record<string, never>; response: DictationState }
   listDictationModels: { params: Record<string, never>; response: DictationModelSummary[] }
   installDictationModel: {

--- a/src/app/components/workspace/composer/composer-file-picker.tsx
+++ b/src/app/components/workspace/composer/composer-file-picker.tsx
@@ -42,13 +42,8 @@ type ComposerFilePickerProps = {
   onToggleFile: (attachment: ComposerAttachment) => void
 }
 
-const smallDisplayHeightBreakpoint = 768
 const sidePlacementGap = 8
 const sidePlacementViewportPadding = 12
-
-function getSmallDisplayPlacementEnabled() {
-  return typeof window !== 'undefined' && window.innerHeight <= smallDisplayHeightBreakpoint
-}
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
@@ -74,24 +69,36 @@ export function ComposerFilePicker({
   const [dropActive, setDropActive] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [searchExpanded, setSearchExpanded] = useState(false)
-  const [smallDisplayHeight, setSmallDisplayHeight] = useState(getSmallDisplayPlacementEnabled)
+  const [sidePlacementEnabled, setSidePlacementEnabled] = useState(false)
   const [sidePosition, setSidePosition] = useState({ left: 0, top: 0 })
   const [sidePositionReady, setSidePositionReady] = useState(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const updatePlacementMode = () => {
-      setSmallDisplayHeight(getSmallDisplayPlacementEnabled())
+      const anchorRect = anchorRef?.current?.getBoundingClientRect()
+      const estimatedPanelHeight = Math.min(
+        378,
+        window.innerHeight - sidePlacementViewportPadding * 2,
+      )
+      setSidePlacementEnabled(
+        Boolean(
+          anchorRect &&
+            (preferSidePlacement ||
+              anchorRect.top <
+                estimatedPanelHeight + sidePlacementGap + sidePlacementViewportPadding),
+        ),
+      )
     }
 
     updatePlacementMode()
     window.addEventListener('resize', updatePlacementMode)
+    window.addEventListener('scroll', updatePlacementMode, true)
     return () => {
       window.removeEventListener('resize', updatePlacementMode)
+      window.removeEventListener('scroll', updatePlacementMode, true)
     }
-  }, [])
-
-  const sidePlacementEnabled = preferSidePlacement && smallDisplayHeight && Boolean(anchorRef)
+  }, [anchorRef, preferSidePlacement])
 
   const attachedByPath = useMemo(
     () => new Set(attachments.map((attachment) => attachment.path)),

--- a/src/app/components/workspace/composer/composer-model-popover.tsx
+++ b/src/app/components/workspace/composer/composer-model-popover.tsx
@@ -27,7 +27,6 @@ type ComposerModelPopoverProps = {
   onSelectThinkingLevel: (level: ComposerThinkingLevel) => void
 }
 
-const smallDisplayHeightBreakpoint = 768
 const sidePlacementGap = 8
 const sidePlacementViewportPadding = 12
 
@@ -106,10 +105,6 @@ function MenuList({ items }: { items: MenuOption[] }) {
   )
 }
 
-function getSmallDisplayPlacementEnabled() {
-  return typeof window !== 'undefined' && window.innerHeight <= smallDisplayHeightBreakpoint
-}
-
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
@@ -142,24 +137,36 @@ export function ComposerModelPopover({
   const [openMenu, setOpenMenu] = useState<NestedMenu>(null)
   const [selectedProvider, setSelectedProvider] = useState(currentModel?.provider ?? '')
   const [modelSearch, setModelSearch] = useState('')
-  const [smallDisplayHeight, setSmallDisplayHeight] = useState(getSmallDisplayPlacementEnabled)
+  const [sidePlacementEnabled, setSidePlacementEnabled] = useState(false)
   const [sidePosition, setSidePosition] = useState({ left: 0, top: 0 })
   const [sidePositionReady, setSidePositionReady] = useState(false)
   const modelSearchRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const updatePlacementMode = () => {
-      setSmallDisplayHeight(getSmallDisplayPlacementEnabled())
+      const anchorRect = anchorRef.current?.getBoundingClientRect()
+      const estimatedPanelHeight = Math.min(
+        360,
+        window.innerHeight - sidePlacementViewportPadding * 2,
+      )
+      setSidePlacementEnabled(
+        Boolean(
+          anchorRect &&
+            (preferSidePlacement ||
+              anchorRect.top <
+                estimatedPanelHeight + sidePlacementGap + sidePlacementViewportPadding),
+        ),
+      )
     }
 
     updatePlacementMode()
     window.addEventListener('resize', updatePlacementMode)
+    window.addEventListener('scroll', updatePlacementMode, true)
     return () => {
       window.removeEventListener('resize', updatePlacementMode)
+      window.removeEventListener('scroll', updatePlacementMode, true)
     }
-  }, [])
-
-  const sidePlacementEnabled = preferSidePlacement && smallDisplayHeight
+  }, [anchorRef, preferSidePlacement])
 
   useEffect(() => {
     if (currentModel?.provider) {

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -9,7 +9,9 @@ import {
   getComposerAttachmentsFromClipboardData,
   hasAttachmentHintInClipboardData,
 } from './composer-paste-attachments'
+import { ComposerSkillMentionPanel } from './composer-skill-mention-panel'
 import { ComposerTextField } from './composer-text-field'
+import type { ComposerSkillMentions } from './useComposerSkillMentions'
 import {
   type ComposerSlashCommands,
   getComposerSlashCommandGroupLabel,
@@ -66,8 +68,46 @@ function SlashCommandOption({
   )
 }
 
+function SlashCommandPanel({
+  panelRef,
+  slashCommands,
+}: {
+  panelRef: RefObject<HTMLDivElement | null>
+  slashCommands: ComposerSlashCommands
+}) {
+  if (!slashCommands.open) return null
+  return (
+    <div
+      ref={panelRef}
+      id={slashCommands.listboxId}
+      role="listbox"
+      tabIndex={-1}
+      aria-label="Composer slash commands"
+      className="absolute right-0 bottom-full left-0 z-20 max-h-64 scroll-py-1.5 overflow-auto rounded-xl border border-[color:var(--border-strong)] bg-[color:var(--panel)] p-1.5 shadow-[var(--shadow)]"
+    >
+      {slashCommands.commands.length > 0 ? (
+        slashCommands.commands.map((command, index) => (
+          <SlashCommandOption
+            key={`${command.source}:${command.name}`}
+            command={command}
+            index={index}
+            previousCommand={slashCommands.commands[index - 1]}
+            selected={index === slashCommands.selectedIndex}
+            slashCommands={slashCommands}
+          />
+        ))
+      ) : (
+        <div className="px-2 py-2 text-[12px] text-[color:var(--muted)]">
+          {slashCommands.loading ? 'Loading commands…' : 'No matching commands'}
+        </div>
+      )}
+    </div>
+  )
+}
+
 type ComposerKeyDownInput = {
   cancelDictation: () => Promise<void>
+  clearError: () => void
   dictationActive: boolean
   dictationTranscribing: boolean
   inputLocked: boolean
@@ -75,6 +115,8 @@ type ComposerKeyDownInput = {
   onEscapeOverride?: (() => boolean) | undefined
   onSubmitOverride?: (() => boolean) | undefined
   slashCommands: ComposerSlashCommands
+  skillMentions: ComposerSkillMentions
+  setDraft: (value: string) => void
 }
 
 function isCursorAtStart(textarea: HTMLTextAreaElement) {
@@ -86,6 +128,68 @@ function isCursorAtEnd(textarea: HTMLTextAreaElement) {
     textarea.selectionStart === textarea.selectionEnd &&
     textarea.selectionEnd === textarea.value.length
   )
+}
+
+function handleOpenAutocompleteKeyDown(
+  event: KeyboardEvent<HTMLTextAreaElement>,
+  input: ComposerKeyDownInput,
+) {
+  return input.slashCommands.handleKeyDown(event) || input.skillMentions.handleKeyDown(event)
+}
+
+function handleDeleteTextKey(
+  event: KeyboardEvent<HTMLTextAreaElement>,
+  setDraft: (value: string) => void,
+  clearError: () => void,
+) {
+  if (event.key !== 'Backspace' && event.key !== 'Delete') return false
+  if (event.altKey || event.ctrlKey || event.metaKey) return false
+  const textarea = event.currentTarget
+  const selectionStart = textarea.selectionStart
+  const selectionEnd = textarea.selectionEnd
+  const segments = [
+    ...new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(textarea.value),
+  ]
+  const previousSegment = [...segments].reverse().find((segment) => segment.index < selectionStart)
+  const nextSegment = segments.find((segment) => segment.index > selectionEnd)
+  const deleteStart =
+    selectionStart === selectionEnd && event.key === 'Backspace'
+      ? (previousSegment?.index ?? 0)
+      : selectionStart
+  const deleteEnd =
+    selectionStart === selectionEnd && event.key === 'Delete'
+      ? (nextSegment?.index ?? textarea.value.length)
+      : selectionEnd
+  if (deleteStart === deleteEnd) return false
+  event.preventDefault()
+  const nextValue = `${textarea.value.slice(0, deleteStart)}${textarea.value.slice(deleteEnd)}`
+  setDraft(nextValue)
+  clearError()
+  window.requestAnimationFrame(() => textarea.setSelectionRange(deleteStart, deleteStart))
+  return true
+}
+
+function handleHorizontalBoundaryNavigation(
+  event: KeyboardEvent<HTMLTextAreaElement>,
+  onArrowNavigationOverride: ((direction: 'previous' | 'next') => boolean) | undefined,
+) {
+  if (
+    event.key === 'ArrowLeft' &&
+    isCursorAtStart(event.currentTarget) &&
+    onArrowNavigationOverride?.('previous')
+  ) {
+    event.preventDefault()
+    return true
+  }
+  if (
+    event.key === 'ArrowRight' &&
+    isCursorAtEnd(event.currentTarget) &&
+    onArrowNavigationOverride?.('next')
+  ) {
+    event.preventDefault()
+    return true
+  }
+  return false
 }
 
 function handleComposerTextKeyDown(
@@ -105,28 +209,20 @@ function handleComposerTextKeyDown(
     event.preventDefault()
     return
   }
+  if (handleDeleteTextKey(event, input.setDraft, input.clearError)) {
+    return
+  }
+  if (handleOpenAutocompleteKeyDown(event, input)) {
+    return
+  }
   if (event.key === 'Enter' && !event.shiftKey) {
     event.preventDefault()
     if (!input.onSubmitOverride?.()) input.slashCommands.submit()
     return
   }
-  if (
-    event.key === 'ArrowLeft' &&
-    isCursorAtStart(event.currentTarget) &&
-    input.onArrowNavigationOverride?.('previous')
-  ) {
-    event.preventDefault()
+  if (handleHorizontalBoundaryNavigation(event, input.onArrowNavigationOverride)) {
     return
   }
-  if (
-    event.key === 'ArrowRight' &&
-    isCursorAtEnd(event.currentTarget) &&
-    input.onArrowNavigationOverride?.('next')
-  ) {
-    event.preventDefault()
-    return
-  }
-  input.slashCommands.handleKeyDown(event)
 }
 
 type ComposerPromptInputPanelProps = {
@@ -154,6 +250,8 @@ type ComposerPromptInputPanelProps = {
   projectId: string
   slashCommandPanelRef: RefObject<HTMLDivElement | null>
   slashCommands: ComposerSlashCommands
+  skillMentionPanelRef: RefObject<HTMLDivElement | null>
+  skillMentions: ComposerSkillMentions
   showDictationButton: boolean
   attachPickerAttachments: Parameters<typeof ComposerFilePicker>[0]['onAttachAttachments']
   cancelDictation: () => Promise<void>
@@ -200,6 +298,8 @@ export function ComposerPromptInputPanel({
   projectId,
   slashCommandPanelRef,
   slashCommands,
+  skillMentionPanelRef,
+  skillMentions,
   showDictationButton,
   attachPickerAttachments,
   cancelDictation,
@@ -241,33 +341,7 @@ export function ComposerPromptInputPanel({
         <div className="flex items-end justify-between gap-2">
           <div className="flex min-w-0 flex-1 items-end gap-2">
             <div className="min-w-0 flex-1">
-              {slashCommands.open ? (
-                <div
-                  ref={slashCommandPanelRef}
-                  id={slashCommands.listboxId}
-                  role="listbox"
-                  tabIndex={-1}
-                  aria-label="Composer slash commands"
-                  className="absolute right-0 bottom-full left-0 z-20 max-h-64 scroll-py-1.5 overflow-auto rounded-xl border border-[color:var(--border-strong)] bg-[color:var(--panel)] p-1.5 shadow-[var(--shadow)]"
-                >
-                  {slashCommands.commands.length > 0 ? (
-                    slashCommands.commands.map((command, index) => (
-                      <SlashCommandOption
-                        key={`${command.source}:${command.name}`}
-                        command={command}
-                        index={index}
-                        previousCommand={slashCommands.commands[index - 1]}
-                        selected={index === slashCommands.selectedIndex}
-                        slashCommands={slashCommands}
-                      />
-                    ))
-                  ) : (
-                    <div className="px-2 py-2 text-[12px] text-[color:var(--muted)]">
-                      {slashCommands.loading ? 'Loading commands…' : 'No matching commands'}
-                    </div>
-                  )}
-                </div>
-              ) : null}
+              <SlashCommandPanel panelRef={slashCommandPanelRef} slashCommands={slashCommands} />
               <ComposerTextField
                 value={draft}
                 onChange={setDraft}
@@ -279,13 +353,16 @@ export function ComposerPromptInputPanel({
                 onKeyDown={(event) =>
                   handleComposerTextKeyDown(event, {
                     cancelDictation,
+                    clearError,
                     dictationActive,
                     dictationTranscribing,
                     inputLocked,
                     onArrowNavigationOverride,
                     onEscapeOverride,
                     onSubmitOverride,
+                    setDraft,
                     slashCommands,
+                    skillMentions,
                   })
                 }
                 onPaste={(event: ClipboardEvent<HTMLTextAreaElement>) => {
@@ -312,8 +389,16 @@ export function ComposerPromptInputPanel({
                   })
                 }}
                 ariaLabel="Prompt composer"
-                ariaActiveDescendant={slashCommands.activeDescendantId}
-                ariaControls={slashCommands.open ? slashCommands.listboxId : undefined}
+                ariaActiveDescendant={
+                  slashCommands.activeDescendantId ?? skillMentions.activeDescendantId
+                }
+                ariaControls={
+                  slashCommands.open
+                    ? slashCommands.listboxId
+                    : skillMentions.open
+                      ? skillMentions.listboxId
+                      : undefined
+                }
                 placeholder={placeholderText}
                 readOnly={inputLocked}
                 hoverToFocus={hoverToFocus}
@@ -322,6 +407,14 @@ export function ComposerPromptInputPanel({
                 placeholderTone={errorMessage ? 'error' : 'muted'}
                 statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                 reservedLineCount={1}
+                inlinePopover={
+                  skillMentions.open ? (
+                    <ComposerSkillMentionPanel
+                      panelRef={skillMentionPanelRef}
+                      skillMentions={skillMentions}
+                    />
+                  ) : null
+                }
                 trailingAdornment={
                   <ComposerDictationControls
                     dictationActive={dictationActive}

--- a/src/app/components/workspace/composer/composer-prompt-surface.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-surface.tsx
@@ -8,6 +8,7 @@ import { ComposerFooter } from './composer-footer'
 import { hasFilePayloadInClipboardData } from './composer-paste-attachments'
 import { ComposerPromptInputPanel } from './composer-prompt-input-panel'
 import { useComposerController } from './controller/useComposerController'
+import { useComposerSkillMentions } from './useComposerSkillMentions'
 import { useComposerSlashCommands } from './useComposerSlashCommands'
 
 type ComposerPromptSurfaceProps = ComposerProps & {
@@ -146,6 +147,7 @@ export function ComposerPromptSurface({
   const dictationTranscribing = dictationInterimText.length > 0
   const composerMode = activeView === 'chat' ? 'chat' : 'code'
   const slashCommandPanelRef = useRef<HTMLDivElement>(null)
+  const skillMentionPanelRef = useRef<HTMLDivElement>(null)
   const stopButtonBoundaryRef = useRef<HTMLDivElement>(null)
   const askQuestionsOverlayRef = useRef<HTMLDivElement>(null)
   const lastAskQuestionsOverlayHeightRef = useRef(0)
@@ -174,9 +176,19 @@ export function ComposerPromptSurface({
   const slashCommandListSignature = slashCommands.commands
     .map((command) => `${command.source}:${command.name}`)
     .join('|')
+  const skillMentions = useComposerSkillMentions({
+    draft,
+    projectId,
+    sessionPath,
+    composerMode,
+    setDraft,
+  })
+  const skillMentionListSignature = skillMentions.skills
+    .map((skill) => `${skill.name}:${skill.filePath}`)
+    .join('|')
 
   useEffect(() => {
-    if (!slashCommands.open) {
+    if (!(slashCommands.open || skillMentions.open)) {
       return
     }
 
@@ -185,20 +197,22 @@ export function ComposerPromptSurface({
       if (
         !target ||
         slashCommandPanelRef.current?.contains(target) ||
+        skillMentionPanelRef.current?.contains(target) ||
         composerPanelRef.current?.contains(target) ||
         stopButtonBoundaryRef.current?.contains(target)
       ) {
         return
       }
 
-      slashCommands.dismiss({ clearDraft: true })
+      if (slashCommands.open) slashCommands.dismiss({ clearDraft: true })
+      if (skillMentions.open) skillMentions.dismiss()
     }
 
     window.addEventListener('pointerdown', handlePointerDown, true)
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown, true)
     }
-  }, [composerPanelRef, slashCommands])
+  }, [composerPanelRef, skillMentions, slashCommands])
 
   useEffect(() => {
     if (!(slashCommands.open && slashCommands.activeDescendantId)) {
@@ -238,6 +252,30 @@ export function ComposerPromptSurface({
     slashCommands.activeDescendantId,
     slashCommands.selectedIndex,
     slashCommandListSignature,
+  ])
+
+  useEffect(() => {
+    if (!(skillMentions.open && skillMentions.activeDescendantId)) {
+      return
+    }
+
+    void skillMentionListSignature
+
+    const panel = skillMentionPanelRef.current
+    const option = panel?.querySelector<HTMLElement>(`#${skillMentions.activeDescendantId}`)
+    if (!(panel && option)) return
+
+    if (skillMentions.selectedIndex === 0) {
+      panel.scrollTop = 0
+      return
+    }
+
+    option.scrollIntoView({ block: 'nearest' })
+  }, [
+    skillMentionListSignature,
+    skillMentions.activeDescendantId,
+    skillMentions.open,
+    skillMentions.selectedIndex,
   ])
 
   useEffect(() => {
@@ -442,6 +480,8 @@ export function ComposerPromptSurface({
               projectId={projectId}
               slashCommandPanelRef={slashCommandPanelRef}
               slashCommands={slashCommands}
+              skillMentionPanelRef={skillMentionPanelRef}
+              skillMentions={skillMentions}
               showDictationButton={showDictationButton}
               attachPickerAttachments={attachPickerAttachments}
               cancelDictation={cancelDictation}

--- a/src/app/components/workspace/composer/composer-skill-mention-panel.tsx
+++ b/src/app/components/workspace/composer/composer-skill-mention-panel.tsx
@@ -1,0 +1,82 @@
+import type { RefObject } from 'react'
+import { cn } from '../../../utils/cn'
+import {
+  type ComposerSkillMentions,
+  getComposerSkillMentionOptionId,
+} from './useComposerSkillMentions'
+
+function SkillMentionOption({
+  index,
+  selected,
+  skillMentions,
+  skill,
+}: {
+  index: number
+  selected: boolean
+  skillMentions: ComposerSkillMentions
+  skill: ComposerSkillMentions['skills'][number]
+}) {
+  return (
+    <button
+      id={getComposerSkillMentionOptionId(index)}
+      type="button"
+      role="option"
+      aria-selected={selected}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left',
+        selected
+          ? 'bg-[color:var(--accent-bg)] text-[color:var(--text)]'
+          : 'text-[color:var(--muted)] hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]',
+      )}
+      onPointerEnter={() => skillMentions.setSelectedIndex(index)}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => skillMentions.selectSkill(skill)}
+    >
+      <span className="shrink-0 text-[12px] text-[color:var(--text)]">${skill.name}</span>
+      {skill.description ? (
+        <span className="min-w-0 truncate text-[12px] text-[color:var(--muted)]">
+          {skill.description}
+        </span>
+      ) : null}
+    </button>
+  )
+}
+
+export function ComposerSkillMentionPanel({
+  panelRef,
+  skillMentions,
+}: {
+  panelRef: RefObject<HTMLDivElement | null>
+  skillMentions: ComposerSkillMentions
+}) {
+  if (!skillMentions.open) return null
+  return (
+    <div
+      ref={panelRef}
+      id={skillMentions.listboxId}
+      role="listbox"
+      tabIndex={-1}
+      aria-label="Composer skills"
+      className={cn(
+        'pointer-events-auto w-[26.5rem] max-w-[calc(100vw-2rem)] scroll-py-1.5 rounded-xl border border-[color:var(--border-strong)] bg-[color:var(--panel)] p-1.5 shadow-[var(--shadow)]',
+        skillMentions.skills.length > 10 && 'max-h-72 overflow-y-auto',
+      )}
+    >
+      {skillMentions.skills.length > 0 ? (
+        skillMentions.skills.map((skill, index) => (
+          <SkillMentionOption
+            key={skill.filePath}
+            index={index}
+            selected={index === skillMentions.selectedIndex}
+            skill={skill}
+            skillMentions={skillMentions}
+          />
+        ))
+      ) : (
+        <div className="px-2 py-2 text-[12px] text-[color:var(--muted)]">
+          {skillMentions.loading ? 'Loading skills…' : 'No matching skills'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { createPortal } from 'react-dom'
 import { useHoverToFocus } from '../../../hooks/useHoverToFocus'
 import { compactIconButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
@@ -27,6 +28,7 @@ type ComposerTextFieldProps = {
   ariaActiveDescendant?: string | undefined
   ariaControls?: string | undefined
   reservedLineCount?: number
+  inlinePopover?: ReactNode
   trailingAdornment?: ReactNode
   readOnly?: boolean
   hoverToFocus?: boolean
@@ -164,6 +166,49 @@ function TrailingAdornment({
   )
 }
 
+function measureTextareaMarkerPosition(input: {
+  markerText: string
+  placeholder: string
+  textarea: HTMLTextAreaElement
+}) {
+  const computedStyle = window.getComputedStyle(input.textarea)
+  const mirror = document.createElement('div')
+  const marker = document.createElement('span')
+  const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 20
+
+  mirror.style.position = 'absolute'
+  mirror.style.visibility = 'hidden'
+  mirror.style.pointerEvents = 'none'
+  mirror.style.whiteSpace = 'pre-wrap'
+  mirror.style.overflowWrap = 'break-word'
+  mirror.style.wordBreak = 'break-word'
+  mirror.style.boxSizing = computedStyle.boxSizing
+  mirror.style.width = `${input.textarea.clientWidth}px`
+  mirror.style.font = computedStyle.font
+  mirror.style.fontFamily = computedStyle.fontFamily
+  mirror.style.fontSize = computedStyle.fontSize
+  mirror.style.fontWeight = computedStyle.fontWeight
+  mirror.style.letterSpacing = computedStyle.letterSpacing
+  mirror.style.lineHeight = computedStyle.lineHeight
+  mirror.style.padding = computedStyle.padding
+  mirror.style.border = computedStyle.border
+
+  mirror.textContent = input.markerText || input.placeholder || ''
+  marker.textContent = '\u200b'
+  mirror.appendChild(marker)
+  document.body.appendChild(mirror)
+
+  const mirrorRect = mirror.getBoundingClientRect()
+  const markerRect = marker.getBoundingClientRect()
+  document.body.removeChild(mirror)
+
+  return {
+    left: Math.max(0, markerRect.left - mirrorRect.left),
+    lineHeight,
+    top: Math.max(0, markerRect.top - mirrorRect.top),
+  }
+}
+
 export function ComposerTextField({
   value,
   placeholder,
@@ -174,6 +219,7 @@ export function ComposerTextField({
   ariaActiveDescendant,
   ariaControls,
   reservedLineCount = 4,
+  inlinePopover = null,
   trailingAdornment = null,
   readOnly = false,
   hoverToFocus = true,
@@ -190,9 +236,14 @@ export function ComposerTextField({
 }: ComposerTextFieldProps) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const inlinePopoverWrapperRef = useRef<HTMLDivElement>(null)
   const lastReportedHeightRef = useRef<number | null>(null)
   const [reservedHeight, setReservedHeight] = useState<number | null>(null)
   const [trailingAdornmentPosition, setTrailingAdornmentPosition] = useState<{
+    left: number
+    top: number
+  } | null>(null)
+  const [inlinePopoverPosition, setInlinePopoverPosition] = useState<{
     left: number
     top: number
   } | null>(null)
@@ -263,39 +314,14 @@ export function ComposerTextField({
     }
 
     const measureTrailingAdornmentPosition = () => {
-      const computedStyle = window.getComputedStyle(textarea)
-      const mirror = document.createElement('div')
-      const marker = document.createElement('span')
-      const lineHeight = Number.parseFloat(computedStyle.lineHeight) || lineHeightRef.current
-
-      mirror.style.position = 'absolute'
-      mirror.style.visibility = 'hidden'
-      mirror.style.pointerEvents = 'none'
-      mirror.style.whiteSpace = 'pre-wrap'
-      mirror.style.overflowWrap = 'break-word'
-      mirror.style.wordBreak = 'break-word'
-      mirror.style.boxSizing = computedStyle.boxSizing
-      mirror.style.width = `${textarea.clientWidth}px`
-      mirror.style.font = computedStyle.font
-      mirror.style.fontFamily = computedStyle.fontFamily
-      mirror.style.fontSize = computedStyle.fontSize
-      mirror.style.fontWeight = computedStyle.fontWeight
-      mirror.style.letterSpacing = computedStyle.letterSpacing
-      mirror.style.lineHeight = computedStyle.lineHeight
-      mirror.style.padding = computedStyle.padding
-      mirror.style.border = computedStyle.border
-
-      mirror.textContent = value || placeholder || ''
-      marker.textContent = '\u200b'
-      mirror.appendChild(marker)
-      document.body.appendChild(mirror)
-
-      const mirrorRect = mirror.getBoundingClientRect()
-      const markerRect = marker.getBoundingClientRect()
-      document.body.removeChild(mirror)
-
-      const markerLeft = Math.max(0, markerRect.left - mirrorRect.left)
-      const markerTop = Math.max(0, markerRect.top - mirrorRect.top)
+      const markerPosition = measureTextareaMarkerPosition({
+        markerText: value,
+        placeholder,
+        textarea,
+      })
+      const markerLeft = markerPosition.left
+      const markerTop = markerPosition.top
+      const lineHeight = markerPosition.lineHeight || lineHeightRef.current
       const adornmentWidth = 24
       const adornmentGap = 6
       const shouldWrapAdornment = markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth
@@ -322,6 +348,77 @@ export function ComposerTextField({
     window.addEventListener('resize', measureTrailingAdornmentPosition)
     return () => window.removeEventListener('resize', measureTrailingAdornmentPosition)
   }, [placeholder, trailingAdornment, value])
+
+  useLayoutEffect(() => {
+    if (!inlinePopover) {
+      setInlinePopoverPosition(null)
+      return
+    }
+
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const measureInlinePopoverPosition = () => {
+      const cursorPosition = textarea.selectionStart ?? value.length
+      const markerPosition = measureTextareaMarkerPosition({
+        markerText: value.slice(0, cursorPosition),
+        placeholder,
+        textarea,
+      })
+      const textareaRect = textarea.getBoundingClientRect()
+      const popoverHeight = inlinePopoverWrapperRef.current?.getBoundingClientRect().height ?? 288
+      const popoverWidth = 320
+      const gap = 8
+      const nextLeft = Math.max(
+        12,
+        Math.min(
+          window.innerWidth - popoverWidth - 12,
+          textareaRect.left + markerPosition.left + gap,
+        ),
+      )
+      const preferredTop =
+        textareaRect.top +
+        markerPosition.top -
+        textarea.scrollTop +
+        markerPosition.lineHeight / 2 -
+        popoverHeight / 2
+      const nextTop = Math.min(window.innerHeight - popoverHeight - 12, Math.max(12, preferredTop))
+      setInlinePopoverPosition((current) =>
+        current?.left === nextLeft && current.top === nextTop
+          ? current
+          : { left: nextLeft, top: nextTop },
+      )
+    }
+
+    measureInlinePopoverPosition()
+    window.addEventListener('resize', measureInlinePopoverPosition)
+    textarea.addEventListener('keyup', measureInlinePopoverPosition)
+    textarea.addEventListener('click', measureInlinePopoverPosition)
+    textarea.addEventListener('input', measureInlinePopoverPosition)
+    return () => {
+      window.removeEventListener('resize', measureInlinePopoverPosition)
+      textarea.removeEventListener('keyup', measureInlinePopoverPosition)
+      textarea.removeEventListener('click', measureInlinePopoverPosition)
+      textarea.removeEventListener('input', measureInlinePopoverPosition)
+    }
+  }, [inlinePopover, placeholder, value])
+
+  const inlinePopoverElement =
+    inlinePopover && inlinePopoverPosition && typeof document !== 'undefined'
+      ? createPortal(
+          <div
+            ref={inlinePopoverWrapperRef}
+            className="pointer-events-none fixed z-[120]"
+            style={{
+              left: `${inlinePopoverPosition.left}px`,
+              top: `${inlinePopoverPosition.top}px`,
+            }}
+          >
+            {inlinePopover}
+          </div>,
+          document.body,
+        )
+      : null
 
   return (
     <div
@@ -376,6 +473,7 @@ export function ComposerTextField({
           fieldExpanded={fieldExpanded}
           setFieldExpanded={setFieldExpanded}
         />
+        {inlinePopoverElement}
         <TrailingAdornment
           lineHeight={lineHeightRef.current}
           position={trailingAdornmentPosition}

--- a/src/app/components/workspace/composer/useComposerSkillMentions.ts
+++ b/src/app/components/workspace/composer/useComposerSkillMentions.ts
@@ -1,0 +1,150 @@
+import { type KeyboardEvent, useEffect, useMemo, useState } from 'react'
+import type { ComposerSkillReference } from '../../../desktop/types'
+import { getComposerSkillsQuery } from '../../../query/desktop-query'
+
+const skillMentionListboxId = 'composer-skill-mention-listbox'
+const skillMentionOptionPrefix = 'composer-skill-mention'
+const whitespaceCharacterPattern = /\s/
+const lastTokenPattern = /(?:^|\s)(\$\S*)$/
+
+export function getComposerSkillMentionOptionId(index: number) {
+  return `${skillMentionOptionPrefix}-${index}`
+}
+
+function getSkillMentionMatch(draft: string) {
+  const match = draft.match(lastTokenPattern)
+  const token = match?.[1]
+  if (!token) return null
+  const query = token.slice(1)
+  if (whitespaceCharacterPattern.test(query)) return null
+  return {
+    filter: query.toLowerCase(),
+    start: draft.length - token.length,
+  }
+}
+
+type UseComposerSkillMentionsOptions = {
+  draft: string
+  projectId: string
+  sessionPath: string | null
+  composerMode?: 'chat' | 'code'
+  setDraft: (draft: string) => void
+}
+
+export function useComposerSkillMentions({
+  draft,
+  projectId,
+  sessionPath,
+  composerMode = 'code',
+  setDraft,
+}: UseComposerSkillMentionsOptions) {
+  const [skills, setSkills] = useState<ComposerSkillReference[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [dismissedDraft, setDismissedDraft] = useState<string | null>(null)
+  const candidateMatch = getSkillMentionMatch(draft)
+  const filter = draft === dismissedDraft ? null : (candidateMatch?.filter ?? null)
+  const open = filter !== null
+
+  const filteredSkills = useMemo(() => {
+    if (filter === null) return []
+    return skills
+      .filter((skill) => skill.name.toLowerCase().includes(filter))
+      .sort((left, right) => left.name.localeCompare(right.name))
+  }, [filter, skills])
+
+  const selectSkill = (skill: ComposerSkillReference) => {
+    if (!candidateMatch) return
+    setDraft(`${draft.slice(0, candidateMatch.start)}$${skill.name} `)
+  }
+
+  const dismiss = (options?: { clearDraft?: boolean }) => {
+    setDismissedDraft(draft)
+    setSkills([])
+    setLoading(false)
+    setSelectedIndex(0)
+    if (options?.clearDraft) setDraft('')
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!open) return false
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      dismiss()
+      return true
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setSelectedIndex((current) => Math.min(current + 1, Math.max(0, filteredSkills.length - 1)))
+      return true
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setSelectedIndex((current) => Math.max(0, current - 1))
+      return true
+    }
+    const selectedSkill = filteredSkills[selectedIndex]
+    if ((event.key === 'Tab' || event.key === 'Enter') && !event.shiftKey && selectedSkill) {
+      event.preventDefault()
+      selectSkill(selectedSkill)
+      return true
+    }
+    return false
+  }
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedIndex(0)
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setSkills([])
+    setSelectedIndex(0)
+    setLoading(true)
+    void getComposerSkillsQuery({ projectId, sessionPath, composerMode })
+      .then((nextSkills) => {
+        if (!cancelled) setSkills(nextSkills)
+      })
+      .catch(() => {
+        if (!cancelled) setSkills([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [composerMode, open, projectId, sessionPath])
+
+  useEffect(() => {
+    if (selectedIndex >= filteredSkills.length) {
+      setSelectedIndex(Math.max(0, filteredSkills.length - 1))
+    }
+  }, [filteredSkills.length, selectedIndex])
+
+  useEffect(() => {
+    if (dismissedDraft !== null && draft !== dismissedDraft) setDismissedDraft(null)
+  }, [dismissedDraft, draft])
+
+  return {
+    activeDescendantId: open
+      ? filteredSkills[selectedIndex]
+        ? getComposerSkillMentionOptionId(selectedIndex)
+        : undefined
+      : undefined,
+    dismiss,
+    handleKeyDown,
+    listboxId: skillMentionListboxId,
+    loading,
+    open,
+    selectedIndex,
+    selectSkill,
+    setSelectedIndex,
+    skills: filteredSkills,
+  }
+}
+
+export type ComposerSkillMentions = ReturnType<typeof useComposerSkillMentions>

--- a/src/app/components/workspace/inbox/inbox-composer.tsx
+++ b/src/app/components/workspace/inbox/inbox-composer.tsx
@@ -24,6 +24,7 @@ import { ComposerPromptInputPanel } from '../composer/composer-prompt-input-pane
 import { useComposerAttachmentPicker } from '../composer/useComposerAttachmentPicker'
 import { useComposerClipboardHandlers } from '../composer/useComposerClipboardHandlers'
 import { useComposerDictation } from '../composer/useComposerDictation'
+import { useComposerSkillMentions } from '../composer/useComposerSkillMentions'
 import { useComposerSlashCommands } from '../composer/useComposerSlashCommands'
 import {
   workspaceFooterRowClass,
@@ -107,6 +108,7 @@ export function InboxComposer({
   const modelButtonRef = useRef<HTMLButtonElement>(null)
   const modelMenuRef = useRef<HTMLDivElement>(null)
   const slashCommandPanelRef = useRef<HTMLDivElement>(null)
+  const skillMentionPanelRef = useRef<HTMLDivElement>(null)
   const draftValueRef = useRef(draft)
   const attachmentsRef = useRef(attachments)
   const sendLockRef = useRef(false)
@@ -251,6 +253,15 @@ export function InboxComposer({
   const slashCommandListSignature = slashCommands.commands
     .map((command) => `${command.source}:${command.name}`)
     .join('|')
+  const skillMentions = useComposerSkillMentions({
+    draft,
+    projectId: thread.projectId,
+    sessionPath: thread.sessionPath,
+    setDraft: setDraftValue,
+  })
+  const skillMentionListSignature = skillMentions.skills
+    .map((skill) => `${skill.name}:${skill.filePath}`)
+    .join('|')
   const { handlePaste } = useComposerClipboardHandlers({
     setAttachments: setAttachmentValue,
     setDraftValue,
@@ -258,13 +269,13 @@ export function InboxComposer({
   })
 
   useEffect(() => {
-    if (slashCommands.open) {
+    if (slashCommands.open || skillMentions.open) {
       setOpenMenu((current) => (current === 'picker' ? null : current))
     }
-  }, [slashCommands.open])
+  }, [skillMentions.open, slashCommands.open])
 
   useEffect(() => {
-    if (!slashCommands.open) {
+    if (!(slashCommands.open || skillMentions.open)) {
       return
     }
 
@@ -277,12 +288,14 @@ export function InboxComposer({
 
       if (
         slashCommandPanelRef.current?.contains(target) ||
+        skillMentionPanelRef.current?.contains(target) ||
         composerSurfaceRef.current?.contains(target)
       ) {
         return
       }
 
-      slashCommands.dismiss({ clearDraft: true })
+      if (slashCommands.open) slashCommands.dismiss({ clearDraft: true })
+      if (skillMentions.open) skillMentions.dismiss()
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -292,7 +305,8 @@ export function InboxComposer({
 
       event.preventDefault()
       event.stopImmediatePropagation()
-      slashCommands.dismiss()
+      if (slashCommands.open) slashCommands.dismiss()
+      if (skillMentions.open) skillMentions.dismiss()
     }
 
     window.addEventListener('pointerdown', handlePointerDown, true)
@@ -301,7 +315,7 @@ export function InboxComposer({
       window.removeEventListener('pointerdown', handlePointerDown, true)
       window.removeEventListener('keydown', handleKeyDown, true)
     }
-  }, [slashCommands])
+  }, [skillMentions, slashCommands])
 
   useEffect(() => {
     if (!(slashCommands.open && slashCommands.activeDescendantId)) {
@@ -339,6 +353,28 @@ export function InboxComposer({
     slashCommands.activeDescendantId,
     slashCommands.selectedIndex,
     slashCommandListSignature,
+  ])
+
+  useEffect(() => {
+    if (!(skillMentions.open && skillMentions.activeDescendantId)) {
+      return
+    }
+
+    void skillMentionListSignature
+
+    const panel = skillMentionPanelRef.current
+    const option = panel?.querySelector<HTMLElement>(`#${skillMentions.activeDescendantId}`)
+    if (!(panel && option)) return
+    if (skillMentions.selectedIndex === 0) {
+      panel.scrollTop = 0
+      return
+    }
+    option.scrollIntoView({ block: 'nearest' })
+  }, [
+    skillMentionListSignature,
+    skillMentions.activeDescendantId,
+    skillMentions.open,
+    skillMentions.selectedIndex,
   ])
 
   const compact = async () => {
@@ -465,6 +501,8 @@ export function InboxComposer({
             projectId={thread.projectId}
             slashCommandPanelRef={slashCommandPanelRef}
             slashCommands={slashCommands}
+            skillMentionPanelRef={skillMentionPanelRef}
+            skillMentions={skillMentions}
             showDictationButton={showDictationButton}
             attachPickerAttachments={attachPickerAttachments}
             cancelDictation={cancelDictation}

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -15,6 +15,7 @@ export type {
   ComposerFilePickerState,
   ComposerModel,
   ComposerQueuedPrompt,
+  ComposerSkillReference,
   ComposerSlashCommand,
   ComposerSlashCommandSource,
   ComposerState,

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -147,6 +147,7 @@ export function installDevWebDesktopBridge() {
       invokeRequest('listComposerAttachmentEntries', request),
     getComposerState: (request = {}) => invokeRequest('getComposerState', request),
     getComposerSlashCommands: (request = {}) => invokeRequest('getComposerSlashCommands', request),
+    getComposerSkills: (request = {}) => invokeRequest('getComposerSkills', request),
     getDictationState: () => invokeRequest('getDictationState', {}),
     listDictationModels: () => invokeRequest('listDictationModels', {}),
     installDictationModel: (modelId: 'tiny.en' | 'base.en' | 'small.en') =>

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -169,6 +169,10 @@ export async function getComposerSlashCommandsQuery(
   return (await window.piDesktop?.getComposerSlashCommands?.(request)) ?? fallbackAppSlashCommands
 }
 
+export async function getComposerSkillsQuery(request: ComposerStateRequest = {}) {
+  return (await window.piDesktop?.getComposerSkills?.(request)) ?? []
+}
+
 export async function getProjectGitStateQuery(projectId: string): Promise<ProjectGitState | null> {
   return (await window.piDesktop?.getProjectGitState?.(projectId)) ?? null
 }

--- a/src/electron/main/ipc/request-handlers/pi-threads.ts
+++ b/src/electron/main/ipc/request-handlers/pi-threads.ts
@@ -12,6 +12,7 @@ type PiThreadsRequestHandlers = Pick<
   | 'listProjectCommits'
   | 'getComposerState'
   | 'getComposerSlashCommands'
+  | 'getComposerSkills'
   | 'getDictationState'
   | 'listDictationModels'
   | 'installDictationModel'
@@ -46,6 +47,7 @@ export function createPiThreadsHandlers(piThreads: PiThreadsModule): PiThreadsRe
       piThreads.listProjectCommits(projectId, limit ?? null),
     getComposerState: (request) => piThreads.loadComposerState(request),
     getComposerSlashCommands: (request) => piThreads.loadComposerSlashCommands(request),
+    getComposerSkills: (request) => piThreads.loadComposerSkills(request),
     getDictationState: () => piThreads.getDictationState(),
     listDictationModels: () => piThreads.listDictationModels(),
     installDictationModel: (request) => piThreads.installDictationModel(request),

--- a/src/electron/main/runtime/desktop-runtime-contracts.ts
+++ b/src/electron/main/runtime/desktop-runtime-contracts.ts
@@ -5,6 +5,7 @@ import type {
   Artifact,
   ArtifactVersion,
   ChatSidebarState,
+  ComposerSkillReference,
   ComposerSlashCommand,
   ComposerState,
   ComposerStateRequest,
@@ -52,6 +53,7 @@ export type PiThreadsModule = {
   loadInboxThreadList: () => Promise<InboxThread[]>
   loadComposerState: (request: ComposerStateRequest) => Promise<ComposerState>
   loadComposerSlashCommands: (request: ComposerStateRequest) => Promise<ComposerSlashCommand[]>
+  loadComposerSkills: (request: ComposerStateRequest) => Promise<ComposerSkillReference[]>
   getDictationState: () => Promise<DictationState>
   listDictationModels: () => Promise<DictationModelSummary[]>
   installDictationModel: (request: {

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -113,6 +113,7 @@ export function createDesktopApi() {
       invokeRequest('listComposerAttachmentEntries', request),
     getComposerState: (request = {}) => invokeRequest('getComposerState', request),
     getComposerSlashCommands: (request = {}) => invokeRequest('getComposerSlashCommands', request),
+    getComposerSkills: (request = {}) => invokeRequest('getComposerSkills', request),
     getDictationState: () => invokeRequest('getDictationState', {}),
     listDictationModels: () => invokeRequest('listDictationModels', {}),
     installDictationModel: (modelId: 'tiny.en' | 'base.en' | 'small.en') =>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,6 +8,7 @@ import type {
   ChatSidebarState,
   ComposerAttachment,
   ComposerFilePickerState,
+  ComposerSkillReference,
   ComposerSlashCommand,
   ComposerState,
   ComposerStateRequest,
@@ -144,6 +145,7 @@ declare global {
       }) => Promise<ComposerFilePickerState>
       getComposerState?: (request?: ComposerStateRequest) => Promise<ComposerState>
       getComposerSlashCommands?: (request?: ComposerStateRequest) => Promise<ComposerSlashCommand[]>
+      getComposerSkills?: (request?: ComposerStateRequest) => Promise<ComposerSkillReference[]>
       getDictationState?: () => Promise<DictationState>
       listDictationModels?: () => Promise<DictationModelSummary[]>
       installDictationModel?: (


### PR DESCRIPTION
## Summary
- Add `$skill` autocomplete to the composer and inbox composer, independent of slash-command skill settings.
- Resolve `$skill` references in composer sends into lightweight SKILL.md path hints while preserving the original user request.
- Improve compact viewport placement for attachment/model popovers and add caret-positioned skill picker UI.

## Details
- Adds a `getComposerSkills` desktop/runtime API that reads skills from the current Pi session resources without requiring `/skill:` command registration.
- Supports multiple `$skill-name` references in a prompt and de-duplicates injected skill paths.
- Skill picker matches model picker list sizing behavior and uses the standard app font.

## Validation
- `bun run ai:check`
