### PR TITLE
Detect and warn about empty bash commands from Pi agent

### DIFF
--- a/desktop/runtime-host/live-runtime-registry.ts
+++ b/desktop/runtime-host/live-runtime-registry.ts
@@ -160,17 +160,33 @@ function handleRuntimeSessionEvent(
       return
     case 'tool_execution_start':
     case 'tool_execution_update':
-    case 'tool_execution_end':
-      rememberRuntimeToolProgress(runtime, {
+    case 'tool_execution_end': {
+      const toolEntry = {
         toolCallId: event.toolCallId,
         toolName: event.toolName,
         args: 'args' in event ? event.args : undefined,
         partialResult: getRuntimeToolProgressPartial(event),
         isError: event.type === 'tool_execution_end' ? event.isError : false,
         terminal: event.type === 'tool_execution_end',
+      }
+      rememberRuntimeToolProgress(runtime, toolEntry, (entry) => {
+        emitDesktopEvent({
+          type: 'runtime-diagnostic',
+          severity: 'warning',
+          message:
+            'Pi sent a bash tool call with an empty command. This may indicate the agent planned but did not execute.',
+          details: {
+            toolCallId: entry.toolCallId,
+            toolName: entry.toolName,
+            args: entry.args,
+          },
+          sessionPath: runtime.session?.sessionFile,
+          projectId: runtime.cwd,
+        })
       })
       scheduleLiveThreadUpdate(runtime)
       return
+    }
     case 'queue_update':
       void publishRuntimeComposerState(
         runtime,

--- a/desktop/runtime-host/live-tool-progress.ts
+++ b/desktop/runtime-host/live-tool-progress.ts
@@ -1,6 +1,14 @@
 import type { AgentMessage } from '@earendil-works/pi-agent-core'
 import type { PiRuntime } from '../runtime/types.ts'
 
+type BashToolArgs = { command?: string; cwd?: string }
+
+function isEmptyBashCommand(entry: RuntimeToolProgress): boolean {
+  if (entry.toolName !== 'bash') return false
+  const args = entry.args as BashToolArgs | undefined
+  return !args?.command || args.command.trim().length === 0
+}
+
 export type RuntimeToolProgress = {
   toolCallId: string
   toolName: string
@@ -60,7 +68,14 @@ export function getLiveToolProgressMessages(runtime: PiRuntime) {
   })
 }
 
-export function rememberRuntimeToolProgress(runtime: PiRuntime, entry: RuntimeToolProgress) {
+export function rememberRuntimeToolProgress(
+  runtime: PiRuntime,
+  entry: RuntimeToolProgress,
+  onEmptyBashCommand?: (entry: RuntimeToolProgress) => void,
+) {
+  if (isEmptyBashCommand(entry)) {
+    onEmptyBashCommand?.(entry)
+  }
   getLiveToolProgress(runtime).set(entry.toolCallId, entry)
 }
 


### PR DESCRIPTION
## Summary

When Pi sends a bash tool call with an empty command, emit a `runtime-diagnostic` warning event. This helps users understand why their agent appears to do nothing after generating a plan.

## Problem

When Pi over-plans without executing, it may send bash tool calls with empty commands. This results in:
- Directories being created but no files written
- The agent appearing to hang after proposing a plan
- No visible feedback to the user about what went wrong

## Solution

1. Add `isEmptyBashCommand()` detection function in `live-tool-progress.ts`
2. Modify `rememberRuntimeToolProgress()` to accept an optional callback
3. When an empty bash command is detected, emit a `runtime-diagnostic` warning with severity `warning`

## Event Payload



## Testing

Can be tested by asking Pi to perform a task that triggers over-planning (e.g., "build me a complex web app"). The warning should appear in the diagnostic log.

## Validation

- [ ] TypeScript compiles without errors
- [ ] Runtime diagnostic event is emitted when empty bash command is detected
- [ ] Existing functionality is not broken (optional callback parameter is backward compatible)