### PR TITLE
Add fuzzy @ file mentions in composer

### DIFF
--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -18,7 +18,10 @@ import type {
 } from '../shared/desktop-ipc'
 import { getDesktopWorkingDirectory } from '../shared/desktop-working-directory'
 import { getSafeExternalUrl } from '../shared/external-url'
-import { listComposerAttachmentEntries } from '../src/desktop-host/composer-attachments'
+import {
+  listComposerAttachmentEntries,
+  searchComposerAttachmentEntries,
+} from '../src/desktop-host/composer-attachments'
 
 function getProcessEnvironmentVariable(name: string) {
   return process.env[name]
@@ -135,6 +138,7 @@ const handlers: DesktopRequestHandlerMap = {
     return Object.fromEntries(entries)
   },
   listComposerAttachmentEntries: (request) => listComposerAttachmentEntries(request),
+  searchComposerAttachmentEntries: (request) => searchComposerAttachmentEntries(request),
   getComposerState: (request) => piThreads.loadComposerState(request),
   getComposerSlashCommands: (request) => piThreads.loadComposerSlashCommands(request),
   getComposerSkills: (request) => piThreads.loadComposerSkills(request),

--- a/shared/desktop-composer-contracts.ts
+++ b/shared/desktop-composer-contracts.ts
@@ -73,6 +73,10 @@ export type ComposerFilePickerState = {
   entries: ComposerFilePickerEntry[]
 }
 
+export type ComposerFileSearchEntry = ComposerFilePickerEntry & {
+  relativePath: string
+}
+
 export type ComposerStateRequest = {
   projectId?: string | undefined | null | undefined
   sessionPath?: string | undefined | null | undefined

--- a/shared/desktop-contracts.ts
+++ b/shared/desktop-contracts.ts
@@ -27,6 +27,7 @@ export type {
   ComposerContextUsage,
   ComposerFilePickerEntry,
   ComposerFilePickerState,
+  ComposerFileSearchEntry,
   ComposerModel,
   ComposerQueuedPrompt,
   ComposerSkillReference,

--- a/shared/desktop-data-contracts.ts
+++ b/shared/desktop-data-contracts.ts
@@ -15,6 +15,7 @@ export type {
   ComposerContextUsage,
   ComposerFilePickerEntry,
   ComposerFilePickerState,
+  ComposerFileSearchEntry,
   ComposerModel,
   ComposerQueuedPrompt,
   ComposerSkillReference,

--- a/shared/desktop-ipc.ts
+++ b/shared/desktop-ipc.ts
@@ -8,6 +8,7 @@ import type {
   ChatSidebarState,
   ComposerAttachment,
   ComposerFilePickerState,
+  ComposerFileSearchEntry,
   ComposerSkillReference,
   ComposerSlashCommand,
   ComposerState,
@@ -185,6 +186,14 @@ export type DesktopRequestMap = {
       rootPath?: string | undefined | null | undefined
     }
     response: ComposerFilePickerState
+  }
+  searchComposerAttachmentEntries: {
+    params: {
+      projectId?: string | undefined | null | undefined
+      query?: string | undefined | null | undefined
+      limit?: number | undefined | null | undefined
+    }
+    response: ComposerFileSearchEntry[]
   }
   getComposerState: { params: ComposerStateRequest; response: ComposerState }
   getComposerSlashCommands: { params: ComposerStateRequest; response: ComposerSlashCommand[] }

--- a/src/app/components/workspace/composer/composer-file-mention-panel.tsx
+++ b/src/app/components/workspace/composer/composer-file-mention-panel.tsx
@@ -1,0 +1,82 @@
+import { File, Folder } from 'lucide-react'
+import type { RefObject } from 'react'
+import { cn } from '../../../utils/cn'
+import {
+  type ComposerFileMentions,
+  getComposerFileMentionOptionId,
+} from './useComposerFileMentions'
+
+function FileMentionOption({
+  file,
+  fileMentions,
+  index,
+  selected,
+}: {
+  file: ComposerFileMentions['files'][number]
+  fileMentions: ComposerFileMentions
+  index: number
+  selected: boolean
+}) {
+  const Icon = file.kind === 'directory' ? Folder : File
+  return (
+    <button
+      id={getComposerFileMentionOptionId(index)}
+      type="button"
+      role="option"
+      aria-selected={selected}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left',
+        selected
+          ? 'bg-[color:var(--accent-bg)] text-[color:var(--text)]'
+          : 'text-[color:var(--muted)] hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]',
+      )}
+      onPointerEnter={() => fileMentions.setSelectedIndex(index)}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => fileMentions.selectFile(file)}
+    >
+      <Icon size={13} className="shrink-0 text-[color:var(--muted)]" />
+      <span className="min-w-0 flex-1 truncate text-[12px] text-[color:var(--text)]">
+        {file.relativePath}
+      </span>
+    </button>
+  )
+}
+
+export function ComposerFileMentionPanel({
+  fileMentions,
+  panelRef,
+}: {
+  fileMentions: ComposerFileMentions
+  panelRef: RefObject<HTMLDivElement | null>
+}) {
+  if (!fileMentions.open) return null
+  return (
+    <div
+      ref={panelRef}
+      id={fileMentions.listboxId}
+      role="listbox"
+      tabIndex={-1}
+      aria-label="Composer files"
+      className={cn(
+        'pointer-events-auto w-[26.5rem] max-w-[calc(100vw-2rem)] scroll-py-1.5 rounded-xl border border-[color:var(--border-strong)] bg-[color:var(--panel)] p-1.5 shadow-[var(--shadow)]',
+        fileMentions.files.length > 10 && 'max-h-72 overflow-y-auto',
+      )}
+    >
+      {fileMentions.files.length > 0 ? (
+        fileMentions.files.map((file, index) => (
+          <FileMentionOption
+            key={file.path}
+            file={file}
+            fileMentions={fileMentions}
+            index={index}
+            selected={index === fileMentions.selectedIndex}
+          />
+        ))
+      ) : (
+        <div className="px-2 py-2 text-[12px] text-[color:var(--muted)]">
+          {fileMentions.loading ? 'Finding files…' : 'No matching files'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/components/workspace/composer/composer-file-picker-attachments-panel.tsx
+++ b/src/app/components/workspace/composer/composer-file-picker-attachments-panel.tsx
@@ -11,6 +11,7 @@ import {
 
 type ComposerFilePickerAttachmentsPanelProps = {
   attachments: ComposerAttachment[]
+  className?: string
   draggedAttachments: ComposerAttachment[]
   dropActive: boolean
   onDragActiveChange: (active: boolean) => void
@@ -32,6 +33,7 @@ function getOpenAttachmentIcon(attachment: ComposerAttachment) {
 
 export function ComposerFilePickerAttachmentsPanel({
   attachments,
+  className,
   draggedAttachments,
   dropActive,
   onDragActiveChange,
@@ -44,6 +46,7 @@ export function ComposerFilePickerAttachmentsPanel({
       className={cn(
         'min-h-0 overflow-x-hidden overflow-y-auto border-r border-[rgba(169,178,215,0.08)] bg-[rgba(255,255,255,0.015)] py-2 pr-0 pl-2',
         dropActive && 'bg-[rgba(255,255,255,0.04)]',
+        className,
       )}
       onDragOver={(event) => {
         event.preventDefault()
@@ -57,12 +60,12 @@ export function ComposerFilePickerAttachmentsPanel({
       }}
       onDrop={onDrop}
     >
-      <div className="grid min-h-full content-start gap-0">
+      <div className="grid min-h-full content-start gap-0 max-[520px]:min-h-0 max-[520px]:gap-1">
         {attachments.length > 0 ? (
           attachments.map((attachment) => (
             <div
               key={attachment.path}
-              className="flex h-5 items-center gap-1 rounded-sm border border-transparent bg-transparent px-1.5 text-[10.5px] text-[color:var(--text)] transition-colors hover:border-[rgba(169,178,215,0.08)] hover:bg-[rgba(255,255,255,0.04)]"
+              className="flex h-5 min-w-0 items-center gap-1 rounded-sm border border-transparent bg-transparent px-1.5 text-[10.5px] text-[color:var(--text)] transition-colors hover:border-[rgba(169,178,215,0.08)] hover:bg-[rgba(255,255,255,0.04)]"
               title={attachment.path}
             >
               <button
@@ -73,7 +76,7 @@ export function ComposerFilePickerAttachmentsPanel({
               >
                 {getOpenAttachmentIcon(attachment)}
               </button>
-              <span className="min-w-0 max-w-[20ch] flex-1 truncate leading-none">
+              <span className="min-w-0 flex-1 truncate leading-none">
                 {getAttachmentDisplayLabel(attachment)}
               </span>
               <button

--- a/src/app/components/workspace/composer/composer-file-picker-file-grid.tsx
+++ b/src/app/components/workspace/composer/composer-file-picker-file-grid.tsx
@@ -5,6 +5,7 @@ import { FileEntryButton } from './file-entry-button'
 
 type ComposerFilePickerFileGridProps = {
   attachedByPath: Set<string>
+  className?: string
   entries: ComposerFilePickerState['entries']
   loading: boolean
   picker: ComposerFilePickerState | null
@@ -18,6 +19,7 @@ type ComposerFilePickerFileGridProps = {
 
 export function ComposerFilePickerFileGrid({
   attachedByPath,
+  className,
   entries,
   loading,
   picker,
@@ -29,13 +31,18 @@ export function ComposerFilePickerFileGrid({
   onToggleFile,
 }: ComposerFilePickerFileGridProps) {
   return (
-    <div className="min-h-0 overflow-x-hidden overflow-y-auto p-2 pt-1">
+    <div className={cn('min-h-0 w-full overflow-x-hidden overflow-y-auto p-2 pt-1', className)}>
       {!picker && loading ? (
         <div className="px-2 py-8 text-center text-[12px] text-[color:var(--muted)]">
           Loading files…
         </div>
       ) : entries.length > 0 ? (
-        <div className={cn('grid grid-cols-3 gap-1', loading && 'pointer-events-none opacity-70')}>
+        <div
+          className={cn(
+            'grid w-full grid-cols-3 gap-1 max-[640px]:grid-cols-2',
+            loading && 'pointer-events-none opacity-70',
+          )}
+        >
           {entries.map((entry) => {
             const attachment: ComposerAttachment = {
               path: entry.path,

--- a/src/app/components/workspace/composer/composer-file-picker.tsx
+++ b/src/app/components/workspace/composer/composer-file-picker.tsx
@@ -112,6 +112,7 @@ export function ComposerFilePicker({
     () => filterFilePickerEntries(picker?.entries ?? [], searchQuery),
     [picker?.entries, searchQuery],
   )
+  const showAttachmentsPanel = attachments.length > 0 || draggedAttachments.length > 0 || dropActive
 
   const handleEntryDragStart = (
     attachment: ComposerAttachment,
@@ -226,15 +227,24 @@ export function ComposerFilePicker({
         onSearchQueryChange={setSearchQuery}
       />
 
-      <div className="grid min-h-0 grid-cols-[minmax(120px,0.25fr)_minmax(0,0.75fr)] overflow-hidden">
-        <ComposerFilePickerAttachmentsPanel
-          attachments={attachments}
-          draggedAttachments={draggedAttachments}
-          dropActive={dropActive}
-          onDragActiveChange={setDropActive}
-          onDrop={handleDropIntoAttachments}
-          onRemoveAttachment={onRemoveAttachment}
-        />
+      <div
+        className={cn(
+          'grid min-h-0 overflow-hidden',
+          showAttachmentsPanel
+            ? 'w-full grid-cols-[minmax(7.5rem,0.34fr)_minmax(0,1fr)]'
+            : 'grid-cols-1',
+        )}
+      >
+        {showAttachmentsPanel ? (
+          <ComposerFilePickerAttachmentsPanel
+            attachments={attachments}
+            draggedAttachments={draggedAttachments}
+            dropActive={dropActive}
+            onDragActiveChange={setDropActive}
+            onDrop={handleDropIntoAttachments}
+            onRemoveAttachment={onRemoveAttachment}
+          />
+        ) : null}
 
         <ComposerFilePickerFileGrid
           attachedByPath={attachedByPath}

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -4,6 +4,7 @@ import type { ComposerAttachment, DesktopActionInvoker } from '../../../desktop/
 import { getPathForFileQuery } from '../../../query/desktop-query'
 import { cn } from '../../../utils/cn'
 import { ComposerDictationControls } from './composer-dictation-controls'
+import { ComposerFileMentionPanel } from './composer-file-mention-panel'
 import { ComposerFilePicker } from './composer-file-picker'
 import {
   getComposerAttachmentsFromClipboardData,
@@ -11,6 +12,7 @@ import {
 } from './composer-paste-attachments'
 import { ComposerSkillMentionPanel } from './composer-skill-mention-panel'
 import { ComposerTextField } from './composer-text-field'
+import type { ComposerFileMentions } from './useComposerFileMentions'
 import type { ComposerSkillMentions } from './useComposerSkillMentions'
 import {
   type ComposerSlashCommands,
@@ -115,6 +117,7 @@ type ComposerKeyDownInput = {
   onEscapeOverride?: (() => boolean) | undefined
   onSubmitOverride?: (() => boolean) | undefined
   slashCommands: ComposerSlashCommands
+  fileMentions: ComposerFileMentions
   skillMentions: ComposerSkillMentions
   setDraft: (value: string) => void
 }
@@ -134,7 +137,11 @@ function handleOpenAutocompleteKeyDown(
   event: KeyboardEvent<HTMLTextAreaElement>,
   input: ComposerKeyDownInput,
 ) {
-  return input.slashCommands.handleKeyDown(event) || input.skillMentions.handleKeyDown(event)
+  return (
+    input.slashCommands.handleKeyDown(event) ||
+    input.fileMentions.handleKeyDown(event) ||
+    input.skillMentions.handleKeyDown(event)
+  )
 }
 
 function handleDeleteTextKey(
@@ -250,6 +257,8 @@ type ComposerPromptInputPanelProps = {
   projectId: string
   slashCommandPanelRef: RefObject<HTMLDivElement | null>
   slashCommands: ComposerSlashCommands
+  fileMentionPanelRef: RefObject<HTMLDivElement | null>
+  fileMentions: ComposerFileMentions
   skillMentionPanelRef: RefObject<HTMLDivElement | null>
   skillMentions: ComposerSkillMentions
   showDictationButton: boolean
@@ -298,6 +307,8 @@ export function ComposerPromptInputPanel({
   projectId,
   slashCommandPanelRef,
   slashCommands,
+  fileMentionPanelRef,
+  fileMentions,
   skillMentionPanelRef,
   skillMentions,
   showDictationButton,
@@ -356,6 +367,7 @@ export function ComposerPromptInputPanel({
                     clearError,
                     dictationActive,
                     dictationTranscribing,
+                    fileMentions,
                     inputLocked,
                     onArrowNavigationOverride,
                     onEscapeOverride,
@@ -390,14 +402,18 @@ export function ComposerPromptInputPanel({
                 }}
                 ariaLabel="Prompt composer"
                 ariaActiveDescendant={
-                  slashCommands.activeDescendantId ?? skillMentions.activeDescendantId
+                  slashCommands.activeDescendantId ??
+                  fileMentions.activeDescendantId ??
+                  skillMentions.activeDescendantId
                 }
                 ariaControls={
                   slashCommands.open
                     ? slashCommands.listboxId
-                    : skillMentions.open
-                      ? skillMentions.listboxId
-                      : undefined
+                    : fileMentions.open
+                      ? fileMentions.listboxId
+                      : skillMentions.open
+                        ? skillMentions.listboxId
+                        : undefined
                 }
                 placeholder={placeholderText}
                 readOnly={inputLocked}
@@ -408,7 +424,12 @@ export function ComposerPromptInputPanel({
                 statusMessage={errorMessage && draft.length > 0 ? errorMessage : null}
                 reservedLineCount={1}
                 inlinePopover={
-                  skillMentions.open ? (
+                  fileMentions.open ? (
+                    <ComposerFileMentionPanel
+                      fileMentions={fileMentions}
+                      panelRef={fileMentionPanelRef}
+                    />
+                  ) : skillMentions.open ? (
                     <ComposerSkillMentionPanel
                       panelRef={skillMentionPanelRef}
                       skillMentions={skillMentions}

--- a/src/app/components/workspace/composer/composer-prompt-surface.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-surface.tsx
@@ -8,6 +8,7 @@ import { ComposerFooter } from './composer-footer'
 import { hasFilePayloadInClipboardData } from './composer-paste-attachments'
 import { ComposerPromptInputPanel } from './composer-prompt-input-panel'
 import { useComposerController } from './controller/useComposerController'
+import { useComposerFileMentions } from './useComposerFileMentions'
 import { useComposerSkillMentions } from './useComposerSkillMentions'
 import { useComposerSlashCommands } from './useComposerSlashCommands'
 
@@ -147,6 +148,7 @@ export function ComposerPromptSurface({
   const dictationTranscribing = dictationInterimText.length > 0
   const composerMode = activeView === 'chat' ? 'chat' : 'code'
   const slashCommandPanelRef = useRef<HTMLDivElement>(null)
+  const fileMentionPanelRef = useRef<HTMLDivElement>(null)
   const skillMentionPanelRef = useRef<HTMLDivElement>(null)
   const stopButtonBoundaryRef = useRef<HTMLDivElement>(null)
   const askQuestionsOverlayRef = useRef<HTMLDivElement>(null)
@@ -186,9 +188,18 @@ export function ComposerPromptSurface({
   const skillMentionListSignature = skillMentions.skills
     .map((skill) => `${skill.name}:${skill.filePath}`)
     .join('|')
+  const fileMentions = useComposerFileMentions({
+    draft,
+    projectId,
+    setDraft,
+    attachAttachments: attachPickerAttachments,
+  })
+  const fileMentionListSignature = fileMentions.files
+    .map((file) => `${file.kind}:${file.path}`)
+    .join('|')
 
   useEffect(() => {
-    if (!(slashCommands.open || skillMentions.open)) {
+    if (!(slashCommands.open || fileMentions.open || skillMentions.open)) {
       return
     }
 
@@ -197,6 +208,7 @@ export function ComposerPromptSurface({
       if (
         !target ||
         slashCommandPanelRef.current?.contains(target) ||
+        fileMentionPanelRef.current?.contains(target) ||
         skillMentionPanelRef.current?.contains(target) ||
         composerPanelRef.current?.contains(target) ||
         stopButtonBoundaryRef.current?.contains(target)
@@ -205,6 +217,7 @@ export function ComposerPromptSurface({
       }
 
       if (slashCommands.open) slashCommands.dismiss({ clearDraft: true })
+      if (fileMentions.open) fileMentions.dismiss()
       if (skillMentions.open) skillMentions.dismiss()
     }
 
@@ -212,7 +225,7 @@ export function ComposerPromptSurface({
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown, true)
     }
-  }, [composerPanelRef, skillMentions, slashCommands])
+  }, [composerPanelRef, fileMentions, skillMentions, slashCommands])
 
   useEffect(() => {
     if (!(slashCommands.open && slashCommands.activeDescendantId)) {
@@ -252,6 +265,24 @@ export function ComposerPromptSurface({
     slashCommands.activeDescendantId,
     slashCommands.selectedIndex,
     slashCommandListSignature,
+  ])
+
+  useEffect(() => {
+    if (!(fileMentions.open && fileMentions.activeDescendantId)) return
+    void fileMentionListSignature
+    const panel = fileMentionPanelRef.current
+    const option = panel?.querySelector<HTMLElement>(`#${fileMentions.activeDescendantId}`)
+    if (!(panel && option)) return
+    if (fileMentions.selectedIndex === 0) {
+      panel.scrollTop = 0
+      return
+    }
+    option.scrollIntoView({ block: 'nearest' })
+  }, [
+    fileMentionListSignature,
+    fileMentions.activeDescendantId,
+    fileMentions.open,
+    fileMentions.selectedIndex,
   ])
 
   useEffect(() => {
@@ -480,6 +511,8 @@ export function ComposerPromptSurface({
               projectId={projectId}
               slashCommandPanelRef={slashCommandPanelRef}
               slashCommands={slashCommands}
+              fileMentionPanelRef={fileMentionPanelRef}
+              fileMentions={fileMentions}
               skillMentionPanelRef={skillMentionPanelRef}
               skillMentions={skillMentions}
               showDictationButton={showDictationButton}

--- a/src/app/components/workspace/composer/file-entry-button.tsx
+++ b/src/app/components/workspace/composer/file-entry-button.tsx
@@ -42,7 +42,7 @@ export function FileEntryButton({
       type="button"
       draggable={!isAlreadyAttached}
       className={cn(
-        'flex h-8 min-w-0 items-center gap-1 rounded-lg border border-transparent bg-transparent px-2 text-left text-[12px] text-[color:var(--text)] transition-colors',
+        'flex h-8 min-w-0 w-full items-center gap-1 rounded-lg border border-transparent bg-transparent px-2 text-left text-[12px] text-[color:var(--text)] transition-colors',
         isAlreadyAttached && 'border-[rgba(169,178,215,0.08)] bg-[rgba(255,255,255,0.05)]',
         isAlreadyAttached &&
           'cursor-default text-[color:var(--muted)] hover:border-transparent hover:bg-transparent',

--- a/src/app/components/workspace/composer/useComposerFileMentions.ts
+++ b/src/app/components/workspace/composer/useComposerFileMentions.ts
@@ -1,0 +1,150 @@
+import { type KeyboardEvent, useEffect, useMemo, useState } from 'react'
+import type { ComposerAttachment, ComposerFileSearchEntry } from '../../../desktop/types'
+import { searchComposerAttachmentEntriesQuery } from '../../../query/desktop-query'
+
+const fileMentionListboxId = 'composer-file-mention-listbox'
+const fileMentionOptionPrefix = 'composer-file-mention'
+const lastTokenPattern = /(?:^|\s)(@[^\s]*)$/
+
+export function getComposerFileMentionOptionId(index: number) {
+  return `${fileMentionOptionPrefix}-${index}`
+}
+
+function getFileMentionMatch(draft: string) {
+  const match = draft.match(lastTokenPattern)
+  const token = match?.[1]
+  if (!token) return null
+  return {
+    filter: token.slice(1),
+    start: draft.length - token.length,
+  }
+}
+
+type UseComposerFileMentionsOptions = {
+  draft: string
+  projectId: string
+  setDraft: (draft: string) => void
+  attachAttachments: (attachments: ComposerAttachment[], options?: { closeMenu?: boolean }) => void
+}
+
+function toAttachment(entry: ComposerFileSearchEntry): ComposerAttachment {
+  return {
+    path: entry.path,
+    name: entry.name,
+    kind: entry.kind,
+  }
+}
+
+export function useComposerFileMentions({
+  draft,
+  projectId,
+  setDraft,
+  attachAttachments,
+}: UseComposerFileMentionsOptions) {
+  const [files, setFiles] = useState<ComposerFileSearchEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [dismissedDraft, setDismissedDraft] = useState<string | null>(null)
+  const candidateMatch = getFileMentionMatch(draft)
+  const filter = draft === dismissedDraft ? null : (candidateMatch?.filter ?? null)
+  const open = filter !== null
+
+  const visibleFiles = useMemo(() => files, [files])
+
+  const selectFile = (file: ComposerFileSearchEntry) => {
+    if (!candidateMatch) return
+    attachAttachments([toAttachment(file)], { closeMenu: false })
+    setDraft(
+      `${draft.slice(0, candidateMatch.start)}@${file.relativePath} ${draft.slice(candidateMatch.start + candidateMatch.filter.length + 1)}`,
+    )
+    dismiss()
+  }
+
+  const dismiss = (options?: { clearDraft?: boolean }) => {
+    setDismissedDraft(draft)
+    setFiles([])
+    setLoading(false)
+    setSelectedIndex(0)
+    if (options?.clearDraft) setDraft('')
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!open) return false
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      dismiss()
+      return true
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setSelectedIndex((current) => Math.min(current + 1, Math.max(0, visibleFiles.length - 1)))
+      return true
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setSelectedIndex((current) => Math.max(0, current - 1))
+      return true
+    }
+    const selectedFile = visibleFiles[selectedIndex]
+    if ((event.key === 'Tab' || event.key === 'Enter') && !event.shiftKey && selectedFile) {
+      event.preventDefault()
+      selectFile(selectedFile)
+      return true
+    }
+    return false
+  }
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedIndex(0)
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    void searchComposerAttachmentEntriesQuery({ projectId, query: filter, limit: 60 })
+      .then((nextFiles) => {
+        if (!cancelled) setFiles(nextFiles)
+      })
+      .catch(() => {
+        if (!cancelled) setFiles([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [filter, open, projectId])
+
+  useEffect(() => {
+    if (selectedIndex >= visibleFiles.length) {
+      setSelectedIndex(Math.max(0, visibleFiles.length - 1))
+    }
+  }, [selectedIndex, visibleFiles.length])
+
+  useEffect(() => {
+    if (dismissedDraft !== null && draft !== dismissedDraft) setDismissedDraft(null)
+  }, [dismissedDraft, draft])
+
+  return {
+    activeDescendantId: open
+      ? visibleFiles[selectedIndex]
+        ? getComposerFileMentionOptionId(selectedIndex)
+        : undefined
+      : undefined,
+    dismiss,
+    files: visibleFiles,
+    handleKeyDown,
+    listboxId: fileMentionListboxId,
+    loading,
+    open,
+    selectedIndex,
+    selectFile,
+    setSelectedIndex,
+  }
+}
+
+export type ComposerFileMentions = ReturnType<typeof useComposerFileMentions>

--- a/src/app/components/workspace/inbox/inbox-composer.tsx
+++ b/src/app/components/workspace/inbox/inbox-composer.tsx
@@ -1,5 +1,12 @@
 import { ArrowUpRight, Bot, Paperclip, Square, X } from 'lucide-react'
-import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from 'react'
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { getDesktopActionErrorMessage } from '../../../desktop/action-results'
 import { getErrorMessage } from '../../../desktop/error-messages'
 import type {
@@ -24,6 +31,7 @@ import { ComposerPromptInputPanel } from '../composer/composer-prompt-input-pane
 import { useComposerAttachmentPicker } from '../composer/useComposerAttachmentPicker'
 import { useComposerClipboardHandlers } from '../composer/useComposerClipboardHandlers'
 import { useComposerDictation } from '../composer/useComposerDictation'
+import { useComposerFileMentions } from '../composer/useComposerFileMentions'
 import { useComposerSkillMentions } from '../composer/useComposerSkillMentions'
 import { useComposerSlashCommands } from '../composer/useComposerSlashCommands'
 import {
@@ -39,6 +47,10 @@ const thinkingLevelLabels: Record<ComposerThinkingLevel, string> = {
   medium: 'Medium',
   high: 'High',
   xhigh: 'X-High',
+}
+
+function isTargetWithinRefs(target: Node, refs: RefObject<Node | null>[]) {
+  return refs.some((ref) => ref.current?.contains(target))
 }
 
 type InboxComposerProps = {
@@ -108,6 +120,7 @@ export function InboxComposer({
   const modelButtonRef = useRef<HTMLButtonElement>(null)
   const modelMenuRef = useRef<HTMLDivElement>(null)
   const slashCommandPanelRef = useRef<HTMLDivElement>(null)
+  const fileMentionPanelRef = useRef<HTMLDivElement>(null)
   const skillMentionPanelRef = useRef<HTMLDivElement>(null)
   const draftValueRef = useRef(draft)
   const attachmentsRef = useRef(attachments)
@@ -262,6 +275,15 @@ export function InboxComposer({
   const skillMentionListSignature = skillMentions.skills
     .map((skill) => `${skill.name}:${skill.filePath}`)
     .join('|')
+  const fileMentions = useComposerFileMentions({
+    draft,
+    projectId: thread.projectId,
+    setDraft: setDraftValue,
+    attachAttachments: attachPickerAttachments,
+  })
+  const fileMentionListSignature = fileMentions.files
+    .map((file) => `${file.kind}:${file.path}`)
+    .join('|')
   const { handlePaste } = useComposerClipboardHandlers({
     setAttachments: setAttachmentValue,
     setDraftValue,
@@ -269,13 +291,13 @@ export function InboxComposer({
   })
 
   useEffect(() => {
-    if (slashCommands.open || skillMentions.open) {
+    if (slashCommands.open || fileMentions.open || skillMentions.open) {
       setOpenMenu((current) => (current === 'picker' ? null : current))
     }
-  }, [skillMentions.open, slashCommands.open])
+  }, [fileMentions.open, skillMentions.open, slashCommands.open])
 
   useEffect(() => {
-    if (!(slashCommands.open || skillMentions.open)) {
+    if (!(slashCommands.open || fileMentions.open || skillMentions.open)) {
       return
     }
 
@@ -287,14 +309,18 @@ export function InboxComposer({
       }
 
       if (
-        slashCommandPanelRef.current?.contains(target) ||
-        skillMentionPanelRef.current?.contains(target) ||
-        composerSurfaceRef.current?.contains(target)
+        isTargetWithinRefs(target, [
+          slashCommandPanelRef,
+          fileMentionPanelRef,
+          skillMentionPanelRef,
+          composerSurfaceRef,
+        ])
       ) {
         return
       }
 
       if (slashCommands.open) slashCommands.dismiss({ clearDraft: true })
+      if (fileMentions.open) fileMentions.dismiss()
       if (skillMentions.open) skillMentions.dismiss()
     }
 
@@ -306,6 +332,7 @@ export function InboxComposer({
       event.preventDefault()
       event.stopImmediatePropagation()
       if (slashCommands.open) slashCommands.dismiss()
+      if (fileMentions.open) fileMentions.dismiss()
       if (skillMentions.open) skillMentions.dismiss()
     }
 
@@ -315,7 +342,7 @@ export function InboxComposer({
       window.removeEventListener('pointerdown', handlePointerDown, true)
       window.removeEventListener('keydown', handleKeyDown, true)
     }
-  }, [skillMentions, slashCommands])
+  }, [fileMentions, skillMentions, slashCommands])
 
   useEffect(() => {
     if (!(slashCommands.open && slashCommands.activeDescendantId)) {
@@ -353,6 +380,24 @@ export function InboxComposer({
     slashCommands.activeDescendantId,
     slashCommands.selectedIndex,
     slashCommandListSignature,
+  ])
+
+  useEffect(() => {
+    if (!(fileMentions.open && fileMentions.activeDescendantId)) return
+    void fileMentionListSignature
+    const panel = fileMentionPanelRef.current
+    const option = panel?.querySelector<HTMLElement>(`#${fileMentions.activeDescendantId}`)
+    if (!(panel && option)) return
+    if (fileMentions.selectedIndex === 0) {
+      panel.scrollTop = 0
+      return
+    }
+    option.scrollIntoView({ block: 'nearest' })
+  }, [
+    fileMentionListSignature,
+    fileMentions.activeDescendantId,
+    fileMentions.open,
+    fileMentions.selectedIndex,
   ])
 
   useEffect(() => {
@@ -501,6 +546,8 @@ export function InboxComposer({
             projectId={thread.projectId}
             slashCommandPanelRef={slashCommandPanelRef}
             slashCommands={slashCommands}
+            fileMentionPanelRef={fileMentionPanelRef}
+            fileMentions={fileMentions}
             skillMentionPanelRef={skillMentionPanelRef}
             skillMentions={skillMentions}
             showDictationButton={showDictationButton}

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -13,6 +13,7 @@ export type {
   ComposerContextUsage,
   ComposerFilePickerEntry,
   ComposerFilePickerState,
+  ComposerFileSearchEntry,
   ComposerModel,
   ComposerQueuedPrompt,
   ComposerSkillReference,

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -145,6 +145,8 @@ export function installDevWebDesktopBridge() {
     getPathForFile: () => null,
     listComposerAttachmentEntries: (request = {}) =>
       invokeRequest('listComposerAttachmentEntries', request),
+    searchComposerAttachmentEntries: (request = {}) =>
+      invokeRequest('searchComposerAttachmentEntries', request),
     getComposerState: (request = {}) => invokeRequest('getComposerState', request),
     getComposerSlashCommands: (request = {}) => invokeRequest('getComposerSlashCommands', request),
     getComposerSkills: (request = {}) => invokeRequest('getComposerSkills', request),

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -322,6 +322,16 @@ export async function listComposerAttachmentEntriesQuery(
   return (await window.piDesktop?.listComposerAttachmentEntries?.(request)) ?? null
 }
 
+export async function searchComposerAttachmentEntriesQuery(
+  request: {
+    projectId?: string | null | undefined
+    query?: string | null | undefined
+    limit?: number | null | undefined
+  } = {},
+) {
+  return (await window.piDesktop?.searchComposerAttachmentEntries?.(request)) ?? []
+}
+
 export async function readClipboardSnapshotQuery(
   formats?: string[] | null | undefined,
 ): Promise<DesktopClipboardSnapshot | null> {

--- a/src/desktop-host/composer-attachments.ts
+++ b/src/desktop-host/composer-attachments.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -5,6 +6,7 @@ import { getAttachmentKind } from '../../shared/composer-attachments'
 import type {
   ComposerFilePickerEntry,
   ComposerFilePickerState,
+  ComposerFileSearchEntry,
 } from '../../shared/desktop-contracts'
 import { getDesktopWorkingDirectory } from '../../shared/desktop-working-directory'
 
@@ -15,6 +17,208 @@ async function pathExists(targetPath: string) {
   } catch {
     return false
   }
+}
+
+const ignoredSearchDirectories = new Set([
+  '.git',
+  '.hg',
+  '.svn',
+  'node_modules',
+  'build',
+  'dist',
+  'out',
+  '.next',
+  '.turbo',
+  '.vite',
+])
+const maxVisitedSearchEntries = 50_000
+const searchCacheTtlMs = 30_000
+
+type SearchIndexEntry = {
+  path: string
+  name: string
+  relativePath: string
+  lowerRelativePath: string
+  kind: ComposerFilePickerEntry['kind']
+}
+
+type SearchIndex = {
+  entries: SearchIndexEntry[]
+  expiresAt: number
+}
+
+const searchIndexes = new Map<string, SearchIndex>()
+
+function evictExpiredSearchIndexes(now = Date.now()) {
+  for (const [rootPath, index] of searchIndexes) {
+    if (index.expiresAt <= now) searchIndexes.delete(rootPath)
+  }
+}
+
+function scoreFzfMatch(candidate: string, query: string) {
+  if (!query) return 0
+  let score = 0
+  let searchFrom = 0
+  let previousIndex = -1
+
+  for (const character of query) {
+    const index = candidate.indexOf(character, searchFrom)
+    if (index === -1) return null
+
+    score += 1
+    if (index === 0 || '/-_ .'.includes(candidate[index - 1] ?? '')) score += 3
+    if (previousIndex >= 0 && index === previousIndex + 1) score += 5
+    previousIndex = index
+    searchFrom = index + 1
+  }
+
+  if (candidate.includes(query)) score += 20
+  score -= candidate.length / 200
+  return score
+}
+
+function toFileSearchEntry(entry: SearchIndexEntry) {
+  return {
+    path: entry.path,
+    name: entry.name,
+    kind: entry.kind,
+    relativePath: entry.relativePath,
+  } satisfies ComposerFileSearchEntry
+}
+
+function addTopMatch(
+  matches: Array<{ entry: SearchIndexEntry; score: number }>,
+  match: { entry: SearchIndexEntry; score: number },
+  limit: number,
+) {
+  if (matches.length < limit) {
+    matches.push(match)
+    return
+  }
+
+  let worstIndex = 0
+  let worstScore = matches[0]?.score ?? Number.POSITIVE_INFINITY
+  for (let index = 1; index < matches.length; index += 1) {
+    const score = matches[index]?.score ?? Number.POSITIVE_INFINITY
+    if (score < worstScore) {
+      worstIndex = index
+      worstScore = score
+    }
+  }
+  if (match.score > worstScore) matches[worstIndex] = match
+}
+
+async function buildSearchIndex(rootPath: string) {
+  evictExpiredSearchIndexes()
+  const cachedIndex = searchIndexes.get(rootPath)
+  if (cachedIndex && cachedIndex.expiresAt > Date.now()) return cachedIndex.entries
+
+  const entries: SearchIndexEntry[] = []
+  const pendingDirectories = [rootPath]
+  let visitedEntries = 0
+
+  while (pendingDirectories.length > 0 && visitedEntries < maxVisitedSearchEntries) {
+    const currentPath = pendingDirectories.shift()
+    if (!currentPath) break
+
+    let directoryEntries: Dirent[]
+    try {
+      directoryEntries = await readdir(currentPath, { withFileTypes: true })
+    } catch {
+      continue
+    }
+
+    for (const entry of directoryEntries) {
+      visitedEntries += 1
+      if (visitedEntries > maxVisitedSearchEntries) break
+      await addSearchIndexEntry({ entries, entry, currentPath, pendingDirectories, rootPath })
+    }
+  }
+
+  searchIndexes.set(rootPath, { entries, expiresAt: Date.now() + searchCacheTtlMs })
+  return entries
+}
+
+async function addSearchIndexEntry(input: {
+  currentPath: string
+  entries: SearchIndexEntry[]
+  entry: Dirent
+  pendingDirectories: string[]
+  rootPath: string
+}) {
+  if (input.entry.name.startsWith('.')) return
+
+  const entryPath = path.join(input.currentPath, input.entry.name)
+  const relativePath = path.relative(input.rootPath, entryPath)
+  const symlinkKind = input.entry.isSymbolicLink()
+    ? await getSymlinkSearchEntryKind(entryPath)
+    : null
+  const kind = symlinkKind ?? (input.entry.isDirectory() ? 'directory' : null)
+
+  if (kind === 'directory') {
+    if (!ignoredSearchDirectories.has(input.entry.name)) input.pendingDirectories.push(entryPath)
+    input.entries.push({
+      path: entryPath,
+      name: input.entry.name,
+      relativePath,
+      lowerRelativePath: relativePath.toLowerCase(),
+      kind: 'directory',
+    })
+    return
+  }
+
+  if (!(kind || input.entry.isFile())) return
+  input.entries.push({
+    path: entryPath,
+    name: input.entry.name,
+    relativePath,
+    lowerRelativePath: relativePath.toLowerCase(),
+    kind: getAttachmentKind(entryPath),
+  })
+}
+
+async function getSymlinkSearchEntryKind(
+  entryPath: string,
+): Promise<'directory' | 'text' | 'image' | null> {
+  try {
+    const stats = await stat(entryPath)
+    return stats.isDirectory() ? 'directory' : getAttachmentKind(entryPath)
+  } catch {
+    return null
+  }
+}
+
+function compareSearchIndexEntries(left: SearchIndexEntry, right: SearchIndexEntry) {
+  if (left.kind === 'directory' && right.kind !== 'directory') return -1
+  if (left.kind !== 'directory' && right.kind === 'directory') return 1
+  return left.relativePath.localeCompare(right.relativePath, undefined, { sensitivity: 'base' })
+}
+
+export async function searchComposerAttachmentEntries(request: {
+  projectId?: string | null | undefined
+  query?: string | null | undefined
+  limit?: number | null | undefined
+}): Promise<ComposerFileSearchEntry[]> {
+  const rootPath = path.resolve(request.projectId ?? getDesktopWorkingDirectory())
+  const query = (request.query?.trim() ?? '').toLowerCase()
+  const limit = Math.max(1, Math.min(request.limit ?? 50, 100))
+  const index = await buildSearchIndex(rootPath)
+  if (!query)
+    return [...index].sort(compareSearchIndexEntries).slice(0, limit).map(toFileSearchEntry)
+
+  const matches: Array<{ entry: SearchIndexEntry; score: number }> = []
+  for (const entry of index) {
+    const score = scoreFzfMatch(entry.lowerRelativePath, query)
+    if (score === null) continue
+    addTopMatch(matches, { entry, score }, limit)
+  }
+
+  return matches
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.entry.relativePath.localeCompare(right.entry.relativePath),
+    )
+    .map((match) => toFileSearchEntry(match.entry))
 }
 
 export async function normalizeDialogFilePaths(filePaths: string[]) {

--- a/src/electron/main/ipc/request-handlers/system.ts
+++ b/src/electron/main/ipc/request-handlers/system.ts
@@ -13,6 +13,7 @@ import { getSafeExternalUrl } from '../../../../../shared/external-url'
 import {
   listComposerAttachmentEntries,
   normalizeDialogFilePaths,
+  searchComposerAttachmentEntries,
 } from '../../../../desktop-host/composer-attachments'
 import { readNativeClipboardFilePaths } from './clipboard-file-paths'
 
@@ -25,6 +26,7 @@ type SystemRequestHandlers = Pick<
   | 'readClipboardImage'
   | 'getAttachmentKindsForPaths'
   | 'listComposerAttachmentEntries'
+  | 'searchComposerAttachmentEntries'
   | 'openExternal'
   | 'openPath'
   | 'saveTextToDownloads'
@@ -189,6 +191,7 @@ export function createSystemHandlers(): SystemRequestHandlers {
       return Object.fromEntries(entries)
     },
     listComposerAttachmentEntries: (request) => listComposerAttachmentEntries(request),
+    searchComposerAttachmentEntries: (request) => searchComposerAttachmentEntries(request),
     openExternal: async ({ url }) => {
       const safeUrl = getSafeExternalUrl(url)
       if (!safeUrl) {

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -111,6 +111,8 @@ export function createDesktopApi() {
     },
     listComposerAttachmentEntries: (request = {}) =>
       invokeRequest('listComposerAttachmentEntries', request),
+    searchComposerAttachmentEntries: (request = {}) =>
+      invokeRequest('searchComposerAttachmentEntries', request),
     getComposerState: (request = {}) => invokeRequest('getComposerState', request),
     getComposerSlashCommands: (request = {}) => invokeRequest('getComposerSlashCommands', request),
     getComposerSkills: (request = {}) => invokeRequest('getComposerSkills', request),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,6 +8,7 @@ import type {
   ChatSidebarState,
   ComposerAttachment,
   ComposerFilePickerState,
+  ComposerFileSearchEntry,
   ComposerSkillReference,
   ComposerSlashCommand,
   ComposerState,
@@ -143,6 +144,11 @@ declare global {
         path?: string | null | undefined
         rootPath?: string | null | undefined
       }) => Promise<ComposerFilePickerState>
+      searchComposerAttachmentEntries?: (request?: {
+        projectId?: string | null | undefined
+        query?: string | null | undefined
+        limit?: number | null | undefined
+      }) => Promise<ComposerFileSearchEntry[]>
       getComposerState?: (request?: ComposerStateRequest) => Promise<ComposerState>
       getComposerSlashCommands?: (request?: ComposerStateRequest) => Promise<ComposerSlashCommand[]>
       getComposerSkills?: (request?: ComposerStateRequest) => Promise<ComposerSkillReference[]>


### PR DESCRIPTION
## Summary

- Add `@` file/folder mentions to the composer and inbox composer with a fast TypeScript fuzzy search backend.
- Keep selected `@relative/path` text visible in the composer while also attaching the selected file/folder.
- Improve file picker responsiveness so the attachment column only appears when needed, file entries collapse from 3 columns to 2, and attachment rows truncate with their remove button pinned.

## Implementation notes

- Adds `searchComposerAttachmentEntries` over desktop IPC/preload/dev bridge.
- Builds a short-lived cached project file index and ranks matches with a lightweight speed-oriented fuzzy scorer.
- Skips heavy folders like `.git`, `node_modules`, build outputs, etc.
- Leaves native/Rust fuzzy matching as future research in #215.

## Validation

- `bun run ai:check`

Refs #215
