### PR TITLE
Show GitOps errors as copyable overlay

### DIFF
--- a/src/app/components/workspace/composer/composer-git-ops-surface.tsx
+++ b/src/app/components/workspace/composer/composer-git-ops-surface.tsx
@@ -41,6 +41,7 @@ type ComposerGitOpsSurfaceProps = {
   onAction: DesktopActionInvoker
   onLayoutChange: () => void
   onBack: () => void
+  onActionErrorMessageChange?: (message: string | null) => void
 }
 
 export function ComposerGitOpsSurface({
@@ -67,6 +68,7 @@ export function ComposerGitOpsSurface({
   onAction,
   onLayoutChange,
   onBack,
+  onActionErrorMessageChange,
 }: ComposerGitOpsSurfaceProps) {
   void diffCommentCount
 
@@ -130,6 +132,10 @@ export function ComposerGitOpsSurface({
     setErrorMessage: setActionErrorMessage,
   })
   const dictationTranscribing = dictationInterimText.length > 0
+
+  useEffect(() => {
+    onActionErrorMessageChange?.(actionErrorMessage)
+  }, [actionErrorMessage, onActionErrorMessageChange])
 
   useEffect(() => {
     if (!(dictationActive || dictationTranscribing)) {
@@ -209,7 +215,7 @@ export function ComposerGitOpsSurface({
         ) : null}
         {hasDiffComments ? null : (
           <ComposerGitOpsMessageField
-            actionErrorMessage={actionErrorMessage}
+            actionErrorMessage={null}
             actionStatusMessage={actionStatusMessage}
             commitFocused={commitFocused}
             diffCommentError={diffCommentError ?? diffLoadError}
@@ -241,7 +247,7 @@ export function ComposerGitOpsSurface({
 
       {hasDiffComments ? (
         <ComposerGitOpsMessageField
-          actionErrorMessage={actionErrorMessage}
+          actionErrorMessage={null}
           actionStatusMessage={actionStatusMessage}
           commitFocused={commitFocused}
           diffCommentError={diffCommentError ?? diffLoadError}

--- a/src/app/components/workspace/composer/useComposerGitOpsState.ts
+++ b/src/app/components/workspace/composer/useComposerGitOpsState.ts
@@ -213,6 +213,7 @@ export function useComposerGitOpsState({
             ? appSettings.gitOpsDefaultMode === 'commit-push'
             : mode === 'commit-push'),
       )
+      setActionErrorMessage(null)
 
       try {
         const result = await onAction('workspace.commit-options', { gitOpsMode: mode })
@@ -252,6 +253,8 @@ export function useComposerGitOpsState({
     if (!isGitRepo || nextRepoUrl.length === 0) {
       return
     }
+
+    setActionErrorMessage(null)
 
     try {
       const result = await onAction('workspace.commit-options', { repoUrl: nextRepoUrl })

--- a/src/app/components/workspace/git-ops-composer-panel.tsx
+++ b/src/app/components/workspace/git-ops-composer-panel.tsx
@@ -37,6 +37,8 @@ type GitOpsComposerPanelProps = {
 
 function GitOpsErrorDetails({ detail, onDismiss }: { detail: string; onDismiss: () => void }) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
+  const helperText =
+    copyState === 'failed' ? '- copy failed, press Escape to dismiss' : '- click copy to dismiss'
 
   useEffect(() => {
     if (copyState === 'idle') return
@@ -44,6 +46,18 @@ function GitOpsErrorDetails({ detail, onDismiss }: { detail: string; onDismiss: 
     const timeout = window.setTimeout(() => setCopyState('idle'), 1400)
     return () => window.clearTimeout(timeout)
   }, [copyState])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+
+      event.preventDefault()
+      onDismiss()
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
+  }, [onDismiss])
 
   const handleCopy = async () => {
     try {
@@ -56,15 +70,21 @@ function GitOpsErrorDetails({ detail, onDismiss }: { detail: string; onDismiss: 
   }
 
   return (
-    <div className="pointer-events-auto absolute inset-x-0 bottom-[calc(100%+0.75rem)] z-20">
+    <div
+      className="pointer-events-auto absolute inset-x-0 bottom-[calc(100%+0.75rem)] z-20"
+      role="alert"
+      aria-live="polite"
+    >
       <div className="group relative rounded-xl border border-[color:var(--danger-border)] bg-[color:var(--panel)] px-3 py-2 pr-12 text-[13px] shadow-[var(--shadow)]">
         <div className="grid gap-1">
           <div className="flex items-center gap-2 text-[color:var(--danger)]">
             <span className="h-2 w-2 rounded-full bg-[color:var(--danger)]" />
-            <span>Git commit failed</span>
-            <span className="text-[color:var(--muted)]">- click copy to dismiss</span>
+            <span>GitOps action failed</span>
+            <span className="text-[color:var(--muted)]">{helperText}</span>
           </div>
-          <div className="font-mono text-[12px] text-[color:var(--muted)]">{detail}</div>
+          <div className="whitespace-pre-wrap font-mono text-[12px] text-[color:var(--muted)]">
+            {detail}
+          </div>
         </div>
         <button
           type="button"
@@ -108,26 +128,16 @@ export function GitOpsComposerPanel({
 }: GitOpsComposerPanelProps) {
   const composerPanelRef = useRef<HTMLDivElement>(null)
   const [gitActionErrorMessage, setGitActionErrorMessage] = useState<string | null>(null)
-  const [dismissedGitActionErrorMessage, setDismissedGitActionErrorMessage] = useState<
-    string | null
-  >(null)
+  const [gitActionErrorDismissed, setGitActionErrorDismissed] = useState(false)
   const visibleGitActionErrorMessage =
-    gitActionErrorMessage && gitActionErrorMessage !== dismissedGitActionErrorMessage
-      ? gitActionErrorMessage
-      : null
-
-  useEffect(() => {
-    if (!gitActionErrorMessage) {
-      setDismissedGitActionErrorMessage(null)
-    }
-  }, [gitActionErrorMessage])
+    gitActionErrorMessage && !gitActionErrorDismissed ? gitActionErrorMessage : null
 
   return (
     <div className="relative grid gap-0 overflow-visible">
       {visibleGitActionErrorMessage ? (
         <GitOpsErrorDetails
           detail={visibleGitActionErrorMessage}
-          onDismiss={() => setDismissedGitActionErrorMessage(visibleGitActionErrorMessage)}
+          onDismiss={() => setGitActionErrorDismissed(true)}
         />
       ) : null}
       <section
@@ -159,7 +169,10 @@ export function GitOpsComposerPanel({
           onAction={onAction}
           onLayoutChange={onLayoutChange}
           onBack={onBack}
-          onActionErrorMessageChange={setGitActionErrorMessage}
+          onActionErrorMessageChange={(message) => {
+            setGitActionErrorMessage(message)
+            setGitActionErrorDismissed(false)
+          }}
         />
       </section>
     </div>

--- a/src/app/components/workspace/git-ops-composer-panel.tsx
+++ b/src/app/components/workspace/git-ops-composer-panel.tsx
@@ -1,4 +1,5 @@
-import { useRef } from 'react'
+import { Check, Clipboard } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import type {
   AppSettings,
   DesktopActionInvoker,
@@ -34,6 +35,53 @@ type GitOpsComposerPanelProps = {
   onOpenSettingsView: () => void
 }
 
+function GitOpsErrorDetails({ detail, onDismiss }: { detail: string; onDismiss: () => void }) {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
+
+  useEffect(() => {
+    if (copyState === 'idle') return
+
+    const timeout = window.setTimeout(() => setCopyState('idle'), 1400)
+    return () => window.clearTimeout(timeout)
+  }, [copyState])
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(detail)
+      setCopyState('copied')
+      onDismiss()
+    } catch {
+      setCopyState('failed')
+    }
+  }
+
+  return (
+    <div className="pointer-events-auto absolute inset-x-0 bottom-[calc(100%+0.75rem)] z-20">
+      <div className="group relative rounded-xl border border-[color:var(--danger-border)] bg-[color:var(--panel)] px-3 py-2 pr-12 text-[13px] shadow-[var(--shadow)]">
+        <div className="grid gap-1">
+          <div className="flex items-center gap-2 text-[color:var(--danger)]">
+            <span className="h-2 w-2 rounded-full bg-[color:var(--danger)]" />
+            <span>Git commit failed</span>
+            <span className="text-[color:var(--muted)]">- click copy to dismiss</span>
+          </div>
+          <div className="font-mono text-[12px] text-[color:var(--muted)]">{detail}</div>
+        </div>
+        <button
+          type="button"
+          className="absolute top-1.5 right-1.5 grid h-8 min-w-8 place-items-center rounded-[10px] border border-[color:var(--border)] bg-[color:var(--panel)] px-2 text-[11px] font-medium text-[color:var(--muted)] opacity-75 shadow-[var(--shadow)] backdrop-blur-sm transition-[opacity,scale,background-color,color] duration-150 ease-out hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-border)] active:scale-[0.96] group-hover:opacity-100"
+          onClick={() => void handleCopy()}
+          aria-label={copyState === 'copied' ? 'Copied git error' : 'Copy git error'}
+          title={
+            copyState === 'failed' ? 'Copy failed' : copyState === 'copied' ? 'Copied' : 'Copy'
+          }
+        >
+          {copyState === 'copied' ? <Check size={14} /> : <Clipboard size={14} />}
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export function GitOpsComposerPanel({
   dictationModelId,
   dictationMaxDurationSeconds,
@@ -59,38 +107,61 @@ export function GitOpsComposerPanel({
   onOpenSettingsView,
 }: GitOpsComposerPanelProps) {
   const composerPanelRef = useRef<HTMLDivElement>(null)
+  const [gitActionErrorMessage, setGitActionErrorMessage] = useState<string | null>(null)
+  const [dismissedGitActionErrorMessage, setDismissedGitActionErrorMessage] = useState<
+    string | null
+  >(null)
+  const visibleGitActionErrorMessage =
+    gitActionErrorMessage && gitActionErrorMessage !== dismissedGitActionErrorMessage
+      ? gitActionErrorMessage
+      : null
+
+  useEffect(() => {
+    if (!gitActionErrorMessage) {
+      setDismissedGitActionErrorMessage(null)
+    }
+  }, [gitActionErrorMessage])
 
   return (
-    <section
-      ref={composerPanelRef}
-      className="grid gap-0 overflow-visible rounded-[20px] border border-[color:var(--accent-border)] bg-[color:var(--panel)] shadow-none"
-      aria-label="Git ops composer panel"
-    >
-      <ComposerGitOpsSurface
-        dictationModelId={dictationModelId}
-        dictationMaxDurationSeconds={dictationMaxDurationSeconds}
-        composerPanelRef={composerPanelRef}
-        onOpenSettingsView={onOpenSettingsView}
-        projectGitState={projectGitState}
-        projectId={projectId}
-        sessionPath={sessionPath}
-        showDictationButton={showDictationButton}
-        appSettings={appSettings}
-        diffBaseline={diffBaseline}
-        diffRenderMode={diffRenderMode}
-        diffComments={diffComments}
-        diffCommentCount={diffCommentCount}
-        diffCommentsSending={diffCommentsSending}
-        diffCommentError={diffCommentError}
-        diffLoadError={diffLoadError}
-        onSetDiffBaseline={onSetDiffBaseline}
-        onSetDiffRenderMode={onSetDiffRenderMode}
-        onSendDiffComments={onSendDiffComments}
-        onSelectDiffComment={onSelectDiffComment}
-        onAction={onAction}
-        onLayoutChange={onLayoutChange}
-        onBack={onBack}
-      />
-    </section>
+    <div className="relative grid gap-0 overflow-visible">
+      {visibleGitActionErrorMessage ? (
+        <GitOpsErrorDetails
+          detail={visibleGitActionErrorMessage}
+          onDismiss={() => setDismissedGitActionErrorMessage(visibleGitActionErrorMessage)}
+        />
+      ) : null}
+      <section
+        ref={composerPanelRef}
+        className="grid gap-0 overflow-visible rounded-[20px] border border-[color:var(--accent-border)] bg-[color:var(--panel)] shadow-none"
+        aria-label="Git ops composer panel"
+      >
+        <ComposerGitOpsSurface
+          dictationModelId={dictationModelId}
+          dictationMaxDurationSeconds={dictationMaxDurationSeconds}
+          composerPanelRef={composerPanelRef}
+          onOpenSettingsView={onOpenSettingsView}
+          projectGitState={projectGitState}
+          projectId={projectId}
+          sessionPath={sessionPath}
+          showDictationButton={showDictationButton}
+          appSettings={appSettings}
+          diffBaseline={diffBaseline}
+          diffRenderMode={diffRenderMode}
+          diffComments={diffComments}
+          diffCommentCount={diffCommentCount}
+          diffCommentsSending={diffCommentsSending}
+          diffCommentError={diffCommentError}
+          diffLoadError={diffLoadError}
+          onSetDiffBaseline={onSetDiffBaseline}
+          onSetDiffRenderMode={onSetDiffRenderMode}
+          onSendDiffComments={onSendDiffComments}
+          onSelectDiffComment={onSelectDiffComment}
+          onAction={onAction}
+          onLayoutChange={onLayoutChange}
+          onBack={onBack}
+          onActionErrorMessageChange={setGitActionErrorMessage}
+        />
+      </section>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Display GitOps action failures in an overlay above the composer instead of inline in the commit message field.
- Show the real Git error text in a copyable two-row message over the diff.
- Let copying the error dismiss the overlay while allowing new errors to appear again.

## Validation
- bun run ai:check
