### PR TITLE
Fix small UI rough edges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,4 @@
 - Consider creating new, small AGENTS.md files whenever patterns are observed.
 - AGENTS.md files are here to help you - if they are confusing, they should be edited to suit.
 - Popovers, menus, and custom select dropdowns must close on Escape and when clicking outside, matching native control expectations. Escape handlers for nested popovers must run in capture phase and stop propagation so parent views/dialogs do not also close.
+- Keep ASAR enabled; anything run by external stock Node must live outside ASAR with its full dependency tree, and launcher smoke tests must validate `app.asar` plus unpacked runtime deps.

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
       "!**/build",
       "!**/dist",
       "!**/dist-pages",
+      "!**/Frameworks",
       "!**/node_modules",
       "!**/vendor"
     ],

--- a/bun.lock
+++ b/bun.lock
@@ -30,12 +30,14 @@
         "file-uri-to-path": "1.0.0",
         "lucide-react": "^0.525.0",
         "node-pty": "^1.1.0",
+        "prismjs": "^1.30.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "sherpa-onnx-node": "^1.12.38",
         "tar": "^7.5.13",
+        "typebox": "^1.1.38",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
@@ -51,6 +53,7 @@
         "electron": "41.2.1",
         "electron-builder": "^26.0.12",
         "husky": "^9.1.7",
+        "knip": "^6.12.1",
         "lint-staged": "^15.2.7",
         "react-grab": "^0.1.32",
         "tailwindcss": "^4.2.4",
@@ -69,7 +72,7 @@
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 
-    "@antfu/ni": ["@antfu/ni@0.23.2", "", { "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nu": "bin/nu.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs" } }, "sha512-FSEVWXvwroExDXUu8qV6Wqp2X3D1nJ0Li4LFymCyvCVrm7I3lNfG0zZWSWvGU1RE7891eTnFTyh31L3igOwNKQ=="],
+    "@antfu/ni": ["@antfu/ni@30.1.0", "", { "dependencies": { "fzf": "^0.5.2", "package-manager-detector": "^1.6.0", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15" }, "bin": { "ni": "bin/ni.mjs", "nci": "bin/nci.mjs", "nr": "bin/nr.mjs", "nup": "bin/nup.mjs", "nd": "bin/nd.mjs", "nlx": "bin/nlx.mjs", "na": "bin/na.mjs", "nun": "bin/nun.mjs" } }, "sha512-3VuAbPjgY52rQNn4wABaXMhBU2Oq91uy6L8nX49eJ35OLI68CyckGU+HZxcaHix4ymuGM2nFL1D6sLpgODK5xw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
@@ -479,9 +482,89 @@
 
     "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.128.0", "", { "os": "android", "cpu": "arm" }, "sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.1.15", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-Gj863E+aSpc0H3C4cH0fQTaF/tP9yYfhnilR7/dS72qq8thqNpR3fo3jURHRtRKz6KJJ10anxcurHP7b3ZUQkw=="],
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.128.0", "", { "os": "android", "cpu": "arm64" }, "sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ=="],
+
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.128.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA=="],
+
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.128.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ=="],
+
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.128.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg=="],
+
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.128.0", "", { "os": "linux", "cpu": "arm" }, "sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng=="],
+
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.128.0", "", { "os": "linux", "cpu": "arm" }, "sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g=="],
+
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.128.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ=="],
+
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.128.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA=="],
+
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.128.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg=="],
+
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.128.0", "", { "os": "linux", "cpu": "none" }, "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ=="],
+
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.128.0", "", { "os": "linux", "cpu": "none" }, "sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA=="],
+
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.128.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA=="],
+
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.128.0", "", { "os": "linux", "cpu": "x64" }, "sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q=="],
+
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.128.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw=="],
+
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.128.0", "", { "os": "none", "cpu": "arm64" }, "sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg=="],
+
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.128.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA=="],
+
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.128.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw=="],
+
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.128.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA=="],
+
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.128.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
+
+    "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.19.1", "", { "os": "android", "cpu": "arm" }, "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg=="],
+
+    "@oxc-resolver/binding-android-arm64": ["@oxc-resolver/binding-android-arm64@11.19.1", "", { "os": "android", "cpu": "arm64" }, "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA=="],
+
+    "@oxc-resolver/binding-darwin-arm64": ["@oxc-resolver/binding-darwin-arm64@11.19.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ=="],
+
+    "@oxc-resolver/binding-darwin-x64": ["@oxc-resolver/binding-darwin-x64@11.19.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ=="],
+
+    "@oxc-resolver/binding-freebsd-x64": ["@oxc-resolver/binding-freebsd-x64@11.19.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw=="],
+
+    "@oxc-resolver/binding-linux-arm-gnueabihf": ["@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1", "", { "os": "linux", "cpu": "arm" }, "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A=="],
+
+    "@oxc-resolver/binding-linux-arm-musleabihf": ["@oxc-resolver/binding-linux-arm-musleabihf@11.19.1", "", { "os": "linux", "cpu": "arm" }, "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ=="],
+
+    "@oxc-resolver/binding-linux-arm64-gnu": ["@oxc-resolver/binding-linux-arm64-gnu@11.19.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig=="],
+
+    "@oxc-resolver/binding-linux-arm64-musl": ["@oxc-resolver/binding-linux-arm64-musl@11.19.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew=="],
+
+    "@oxc-resolver/binding-linux-ppc64-gnu": ["@oxc-resolver/binding-linux-ppc64-gnu@11.19.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ=="],
+
+    "@oxc-resolver/binding-linux-riscv64-gnu": ["@oxc-resolver/binding-linux-riscv64-gnu@11.19.1", "", { "os": "linux", "cpu": "none" }, "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w=="],
+
+    "@oxc-resolver/binding-linux-riscv64-musl": ["@oxc-resolver/binding-linux-riscv64-musl@11.19.1", "", { "os": "linux", "cpu": "none" }, "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw=="],
+
+    "@oxc-resolver/binding-linux-s390x-gnu": ["@oxc-resolver/binding-linux-s390x-gnu@11.19.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA=="],
+
+    "@oxc-resolver/binding-linux-x64-gnu": ["@oxc-resolver/binding-linux-x64-gnu@11.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ=="],
+
+    "@oxc-resolver/binding-linux-x64-musl": ["@oxc-resolver/binding-linux-x64-musl@11.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw=="],
+
+    "@oxc-resolver/binding-openharmony-arm64": ["@oxc-resolver/binding-openharmony-arm64@11.19.1", "", { "os": "none", "cpu": "arm64" }, "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA=="],
+
+    "@oxc-resolver/binding-wasm32-wasi": ["@oxc-resolver/binding-wasm32-wasi@11.19.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg=="],
+
+    "@oxc-resolver/binding-win32-arm64-msvc": ["@oxc-resolver/binding-win32-arm64-msvc@11.19.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ=="],
+
+    "@oxc-resolver/binding-win32-ia32-msvc": ["@oxc-resolver/binding-win32-ia32-msvc@11.19.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA=="],
+
+    "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
+
+    "@pierre/diffs": ["@pierre/diffs@1.1.21", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-4vz4YRg1qZEiVwx6EnaYlMSIIDOq1CvtcBEc4b/gNxDbQtlvGJof+IWH5cv/bwgDre377Txe/ML4zoSp78yWWw=="],
 
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
 
@@ -583,41 +666,41 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
-    "@react-grab/cli": ["@react-grab/cli@0.1.32", "", { "dependencies": { "@antfu/ni": "^0.23.0", "commander": "^14.0.0", "ignore": "^7.0.5", "jsonc-parser": "^3.3.1", "ora": "^8.2.0", "picocolors": "^1.1.1", "prompts": "^2.4.2", "smol-toml": "^1.6.0" }, "bin": { "react-grab": "dist/cli.js" } }, "sha512-TI4SHATLH2yM1DMRXgH3dt/8b3Rj51BplDOqOQiHQKAMOuKVAR9WE2WGWJRT3LwFpl8BXR9ytAM9vrGDrB7QGw=="],
+    "@react-grab/cli": ["@react-grab/cli@0.1.33", "", { "dependencies": { "@antfu/ni": "^30.1.0", "commander": "^14.0.3", "ignore": "^7.0.5", "jsonc-parser": "^3.3.1", "ora": "^9.4.0", "picocolors": "^1.1.1", "prompts": "^2.4.2", "smol-toml": "^1.6.1" }, "bin": { "react-grab": "bin/cli.js" } }, "sha512-UOc3PwN11Osw0NzaxRLK8trP4X+5iW1Dst3gvHRCafe3wXHyadzHYH8H1hdkcXdlIx3gsoD9ASJ+G/JH+A/jqA=="],
 
     "@react-hook/intersection-observer": ["@react-hook/intersection-observer@3.1.2", "", { "dependencies": { "@react-hook/passive-layout-effect": "^1.2.0", "intersection-observer": "^0.10.0" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ=="],
 
     "@react-hook/passive-layout-effect": ["@react-hook/passive-layout-effect@1.2.1", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.18", "", { "os": "android", "cpu": "arm64" }, "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.18", "", { "os": "freebsd", "cpu": "x64" }, "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18", "", { "os": "linux", "cpu": "arm" }, "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "s390x" }, "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "x64" }, "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.18", "", { "os": "linux", "cpu": "x64" }, "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.18", "", { "os": "none", "cpu": "arm64" }, "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.18", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.18", "", { "os": "win32", "cpu": "x64" }, "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -769,11 +852,11 @@
 
     "@tanstack/pacer": ["@tanstack/pacer@0.20.1", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.3", "@tanstack/store": "^0.9.3" } }, "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.99.1", "", {}, "sha512-5E8xwxyWvr22yt7zvzP3KOZ5TUElOdVA45NP3/Ao1m9mvc9i18NLTDe9m3M00BH2DR5J20cv7xckMPlhKNs+vQ=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.9", "", {}, "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ=="],
 
     "@tanstack/react-pacer": ["@tanstack/react-pacer@0.21.1", "", { "dependencies": { "@tanstack/pacer": "0.20.1", "@tanstack/react-store": "^0.9.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-BIBWmxSi+RHuB4Sh8SPyh3i3PVK8GR3yAyxOqXjERyww1cfvKdu2veUfJuTTiR4os1lfdctcS4HAibt8KTmMiw=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.99.1", "", { "dependencies": { "@tanstack/query-core": "5.99.1" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-akg5GdwW70lvJvCqVHZ7tizGyc+TATjUzKX9RuF1xknhEe/1leofXk7YLYbrbRsuhNbHJBAayaQUMvvOFZ5L5g=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.9", "", { "dependencies": { "@tanstack/query-core": "5.100.9" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
@@ -793,7 +876,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -845,21 +928,21 @@
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260505.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260505.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260505.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260505.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260505.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260505.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260505.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260505.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-o82qX7L97dwQMpj6DzzokF6SQlChcxduNaL4OWzJhJkz1EP//gZOa0/xNPbPLufoJojHLQcANnpkA4JDXZDFhQ=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260507.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260507.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260507.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260507.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260507.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260507.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260507.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260507.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-1NCr79LEzPErrYtminofTji5EvFDYwJ2JDQfDhcQyP8XVJF93LZ5jiDXcYE2MgqDvwPUpaHMY8seC28jHrc/ew=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260505.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5W94O493huwcjrAkuP9yTQVPosXjX/0fEjCZsDn2D59m7VuPLy78R9D2i3UwlnajC75ubFiLcp/sh5o6/dFZVg=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260507.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2iWAWthp9tWDkgIOITi6GGQkEDQ8Mf+L28B83FR+MvvbLEtHJ5BIZoBOSBgKP5KW+eHlAv1LFUC9dggq1+NO0Q=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260505.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-j+N/276dONuTv2mOLgZy/jLsEZ2JLrxbZ8wBS/LIsMGtvp6elaN/ZESEntpUpIUbeoc5H6nHkjicJKNxQTZ90Q=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260507.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXBJx0gF4D9aNZsFavprlbPzL5clAvHsueaVpb3c7M8wv/3FFCdjK7NJUESxpK3+M1RW5MvNaKR6QTzkdunfvQ=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260505.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Vo7nGP0Wbs+VafCMabS4pSDcfJj60fLAmuZ2+hfdsUMFMO0BzHIUFyKBhbaeKVgO5V0yAqvBKrWkovZy0YXxGA=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260507.1", "", { "os": "linux", "cpu": "arm" }, "sha512-i2K4RRVjk9wSMpGcR5G2hKyUowSZMrnSKh5NYx1nVy6srBD7DVrTSBDH+KCVdAVAuZtsl0tOdVJixkRRjOsbpw=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260505.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-pP/LpkknUTeyQkIiC916BpW2R4ToXDZI7zTbkG6Llh5bGTPcTbtM/5SxXSzYH04ogrc5AP6yYRZsUxtv1GGeQA=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260507.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-0F2o8sbpSOHR04ghnhWPFsyuH9uew78v3fc2+tplxAnwZ5Wt72hk6Ka0yG07m8D6Ca0SK/GtTVIq7BfjmNCP8w=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260505.1", "", { "os": "linux", "cpu": "x64" }, "sha512-90Bpi2xCPCE3S/pcL5uXn793AKSf8qLVvQ+w87FpwKknHYXQqOQ38KBO9jX2lynoxr8YcVO1S8BS7PngkwicYg=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260507.1", "", { "os": "linux", "cpu": "x64" }, "sha512-dST5xeuhREr73obBJj4j5Dtf0dEQr6WuUyHIoLaVQCX9PZhWk0Iu2/9jJ0+Gtx7fh3jWGcidNPP1SgmSrXP6Sw=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260505.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-VkNazv418LbiI0X6SQPCqVFTiBBvCrIxGkdVD7WBO/M3WHZam4qhK8fF61uQclK2NqYPClI2hPbuR5i8+4s4cg=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260507.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-21rGqCoY2FgnbY2YQFGoAnaHFs5kagwdCmGdn7GmsdNF7P3zvS1ag56BFRYITZ2xw02xYa0fvbXcIIycysBS1A=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260505.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QhueS4Y0hxYnkQoXrAmB0JKpnXn18nNJwqxLSpyEHCEr+XnggiHBNfjT+p1LeG42TEn0w+skcfwc/Mkmk/gyCg=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260507.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PORjTM6k/7ySuN7qbKKLKPJ5AlSQuZbaDkLsdQglapQySeHcrdjOhFl172U+V954sR+KhrE3ckhuinEH+Vjkug=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -973,7 +1056,7 @@
 
     "builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
 
-    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "cacache": ["cacache@19.0.1", "", { "dependencies": { "@npmcli/fs": "^4.0.0", "fs-minipass": "^3.0.0", "glob": "^10.2.2", "lru-cache": "^10.0.1", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^12.0.0", "tar": "^7.4.3", "unique-filename": "^4.0.0" } }, "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ=="],
 
@@ -1011,7 +1094,7 @@
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
-    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+    "cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
 
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
 
@@ -1229,6 +1312,8 @@
 
     "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
 
+    "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
+
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -1251,6 +1336,8 @@
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
+    "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
+
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
@@ -1264,6 +1351,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "fzf": ["fzf@0.5.2", "", {}, "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="],
 
     "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 
@@ -1280,6 +1369,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
@@ -1389,7 +1480,7 @@
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
-    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1418,6 +1509,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "knip": ["knip@6.12.1", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.128.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-9JRZB1mENe8xNMpP4jJRiFXkRVBHTWzD7YtiLywkO7aKXCefbvI+hA0YDl7H7dPvJt7gcVolgxKgABJQ31NL3w=="],
 
     "koffi": ["koffi@2.16.1", "", {}, "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ=="],
 
@@ -1459,7 +1552,7 @@
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
-    "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+    "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
@@ -1697,9 +1790,13 @@
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
-    "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+    "ora": ["ora@9.4.0", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ=="],
 
     "outvariant": ["outvariant@1.4.0", "", {}, "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw=="],
+
+    "oxc-parser": ["oxc-parser@0.128.0", "", { "dependencies": { "@oxc-project/types": "^0.128.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.128.0", "@oxc-parser/binding-android-arm64": "0.128.0", "@oxc-parser/binding-darwin-arm64": "0.128.0", "@oxc-parser/binding-darwin-x64": "0.128.0", "@oxc-parser/binding-freebsd-x64": "0.128.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.128.0", "@oxc-parser/binding-linux-arm64-gnu": "0.128.0", "@oxc-parser/binding-linux-arm64-musl": "0.128.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.128.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.128.0", "@oxc-parser/binding-linux-riscv64-musl": "0.128.0", "@oxc-parser/binding-linux-s390x-gnu": "0.128.0", "@oxc-parser/binding-linux-x64-gnu": "0.128.0", "@oxc-parser/binding-linux-x64-musl": "0.128.0", "@oxc-parser/binding-openharmony-arm64": "0.128.0", "@oxc-parser/binding-wasm32-wasi": "0.128.0", "@oxc-parser/binding-win32-arm64-msvc": "0.128.0", "@oxc-parser/binding-win32-ia32-msvc": "0.128.0", "@oxc-parser/binding-win32-x64-msvc": "0.128.0" } }, "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw=="],
+
+    "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
     "p-cancelable": ["p-cancelable@2.1.1", "", {}, "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="],
 
@@ -1714,6 +1811,8 @@
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
@@ -1745,7 +1844,7 @@
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
-    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "postject": ["postject@1.0.0-alpha.6", "", { "dependencies": { "commander": "^9.4.0" }, "bin": { "postject": "dist/cli.js" } }, "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A=="],
 
@@ -1785,15 +1884,15 @@
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
-    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
     "react-devtools-inline": ["react-devtools-inline@4.4.0", "", { "dependencies": { "es6-symbol": "^3" } }, "sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ=="],
 
-    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "react-error-boundary": ["react-error-boundary@3.1.4", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA=="],
 
-    "react-grab": ["react-grab@0.1.32", "", { "dependencies": { "@react-grab/cli": "0.1.32", "bippy": "^0.5.39" }, "peerDependencies": { "react": ">=17.0.0" }, "optionalPeers": ["react"], "bin": { "react-grab": "bin/cli.js" } }, "sha512-ODZkzu4zjwX/5a1VxTdIkagPD6uPnp8IkSN2v5FDgFMZkH5r/YEMq43hIsdpHV5/R2ymqS9zLxp4H7SNSRx5ng=="],
+    "react-grab": ["react-grab@0.1.33", "", { "dependencies": { "@react-grab/cli": "0.1.33", "bippy": "^0.5.39" }, "peerDependencies": { "react": ">=17.0.0" }, "optionalPeers": ["react"], "bin": { "react-grab": "bin/cli.js" } }, "sha512-ER919JMsE4TTrb2CpEivqsIjNMSycD4HtS8v7mS3pq67U7WL1K3+C8m9AYOwW4dpuYh+EanC2eJBmfuczHJZ0A=="],
 
     "react-hook-form": ["react-hook-form@7.74.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g=="],
 
@@ -1831,6 +1930,8 @@
 
     "resolve-alpn": ["resolve-alpn@1.2.1", "", {}, "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
@@ -1843,7 +1944,7 @@
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
+    "rolldown": ["rolldown@1.0.0-rc.18", "", { "dependencies": { "@oxc-project/types": "=0.128.0", "@rolldown/pluginutils": "1.0.0-rc.18" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.18", "@rolldown/binding-darwin-arm64": "1.0.0-rc.18", "@rolldown/binding-darwin-x64": "1.0.0-rc.18", "@rolldown/binding-freebsd-x64": "1.0.0-rc.18", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
@@ -1871,19 +1972,19 @@
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
-    "sherpa-onnx-darwin-arm64": ["sherpa-onnx-darwin-arm64@1.12.38", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UIU8gyA2t0oYRobkf2MGUeo0KMjuNn+rHP3y1xZPoZinEVdo+56rUXIJBUbIWmVX4W6mkdKSOHU/ouRKt138vQ=="],
+    "sherpa-onnx-darwin-arm64": ["sherpa-onnx-darwin-arm64@1.13.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dBAiGDPP83CL0rMmHIG2oD+eal4eUNVLumOu5Hsae1f4YPqJ2iXeGF7bZg8HphqQk86K9TfZ4L4NO496sUtuGw=="],
 
-    "sherpa-onnx-darwin-x64": ["sherpa-onnx-darwin-x64@1.12.38", "", { "os": "darwin", "cpu": "x64" }, "sha512-+Wa/RmmZys7UzP9nUnaBq9+npj5LrQ73amqFO5cFX5CycYV1h36Dv+X2nyTYYp1nmt7oI/eKg7VPIvv8iMcHxQ=="],
+    "sherpa-onnx-darwin-x64": ["sherpa-onnx-darwin-x64@1.13.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-/iV/uAkB6dkbqEmxLW4xVrhdAnFPKfA5RTXgeIDmX5926Y30JLWeaxHAnMK2M8swqDtv0Qrh+Ega77R96mP9Sw=="],
 
-    "sherpa-onnx-linux-arm64": ["sherpa-onnx-linux-arm64@1.12.38", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZmH66L6o1QNBh2MYgFFUTsbqEj1q+uwV0ChBIH6nVDHYQBtPyBndbcXv+KmJQSRpTBmRGET10CYZsK5Y+SCpA=="],
+    "sherpa-onnx-linux-arm64": ["sherpa-onnx-linux-arm64@1.13.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-szaiEu0RN/OyaYc5hwaeYvyWvNwh/hmZRHyZKbhdbx8H9ydMgQzirMtKYO//I20l2Ufz0nUPwrpVh5L59jblLg=="],
 
-    "sherpa-onnx-linux-x64": ["sherpa-onnx-linux-x64@1.12.38", "", { "os": "linux", "cpu": "x64" }, "sha512-2kZmoD8kE077gKu5AWYB5P5giqDOjKVd20PvUjdu3+tu6FhFXGiAywP2biTu7ivloWiKtx8nygnih+cCHigx6A=="],
+    "sherpa-onnx-linux-x64": ["sherpa-onnx-linux-x64@1.13.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GYiXTe4lWAICZvJiIvqacCGlxe7A/QveLcgSWHkRidlJfuZ5skLTe4gA/7KoMaxcdhE+SXnlwDUSjVdOgzcOmQ=="],
 
-    "sherpa-onnx-node": ["sherpa-onnx-node@1.12.38", "", { "optionalDependencies": { "sherpa-onnx-darwin-arm64": "^1.12.38", "sherpa-onnx-darwin-x64": "^1.12.38", "sherpa-onnx-linux-arm64": "^1.12.38", "sherpa-onnx-linux-x64": "^1.12.38", "sherpa-onnx-win-ia32": "^1.12.38", "sherpa-onnx-win-x64": "^1.12.38" } }, "sha512-WrfTnQd9uy6Y6aJisnS1X7lELLzc/Q/w6Gi3zj8VawTNL1HIPIAYeKVLuDaxio/0IHanrz0hgu7VIIiDGJkwCQ=="],
+    "sherpa-onnx-node": ["sherpa-onnx-node@1.13.0", "", { "optionalDependencies": { "sherpa-onnx-darwin-arm64": "^1.13.0", "sherpa-onnx-darwin-x64": "^1.13.0", "sherpa-onnx-linux-arm64": "^1.13.0", "sherpa-onnx-linux-x64": "^1.13.0", "sherpa-onnx-win-ia32": "^1.13.0", "sherpa-onnx-win-x64": "^1.13.0" } }, "sha512-2EHPV+6yxp40LQ6JjN3lw/v50bsXO268PtvqAddLgAqcWYTvWAvStPlthv1UTjp0CADhdxizAARkW/+5nQLeQQ=="],
 
-    "sherpa-onnx-win-ia32": ["sherpa-onnx-win-ia32@1.12.38", "", { "os": "win32", "cpu": "ia32" }, "sha512-NBluqnyXM2DemURbTnGPdkpRSQGlhJ+8RbtxFt6hRYSaJ7gTN0154rJ6IebHI7UiZSuXe3r8ZYUs3UZYqhplAQ=="],
+    "sherpa-onnx-win-ia32": ["sherpa-onnx-win-ia32@1.13.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-m8h4rFQUnsI4NP7UezR+yCrdPsU84EUDvPjE/puPJaAlFxcIapD9K6ibnoK4+r3g3QwVbKCIxJnC+fCBW6qr+A=="],
 
-    "sherpa-onnx-win-x64": ["sherpa-onnx-win-x64@1.12.38", "", { "os": "win32", "cpu": "x64" }, "sha512-D7kimY7oosJID+9gTZI3g/Pc43/3ZYQ6EP8rpBhCGTDlND9DaDXpOS7aUCVqUAVRZU3+w6rZyE0s9LVuWoo/9w=="],
+    "sherpa-onnx-win-x64": ["sherpa-onnx-win-x64@1.13.0", "", { "os": "win32", "cpu": "x64" }, "sha512-vDNEt1ztlsG8LLDnuX3Km6WmUDZ9qcwcFhlv4ROERV1qxf9BjK8j3BTg56/1EpQjDogEKBJwi8a4cbiHGPL/hw=="],
 
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
@@ -1929,7 +2030,7 @@
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
-    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
+    "stdin-discarder": ["stdin-discarder@0.3.2", "", {}, "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.4.6", "", {}, "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg=="],
 
@@ -1949,7 +2050,7 @@
 
     "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 
@@ -1971,7 +2072,7 @@
 
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
-    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+    "tar": ["tar@7.5.15", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ=="],
 
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
@@ -2021,11 +2122,13 @@
 
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
-    "typebox": ["typebox@1.1.32", "", {}, "sha512-cbGoj7BCxGcFDJ/RR7wbyMe9IkO2SeNhwLdZWQ+xRtun9+ze9iM1pBND4SoFAxgonuJYrCIWnEQ7sE4bMVDYHA=="],
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "unbash": ["unbash@3.0.0", "", {}, "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="],
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
@@ -2075,11 +2178,13 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
+    "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 
     "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
+    "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
@@ -2115,6 +2220,8 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
@@ -2125,11 +2232,15 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@earendil-works/pi-agent-core/typebox": ["typebox@1.1.32", "", {}, "sha512-cbGoj7BCxGcFDJ/RR7wbyMe9IkO2SeNhwLdZWQ+xRtun9+ze9iM1pBND4SoFAxgonuJYrCIWnEQ7sE4bMVDYHA=="],
+
     "@earendil-works/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@earendil-works/pi-ai/typebox": ["typebox@1.1.32", "", {}, "sha512-cbGoj7BCxGcFDJ/RR7wbyMe9IkO2SeNhwLdZWQ+xRtun9+ze9iM1pBND4SoFAxgonuJYrCIWnEQ7sE4bMVDYHA=="],
 
     "@earendil-works/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@earendil-works/pi-coding-agent/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+    "@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.32", "", {}, "sha512-cbGoj7BCxGcFDJ/RR7wbyMe9IkO2SeNhwLdZWQ+xRtun9+ze9iM1pBND4SoFAxgonuJYrCIWnEQ7sE4bMVDYHA=="],
 
     "@earendil-works/pi-tui/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -2153,6 +2264,8 @@
 
     "@electron/rebuild/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "@electron/rebuild/tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
     "@electron/universal/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "@electron/universal/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
@@ -2173,6 +2286,8 @@
 
     "@react-grab/cli/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -2191,13 +2306,19 @@
 
     "app-builder-lib/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
+    "app-builder-lib/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
     "app-builder-lib/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "app-builder-lib/tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "cacache/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "cacache/tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -2235,10 +2356,6 @@
 
     "lint-staged/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
-
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -2259,11 +2376,13 @@
 
     "node-gyp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "node-gyp/tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "ora/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
@@ -2279,11 +2398,13 @@
 
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.18", "", {}, "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw=="],
 
     "simple-update-notifier/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -2307,6 +2428,8 @@
 
     "uvu/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
+    "vitest/vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
@@ -2324,6 +2447,8 @@
     "@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "@electron/rebuild/ora/cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
+
+    "@electron/rebuild/ora/cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
 
     "@electron/rebuild/ora/is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
 
@@ -2381,13 +2506,15 @@
 
     "minipass-sized/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
-    "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
     "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "vitest/vite/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "vitest/vite/rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -2422,6 +2549,40 @@
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+
+    "vitest/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
     "@electron/rebuild/ora/cli-cursor/restore-cursor/onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 

--- a/desktop/pi-desktop-runtime.ts
+++ b/desktop/pi-desktop-runtime.ts
@@ -8,6 +8,7 @@ import type {
   ProseMessage,
   ThreadData,
 } from '../shared/desktop-contracts.ts'
+import { getPersistedSessionPath } from '../shared/session-paths.ts'
 import { getLatestInboxAssistantMessage } from '../shared/thread-inbox.ts'
 import { loadAppSettings } from './app-settings/readers.ts'
 import { getChatSessionDir } from './chat-session-dir.ts'
@@ -33,6 +34,17 @@ function withComposerModeSettings<TRequest extends ComposerStateRequest>(
   request: TRequest,
 ): TRequest {
   const appSettings = loadAppSettings()
+  const persistedSessionPath = getPersistedSessionPath(request.sessionPath)
+  const composerSessionDir = request.composerMode === 'chat' ? getChatSessionDir() : null
+
+  if (persistedSessionPath) {
+    return {
+      ...request,
+      composerStreamingBehavior: appSettings.composerStreamingBehavior,
+      composerSessionDir,
+    }
+  }
+
   const composerModelSelection =
     request.composerMode === 'chat'
       ? appSettings.chatModel
@@ -52,7 +64,7 @@ function withComposerModeSettings<TRequest extends ComposerStateRequest>(
     composerUseDefaultModel: Boolean(request.composerMode) && composerModelSelection === null,
     composerThinkingLevel,
     composerStreamingBehavior: appSettings.composerStreamingBehavior,
-    composerSessionDir: request.composerMode === 'chat' ? getChatSessionDir() : null,
+    composerSessionDir,
   }
 }
 
@@ -204,14 +216,21 @@ export function getComposerState(request = {}) {
 }
 
 export function setComposerModel(request: ComposerStateRequest, provider: string, modelId: string) {
-  return invokeRuntimeHost('setComposerModel', { request, provider, modelId })
+  return invokeRuntimeHost('setComposerModel', {
+    request: withComposerModeSettings(request),
+    provider,
+    modelId,
+  })
 }
 
 export function setComposerThinkingLevel(
   request: ComposerStateRequest,
   level: ComposerThinkingLevel,
 ) {
-  return invokeRuntimeHost('setComposerThinkingLevel', { request, level })
+  return invokeRuntimeHost('setComposerThinkingLevel', {
+    request: withComposerModeSettings(request),
+    level,
+  })
 }
 
 export function sendComposerPrompt(

--- a/desktop/pi-threads/project-actions.ts
+++ b/desktop/pi-threads/project-actions.ts
@@ -12,7 +12,7 @@ import {
 import { loadAppSettings } from '../app-settings/readers.ts'
 import { deleteArtifactsForConversations } from '../artifact-state-db.ts'
 import { selectProjectRuntime } from '../pi-desktop-runtime.ts'
-import { createProject, createProjectFromGitHubUrl } from '../project-create.ts'
+import { addProjectFromPath, createProject, createProjectFromGitHubUrl } from '../project-create.ts'
 import { getOriginUrl } from '../project-git/project-state.ts'
 import { importProjects, scanKnownProjects } from '../project-import.ts'
 import { openPathWithSystem } from '../system-open-path.ts'
@@ -137,6 +137,15 @@ async function isBusyProjectDeletionTarget(projectId: string) {
 async function createProjectFromPayload(payload: AnyDesktopActionPayload) {
   const appSettings = loadAppSettings()
   const repoUrl = typeof payload.repoUrl === 'string' ? payload.repoUrl.trim() : ''
+  const projectPath = typeof payload.projectPath === 'string' ? payload.projectPath.trim() : ''
+  if (projectPath) {
+    return await addProjectFromPath({
+      projectPath,
+      createIfMissing: payload.createIfMissing === true,
+      initializeGit: appSettings.initializeGitOnProjectCreate,
+    })
+  }
+
   return repoUrl
     ? await createProjectFromGitHubUrl({
         preferredProjectLocation: appSettings.preferredProjectLocation,

--- a/desktop/pi-threads/project-actions.ts
+++ b/desktop/pi-threads/project-actions.ts
@@ -138,6 +138,7 @@ async function createProjectFromPayload(payload: AnyDesktopActionPayload) {
   const appSettings = loadAppSettings()
   const repoUrl = typeof payload.repoUrl === 'string' ? payload.repoUrl.trim() : ''
   const projectPath = typeof payload.projectPath === 'string' ? payload.projectPath.trim() : ''
+  const parentPath = typeof payload.parentPath === 'string' ? payload.parentPath.trim() : ''
   if (projectPath) {
     return await addProjectFromPath({
       projectPath,
@@ -148,11 +149,11 @@ async function createProjectFromPayload(payload: AnyDesktopActionPayload) {
 
   return repoUrl
     ? await createProjectFromGitHubUrl({
-        preferredProjectLocation: appSettings.preferredProjectLocation,
+        preferredProjectLocation: parentPath || appSettings.preferredProjectLocation,
         repositoryUrl: repoUrl,
       })
     : await createProject({
-        preferredProjectLocation: appSettings.preferredProjectLocation,
+        preferredProjectLocation: parentPath || appSettings.preferredProjectLocation,
         projectName: getProjectName(payload) ?? '',
         initializeGit: appSettings.initializeGitOnProjectCreate,
       })

--- a/desktop/project-create.ts
+++ b/desktop/project-create.ts
@@ -64,6 +64,34 @@ export async function createProject(options: {
   return result
 }
 
+export async function addProjectFromPath(options: {
+  projectPath: string
+  createIfMissing: boolean
+  initializeGit: boolean
+}) {
+  const projectPath = options.projectPath.trim()
+  if (projectPath.length === 0) {
+    throw new Error('Choose a folder to add.')
+  }
+
+  const resolvedProjectPath = path.resolve(projectPath)
+  const exists = await directoryExists(resolvedProjectPath)
+  if (!(exists || options.createIfMissing)) {
+    throw new Error('Choose an existing folder or create a new one.')
+  }
+
+  if (!exists) {
+    await mkdir(resolvedProjectPath, { recursive: true })
+    if (options.initializeGit) {
+      await initializeProjectGit(resolvedProjectPath)
+    }
+  }
+
+  const result = await startNewThread({ projectId: resolvedProjectPath })
+  moveProjectToTop(resolvedProjectPath)
+  return result
+}
+
 async function resolvePathIfPresent(projectPath: string) {
   try {
     return await realpath(projectPath)

--- a/desktop/project-create.ts
+++ b/desktop/project-create.ts
@@ -82,9 +82,10 @@ export async function addProjectFromPath(options: {
 
   if (!exists) {
     await mkdir(resolvedProjectPath, { recursive: true })
-    if (options.initializeGit) {
-      await initializeProjectGit(resolvedProjectPath)
-    }
+  }
+
+  if (options.initializeGit) {
+    await initializeProjectGit(resolvedProjectPath)
   }
 
   const result = await startNewThread({ projectId: resolvedProjectPath })

--- a/desktop/project-create.ts
+++ b/desktop/project-create.ts
@@ -74,15 +74,17 @@ export async function addProjectFromPath(options: {
     throw new Error('Choose a folder to add.')
   }
 
-  const resolvedProjectPath = path.resolve(projectPath)
-  const exists = await directoryExists(resolvedProjectPath)
+  const candidateProjectPath = path.resolve(projectPath)
+  const exists = await directoryExists(candidateProjectPath)
   if (!(exists || options.createIfMissing)) {
     throw new Error('Choose an existing folder or create a new one.')
   }
 
   if (!exists) {
-    await mkdir(resolvedProjectPath, { recursive: true })
+    await mkdir(candidateProjectPath, { recursive: true })
   }
+
+  const resolvedProjectPath = await resolvePathIfPresent(candidateProjectPath)
 
   if (options.initializeGit) {
     await initializeProjectGit(resolvedProjectPath)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,23 @@
+### 0.1.64
+
+- Added copy controls to chat and reasoning messages.
+- Made chat text selection less annoying. Dragging over messages should not collapse them.
+- Improved wrapping for long markdown, links, and awkward agent output.
+- Polished compact composer controls.
+- Added a working-state stop button animation. It looks properly agitated when the agent is busy.
+- Smoothed composer resizing, textarea scrolling, and bottom anchoring.
+- Added an in-app folder browser for adding projects.
+- Added project creation and GitHub clone flows from the selected folder.
+- Fixed folder browser edge cases around stale loads and Git initialization.
+- Added targeted Settings routing for setup prompts.
+- Dictation setup now opens the right Settings section instead of leaving you to hunt for it.
+- Missing project location setup now points at the right Settings card.
+- Fixed persisted chats overriding each other’s model/thinking choices.
+- Fixed compact terminal/sidebar behavior, including Pi TUI takeover fold-button alignment.
+- Improved macOS window chrome and quit behavior.
+
+Snapshot: May 10, 2026.
+
 ### 0.1.61-6x hotfixes
 
 - ASAR is back. And then it disappeared. And it's back again.
@@ -45,7 +65,7 @@ Snapshot: May 4, 2026.
 - Added in-app update detection and restart flow.
 - Upgraded the terminal renderer to Ghostty via WTerm 0.3.0.
 - Added loading skeletons across workspace surfaces.
-- Fixed clean desktop shutdown,
+- Fixed clean desktop shutdown.
 - Updated Pi packages to 0.72.1.
 
 Snapshot: May 3, 2026.

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": [
+    "src/main.tsx",
+    "src/electron/main/index.ts",
+    "src/electron/preload/index.ts",
+    "desktop/pi-threads.ts",
+    "desktop/pi-skills.ts",
+    "desktop/skill-creator-session.ts",
+    "desktop/runtime-host/worker.ts",
+    "desktop/terminal/manager.ts",
+    "scripts/*.ts",
+    "pages/src/main.tsx",
+    "packages/howcode/bin/howcode.js",
+    "packages/howcode/lib/howcode.js",
+    "desktop/native-extensions/howcode-native-ask-questions.mjs"
+  ],
+  "project": [
+    "src/**/*.{ts,tsx}",
+    "desktop/**/*.{ts,mjs}",
+    "shared/**/*.{ts,d.ts}",
+    "scripts/**/*.ts",
+    "pages/**/*.{ts,tsx}",
+    "packages/howcode/**/*.{js,cjs,mjs}"
+  ],
+  "ignore": ["build/**", "dist/**", "dist-pages/**", "artifacts/**", "node_modules/**"],
+  "ignoreDependencies": [
+    "@earendil-works/pi-ai",
+    "@earendil-works/pi-tui",
+    "bindings",
+    "clip-filepaths",
+    "file-uri-to-path",
+    "node-pty",
+    "sherpa-onnx-node",
+    "tar",
+    "@types/three",
+    "tailwindcss"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "ai:check": "bun run lint && bun run typecheck && bun run test",
     "pages:dev": "vite --config pages/vite.config.ts",
     "pages:build": "vite build --config pages/vite.config.ts",
-    "pages:preview": "vite preview --config pages/vite.config.ts"
+    "pages:preview": "vite preview --config pages/vite.config.ts",
+    "deadcode": "knip"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,cts,mts,cjs,mjs,json,css,md}": [
@@ -82,7 +83,9 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "sherpa-onnx-node": "^1.12.38",
-    "tar": "^7.5.13"
+    "tar": "^7.5.13",
+    "prismjs": "^1.30.0",
+    "typebox": "^1.1.38"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
@@ -103,7 +106,8 @@
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "knip": "^6.12.1"
   },
   "overrides": {
     "@aws-sdk/client-bedrock-runtime": "^3.1036.0",

--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -1,6 +1,6 @@
 const leadingDotsPattern = /^\.+/
 
-import { mkdir, open, stat } from 'node:fs/promises'
+import { mkdir, open, readdir, realpath, stat } from 'node:fs/promises'
 import http from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
@@ -81,6 +81,47 @@ async function writeUniqueTextFile(directoryPath: string, fileName: string, cont
   throw new Error('Could not find an unused file name in Downloads.')
 }
 
+async function listProjectDirectoryEntries(request: { path?: string | null | undefined }) {
+  const homePath = os.homedir()
+  const requestedPath = request.path?.trim() ? request.path : homePath
+  const currentPath = await realpath(path.resolve(requestedPath)).catch(() =>
+    path.resolve(requestedPath),
+  )
+  const directoryEntries = await readdir(currentPath, { withFileTypes: true })
+  const entries = await Promise.all(
+    directoryEntries
+      .filter(
+        (entry) => !entry.name.startsWith('.') && (entry.isDirectory() || entry.isSymbolicLink()),
+      )
+      .map(async (entry) => {
+        const entryPath = path.join(currentPath, entry.name)
+        if (entry.isDirectory()) {
+          return { path: entryPath, name: entry.name, kind: 'directory' as const }
+        }
+
+        try {
+          const stats = await stat(entryPath)
+          return stats.isDirectory()
+            ? { path: entryPath, name: entry.name, kind: 'directory' as const }
+            : null
+        } catch {
+          return null
+        }
+      }),
+  )
+
+  return {
+    homePath,
+    currentPath,
+    parentPath: path.dirname(currentPath) === currentPath ? null : path.dirname(currentPath),
+    entries: entries
+      .filter((entry): entry is { path: string; name: string; kind: 'directory' } => Boolean(entry))
+      .sort((left, right) =>
+        left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }),
+      ),
+  }
+}
+
 piThreads.subscribeDesktopEvents((event) => {
   sendSseEvent(desktopEventClients, 'desktopEvent', event)
 })
@@ -115,6 +156,7 @@ const handlers: DesktopRequestHandlerMap = {
   continueSkillCreatorSession: (request) => skillCreator.continueSkillCreatorSession(request),
   closeSkillCreatorSession: (request) => skillCreator.closeSkillCreatorSession(request),
   pickComposerAttachments: () => [],
+  listProjectDirectoryEntries,
   readClipboardSnapshot: () => ({ formats: [], valuesByFormat: {} }),
   readClipboardFilePaths: () => ({ filePaths: [], text: null }),
   readClipboardImage: () => null,

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -37,6 +37,8 @@ export type DesktopActionPayloadFields = {
   projectId?: string | undefined | null | undefined
   projectIds?: string[] | undefined
   projectName?: string | undefined
+  projectPath?: string | undefined
+  createIfMissing?: boolean | undefined
   provider?: string | undefined
   queueId?: string | undefined
   answers?: string[][] | undefined | null
@@ -97,6 +99,8 @@ export type DesktopActionPayloadMap = {
   'threads.collapse-all': EmptyActionPayload
   'project.add': {
     projectName?: string | undefined
+    projectPath?: string | undefined
+    createIfMissing?: boolean | undefined
     repoUrl?: string | undefined | null | undefined
   }
   'project.select': {

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -38,6 +38,7 @@ export type DesktopActionPayloadFields = {
   projectIds?: string[] | undefined
   projectName?: string | undefined
   projectPath?: string | undefined
+  parentPath?: string | undefined
   createIfMissing?: boolean | undefined
   provider?: string | undefined
   queueId?: string | undefined
@@ -100,6 +101,7 @@ export type DesktopActionPayloadMap = {
   'project.add': {
     projectName?: string | undefined
     projectPath?: string | undefined
+    parentPath?: string | undefined
     createIfMissing?: boolean | undefined
     repoUrl?: string | undefined | null | undefined
   }

--- a/shared/desktop-ipc.ts
+++ b/shared/desktop-ipc.ts
@@ -163,6 +163,15 @@ export type DesktopRequestMap = {
     params: { projectId?: string | undefined | null | undefined }
     response: ComposerAttachment[]
   }
+  listProjectDirectoryEntries: {
+    params: { path?: string | undefined | null | undefined }
+    response: {
+      homePath: string
+      currentPath: string
+      parentPath: string | null
+      entries: Array<{ path: string; name: string; kind: 'directory' }>
+    }
+  }
   readClipboardSnapshot: {
     params: { formats?: string[] | undefined | null | undefined }
     response: DesktopClipboardSnapshot

--- a/src/app/app-shell/app-shell-layout.tsx
+++ b/src/app/app-shell/app-shell-layout.tsx
@@ -295,7 +295,7 @@ function AppShellSidebar(props: AppShellLayoutViewProps) {
       onToggleSettings={handleToggleSettings}
       onOpenExtensionsView={() => handleShowView('extensions')}
       onOpenSkillsView={() => handleShowView('skills')}
-      onOpenSettingsPanel={() => handleShowView('settings')}
+      onOpenSettingsPanel={(target) => handleShowView('settings', target)}
       onOpenArchivedThreads={() => handleShowView('archived')}
       onDismissInboxThread={controller.handleDismissInboxThread}
       onCreateChatGroup={controller.handleCreateChatGroup}

--- a/src/app/app-shell/app-shell-layout.tsx
+++ b/src/app/app-shell/app-shell-layout.tsx
@@ -1,5 +1,5 @@
 import { PanelLeftOpen, PanelRightClose } from 'lucide-react'
-import type { Dispatch, RefObject, SetStateAction } from 'react'
+import type { CSSProperties, Dispatch, RefObject, SetStateAction } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getPersistedSessionPath, isLocalSessionPath } from '../../../shared/session-paths'
 import { Sidebar } from '../components/sidebar/sidebar'
@@ -378,6 +378,14 @@ function CompactWorkspaceSidebarButton(props: AppShellLayoutViewProps) {
   } = props
   if (!(sidebarCompactMode && !sidebarOverlayOpen && !utilityViewActive)) return null
   const closeVisible = artifactDrawerOverlayVisible && closeArtifactDrawerOverlay
+  const workspaceDockStyle = {
+    '--dock-left-lane': 'max(2rem, calc((100cqw - 800px - 1rem) / 2))',
+  } as CSSProperties
+  const sidebarButtonStyle = compactSidebarButtonEdgeMode
+    ? undefined
+    : ({
+        transform: 'translateX(clamp(2rem, calc(8rem - var(--dock-left-lane)), 2.5rem))',
+      } as CSSProperties)
   return (
     <div
       className={cn(
@@ -385,12 +393,16 @@ function CompactWorkspaceSidebarButton(props: AppShellLayoutViewProps) {
         compactSidebarButtonEdgeMode ? 'px-3' : 'px-5',
       )}
     >
-      <div className="grid w-full grid-cols-[minmax(2rem,1fr)_minmax(0,800px)_minmax(2rem,1fr)] items-end gap-2">
+      <div
+        className="grid w-full grid-cols-[minmax(2rem,1fr)_minmax(0,800px)_minmax(2rem,1fr)] items-end gap-2 [container-type:inline-size]"
+        style={workspaceDockStyle}
+      >
         <div
           className={cn(
-            'pointer-events-auto mb-1.5 min-w-0 justify-self-end self-end',
-            compactSidebarButtonEdgeMode ? 'justify-self-start' : 'translate-x-10',
+            'pointer-events-auto mb-1.5 min-w-0 self-end transition-transform duration-100 ease-out',
+            compactSidebarButtonEdgeMode ? 'justify-self-start' : 'justify-self-end',
           )}
+          style={sidebarButtonStyle}
         >
           <button
             type="button"

--- a/src/app/app-shell/app-shell-layout.tsx
+++ b/src/app/app-shell/app-shell-layout.tsx
@@ -376,7 +376,8 @@ function CompactWorkspaceSidebarButton(props: AppShellLayoutViewProps) {
     closeArtifactDrawerOverlay,
     handleToggleSidebar,
   } = props
-  if (!(sidebarCompactMode && !sidebarOverlayOpen && !utilityViewActive)) return null
+  if (!(sidebarCompactMode && !sidebarOverlayOpen && !utilityViewActive) || props.takeoverVisible)
+    return null
   const closeVisible = artifactDrawerOverlayVisible && closeArtifactDrawerOverlay
   const workspaceDockStyle = {
     '--dock-left-lane': 'max(2rem, calc((100cqw - 800px - 1rem) / 2))',
@@ -533,7 +534,11 @@ function AppShellWorkspaceSection(props: AppShellLayoutViewProps) {
           terminalDrawerVisible={terminalDrawerVisible}
           terminalSessionPath={terminalSessionPath}
           terminalDrawerOverlay={sidebarCompactMode}
+          sidebarCollapsed={sidebarCollapsed}
+          sidebarCompactMode={sidebarCompactMode}
+          sidebarOverlayOpen={props.sidebarOverlayOpen}
           workspaceContentClass={workspaceContentClass}
+          onToggleSidebar={handleToggleSidebar}
           onOpenGitOps={handleOpenGitOpsFromTakeover}
           onSetDiffBaseline={handleSetDiffBaseline}
           hoverToFocus={controller.shellState?.appSettings.hoverToFocus ?? true}

--- a/src/app/app-shell/app-shell-layout.tsx
+++ b/src/app/app-shell/app-shell-layout.tsx
@@ -936,6 +936,15 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
     if (!sidebarCompactMode) setSidebarOverlayOpen(false)
   }, [sidebarCompactMode])
 
+  const previousSidebarCompactModeRef = useRef(sidebarCompactMode)
+  useEffect(() => {
+    const wasSidebarCompactMode = previousSidebarCompactModeRef.current
+    previousSidebarCompactModeRef.current = sidebarCompactMode
+    if (!wasSidebarCompactMode && sidebarCompactMode && terminalDrawerVisible) {
+      controllerRef.current.handleCloseTerminalDrawer()
+    }
+  }, [sidebarCompactMode, terminalDrawerVisible])
+
   useEffect(() => {
     if (!sidebarOverlayOpen) return
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/app/app-shell/app-shell-overlays.tsx
+++ b/src/app/app-shell/app-shell-overlays.tsx
@@ -1,6 +1,8 @@
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useCallback, useRef } from 'react'
 import { TerminalPanel } from '../components/workspace/terminal-panel'
 import type { ProjectDiffBaseline } from '../desktop/types'
+import { cn } from '../utils/cn'
 import type { AppShellController } from './useAppShellController'
 
 const TERMINAL_DRAWER_OFFSET = 'min(28rem, calc(100% - 2.5rem))'
@@ -15,11 +17,54 @@ type AppShellOverlaysProps = {
   terminalDrawerVisible: boolean
   terminalSessionPath: string | null
   terminalDrawerOverlay?: boolean
+  sidebarCollapsed: boolean
+  sidebarCompactMode: boolean
+  sidebarOverlayOpen: boolean
   workspaceContentClass: string
+  onToggleSidebar: () => void
   onOpenGitOps: () => void
   onSetDiffBaseline: (baseline: ProjectDiffBaseline) => void
   hoverToFocus?: boolean
   hoverToBlur?: boolean
+}
+
+type TakeoverSidebarButtonProps = {
+  sidebarCollapsed: boolean
+  sidebarCompactMode: boolean
+  sidebarOverlayOpen: boolean
+  className?: string
+  onToggleSidebar: () => void
+}
+
+function TakeoverSidebarButton({
+  sidebarCollapsed,
+  sidebarCompactMode,
+  sidebarOverlayOpen,
+  className,
+  onToggleSidebar,
+}: TakeoverSidebarButtonProps) {
+  const showSidebarButton = sidebarCompactMode ? !sidebarOverlayOpen : true
+  if (!showSidebarButton) return null
+  const label = sidebarCollapsed || sidebarCompactMode ? 'Show sidebar' : 'Hide sidebar'
+
+  return (
+    <div className={cn('pointer-events-none z-[90]', className)}>
+      <button
+        type="button"
+        className="pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--panel)] text-[color:var(--muted)] opacity-70 shadow-[0_10px_28px_rgba(0,0,0,0.22)] transition hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100"
+        onClick={onToggleSidebar}
+        aria-label={label}
+        data-tooltip={label}
+        data-tooltip-placement="right"
+      >
+        {sidebarCollapsed || sidebarCompactMode ? (
+          <PanelLeftOpen size={15} />
+        ) : (
+          <PanelLeftClose size={15} />
+        )}
+      </button>
+    </div>
+  )
 }
 
 export function AppShellOverlays({
@@ -32,7 +77,10 @@ export function AppShellOverlays({
   terminalDrawerVisible,
   terminalSessionPath,
   terminalDrawerOverlay = false,
-  workspaceContentClass,
+  sidebarCollapsed,
+  sidebarCompactMode,
+  sidebarOverlayOpen,
+  onToggleSidebar,
   onOpenGitOps,
   onSetDiffBaseline,
   hoverToFocus = true,
@@ -49,6 +97,13 @@ export function AppShellOverlays({
   const handleToggleTerminal = useCallback(() => {
     controllerRef.current.handleToggleTerminal()
   }, [])
+  const sidebarButtonProps = {
+    sidebarCollapsed,
+    sidebarCompactMode,
+    sidebarOverlayOpen,
+    onToggleSidebar,
+  }
+  const showSidebarEdgeButton = !(sidebarCompactMode || sidebarCollapsed)
 
   return takeoverPresent ? (
     <div
@@ -63,23 +118,31 @@ export function AppShellOverlays({
             : undefined
         }
       >
-        <div className={`${workspaceContentClass} h-full min-h-0`}>
-          <TerminalPanel
-            key={takeoverTerminalKey}
-            projectId={composerProjectId}
-            sessionPath={terminalSessionPath}
-            onClose={handleReturnToDesktopFromTakeover}
-            onOpenDrawerTerminal={handleToggleTerminal}
-            onOpenGitOps={onOpenGitOps}
-            mode="takeover"
-            projectGitState={projectGitState}
-            diffBaseline={diffBaseline}
-            onSetDiffBaseline={onSetDiffBaseline}
-            hoverToFocus={hoverToFocus}
-            hoverToBlur={hoverToBlur}
-          />
+        <div className="grid h-full min-h-0 w-full grid-cols-[2rem_minmax(0,800px)_2rem] items-end justify-center gap-2">
+          {showSidebarEdgeButton ? null : (
+            <TakeoverSidebarButton {...sidebarButtonProps} className="mb-2 justify-self-end" />
+          )}
+          <div className="col-start-2 h-full min-h-0 w-full">
+            <TerminalPanel
+              key={takeoverTerminalKey}
+              projectId={composerProjectId}
+              sessionPath={terminalSessionPath}
+              onClose={handleReturnToDesktopFromTakeover}
+              onOpenDrawerTerminal={handleToggleTerminal}
+              onOpenGitOps={onOpenGitOps}
+              mode="takeover"
+              projectGitState={projectGitState}
+              diffBaseline={diffBaseline}
+              onSetDiffBaseline={onSetDiffBaseline}
+              hoverToFocus={hoverToFocus}
+              hoverToBlur={hoverToBlur}
+            />
+          </div>
         </div>
       </div>
+      {showSidebarEdgeButton ? (
+        <TakeoverSidebarButton {...sidebarButtonProps} className="absolute bottom-6 left-5" />
+      ) : null}
     </div>
   ) : null
 }

--- a/src/app/app-shell/useAppShellCommands.ts
+++ b/src/app/app-shell/useAppShellCommands.ts
@@ -5,6 +5,7 @@ import type { DesktopActionResult, InboxThread, ShellState } from '../desktop/ty
 import { desktopQueryKeys } from '../query/desktop-query'
 import type { WorkspaceAction, WorkspaceState } from '../state/workspace'
 import type { View } from '../types'
+import type { SettingsOpenTarget } from '../views/settings/settingsTypes'
 import { getProjectSelectionAction } from './scoped-project-view'
 
 type RunDesktopAction = (
@@ -35,6 +36,7 @@ type UseAppShellCommandsInput = {
   scheduleShellStateRefresh: () => void
   setThreadHistoryCompactions: Dispatch<SetStateAction<number>>
   setThreadRefreshKey: Dispatch<SetStateAction<number>>
+  setSettingsOpenTarget: Dispatch<SetStateAction<SettingsOpenTarget | null>>
   shellState: ShellState | null
   workspaceState: WorkspaceState
 }
@@ -60,6 +62,7 @@ export function useAppShellCommands({
   queryClient,
   runDesktopAction,
   scheduleShellStateRefresh,
+  setSettingsOpenTarget,
   setThreadHistoryCompactions,
   setThreadRefreshKey,
   shellState,
@@ -71,7 +74,10 @@ export function useAppShellCommands({
     [dispatch],
   )
 
-  const handleShowView = (view: Exclude<View, 'gitops'>) => {
+  const handleShowView = (view: Exclude<View, 'gitops'>, target?: SettingsOpenTarget) => {
+    if (view === 'settings') {
+      setSettingsOpenTarget(target ?? null)
+    }
     dispatch({ type: 'show-view', view })
   }
 

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -9,6 +9,7 @@ import { useDesktopThreadQuery } from '../hooks/useDesktopThread'
 import { useToast } from '../hooks/useToast'
 import { createChatGroupQuery, getChatSidebarStateQuery } from '../query/desktop-query'
 import { createInitialWorkspaceState, workspaceReducer } from '../state/workspace'
+import type { SettingsOpenTarget } from '../views/settings/settingsTypes'
 import { deriveControllerViewModel } from './controller-view-model'
 import { useAppShellCommands } from './useAppShellCommands'
 import { useAppShellEffects } from './useAppShellEffects'
@@ -29,6 +30,7 @@ export function useAppShellController() {
   const [projectGitLoading, setProjectGitLoading] = useState(false)
   const [extensionsProjectScopeActive, setExtensionsProjectScopeActive] = useState(false)
   const [skillsProjectScopeActive, setSkillsProjectScopeActive] = useState(false)
+  const [settingsOpenTarget, setSettingsOpenTarget] = useState<SettingsOpenTarget | null>(null)
   const [threadRefreshKey, setThreadRefreshKey] = useState(0)
   const [threadHistoryCompactions, setThreadHistoryCompactions] = useState(0)
   const [selectedChatGroupId, setSelectedChatGroupId] = useState<string | null>(null)
@@ -214,6 +216,7 @@ export function useAppShellController() {
     queryClient,
     runDesktopAction,
     scheduleShellStateRefresh,
+    setSettingsOpenTarget,
     setThreadHistoryCompactions,
     setThreadRefreshKey,
     shellState,
@@ -245,6 +248,7 @@ export function useAppShellController() {
     projectGitLoading,
     shellState,
     shellLoading,
+    settingsOpenTarget,
     skillsProjectScopeActive,
     state,
     selectedInboxThread,

--- a/src/app/components/common/markdown-content.tsx
+++ b/src/app/components/common/markdown-content.tsx
@@ -51,7 +51,7 @@ function MarkdownLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
     <a
       {...rest}
       href={href}
-      className="text-[color:var(--markdown-link)] underline decoration-[color:var(--accent-border)] underline-offset-[3px] transition-colors hover:text-[color:var(--accent)]"
+      className="break-words text-[color:var(--markdown-link)] underline decoration-[color:var(--accent-border)] underline-offset-[3px] transition-colors [overflow-wrap:anywhere] hover:text-[color:var(--accent)]"
       onClick={(event) => {
         if (!href) {
           return
@@ -150,7 +150,7 @@ export function MarkdownContent({ markdown, tone = 'default', className }: Markd
   return (
     <div
       className={cn(
-        'grid min-w-0 gap-1.5 text-[14px] leading-[1.68] [overflow-wrap:anywhere] [&_code]:break-all [&_pre_code]:whitespace-pre-wrap [&_pre_code]:break-words [&_pre_code]:text-inherit [&_pre_code]:[overflow-wrap:anywhere]',
+        'grid min-w-0 max-w-full gap-1.5 text-[14px] leading-[1.68] break-words [overflow-wrap:anywhere] [&_*]:min-w-0 [&_code]:break-all [&_pre_code]:whitespace-pre-wrap [&_pre_code]:break-words [&_pre_code]:text-inherit [&_pre_code]:[overflow-wrap:anywhere]',
         className,
       )}
     >
@@ -158,27 +158,32 @@ export function MarkdownContent({ markdown, tone = 'default', className }: Markd
         remarkPlugins={[remarkGfm]}
         components={{
           p: ({ children }) => (
-            <p className={cn('m-0 whitespace-pre-wrap break-words', getToneTextClass(tone))}>
+            <p
+              className={cn(
+                'm-0 max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere]',
+                getToneTextClass(tone),
+              )}
+            >
               {children}
             </p>
           ),
           h1: ({ children }) => (
-            <h1 className="m-0 text-[14px] font-semibold leading-[1.68] text-[color:var(--markdown-heading)]">
+            <h1 className="m-0 max-w-full break-words text-[14px] leading-[1.68] font-semibold text-[color:var(--markdown-heading)] [overflow-wrap:anywhere]">
               {children}
             </h1>
           ),
           h2: ({ children }) => (
-            <h2 className="m-0 text-[14px] font-semibold leading-[1.68] text-[color:var(--markdown-heading)]">
+            <h2 className="m-0 max-w-full break-words text-[14px] leading-[1.68] font-semibold text-[color:var(--markdown-heading)] [overflow-wrap:anywhere]">
               {children}
             </h2>
           ),
           h3: ({ children }) => (
-            <h3 className="m-0 text-[14px] font-semibold leading-[1.68] text-[color:var(--markdown-heading)]">
+            <h3 className="m-0 max-w-full break-words text-[14px] leading-[1.68] font-semibold text-[color:var(--markdown-heading)] [overflow-wrap:anywhere]">
               {children}
             </h3>
           ),
           h4: ({ children }) => (
-            <h4 className="m-0 text-[14px] font-semibold leading-[1.68] text-[color:var(--markdown-heading)]">
+            <h4 className="m-0 max-w-full break-words text-[14px] leading-[1.68] font-semibold text-[color:var(--markdown-heading)] [overflow-wrap:anywhere]">
               {children}
             </h4>
           ),
@@ -193,7 +198,11 @@ export function MarkdownContent({ markdown, tone = 'default', className }: Markd
             </ol>
           ),
           li: ({ children }) => (
-            <li className={cn('min-w-0 break-words', getToneTextClass(tone))}>{children}</li>
+            <li
+              className={cn('min-w-0 break-words [overflow-wrap:anywhere]', getToneTextClass(tone))}
+            >
+              {children}
+            </li>
           ),
           strong: ({ children }) => (
             <strong className={cn('font-semibold', getToneStrongClass(tone))}>{children}</strong>

--- a/src/app/components/common/thread-message.tsx
+++ b/src/app/components/common/thread-message.tsx
@@ -1,3 +1,4 @@
+import { Check, Clipboard } from 'lucide-react'
 import { memo, useEffect, useId, useRef, useState } from 'react'
 import type {
   BashExecutionMessage,
@@ -10,6 +11,51 @@ import type { Message } from '../../types'
 import { getThinkingPreview } from '../../utils/thread-previews'
 import { ExpandablePanel } from './expandable-panel'
 import { MarkdownContent } from './markdown-content'
+
+const copyButtonClass =
+  'inline-flex h-7 w-7 items-center justify-center rounded-lg border border-[color:var(--border)] bg-[color:var(--panel)] text-[color:var(--muted)] opacity-0 shadow-[var(--shadow)] backdrop-blur-sm transition-[opacity,background-color,color,transform] delay-300 duration-150 ease-out hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] hover:opacity-100 hover:delay-0 focus-visible:opacity-100 focus-visible:delay-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-border)] active:scale-[0.96] group-hover/message:opacity-100 group-hover/message:delay-0 group-focus-within/message:opacity-100 group-focus-within/message:delay-0'
+
+function CopyMessageButton({ label, text }: { label: string; text: string }) {
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
+
+  useEffect(() => {
+    if (copyState === 'idle') {
+      return
+    }
+
+    const timeout = window.setTimeout(() => setCopyState('idle'), 1400)
+    return () => window.clearTimeout(timeout)
+  }, [copyState])
+
+  if (text.trim().length === 0) {
+    return null
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopyState('copied')
+    } catch {
+      setCopyState('failed')
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={copyButtonClass}
+      onClick={(event) => {
+        event.stopPropagation()
+        void handleCopy()
+      }}
+      aria-label={copyState === 'copied' ? `Copied ${label}` : `Copy ${label}`}
+      title={copyState === 'failed' ? 'Copy failed' : copyState === 'copied' ? 'Copied' : 'Copy'}
+      data-no-row-toggle="true"
+    >
+      {copyState === 'copied' ? <Check size={13} /> : <Clipboard size={13} />}
+    </button>
+  )
+}
 
 type ThreadMessageProps = {
   message: Message
@@ -43,12 +89,16 @@ function renderThinking(content: string[]) {
   return (
     <div className="grid min-w-0 gap-2 [overflow-wrap:anywhere]">
       {content.map((paragraph) => (
-        <MarkdownContent
-          key={paragraph}
-          markdown={paragraph}
-          tone="thinking"
-          className="gap-1 text-[13px] leading-[1.62]"
-        />
+        <div key={paragraph} className="group/message relative min-w-0 pr-9">
+          <MarkdownContent
+            markdown={paragraph}
+            tone="thinking"
+            className="gap-1 text-[13px] leading-[1.62]"
+          />
+          <div className="absolute top-0 right-0">
+            <CopyMessageButton label="thinking paragraph" text={paragraph} />
+          </div>
+        </div>
       ))}
     </div>
   )
@@ -152,7 +202,7 @@ function SummaryBlock({ label, content }: { label: string; content: string[] }) 
 
 function UserMessageBlock({ message }: { message: ProseMessage }) {
   return (
-    <div className="w-full min-w-0 rounded-2xl border border-[color:var(--accent-border)] bg-[color:var(--message-user-bg)] px-3 py-2 text-[14px] leading-[1.58] text-[color:var(--text)] shadow-[inset_0_1px_0_var(--accent-bg-subtle)]">
+    <div className="group/message relative w-full min-w-0 rounded-2xl border border-[color:var(--accent-border)] bg-[color:var(--message-user-bg)] px-3 py-2 pr-11 text-[14px] leading-[1.58] text-[color:var(--text)] shadow-[inset_0_1px_0_var(--accent-bg-subtle)]">
       <div className="grid min-w-0 gap-3 [overflow-wrap:anywhere]">
         {message.content.map((paragraph) => (
           <MarkdownContent
@@ -162,6 +212,9 @@ function UserMessageBlock({ message }: { message: ProseMessage }) {
             className="text-[14px] leading-[1.58]"
           />
         ))}
+      </div>
+      <div className="absolute top-2 right-2">
+        <CopyMessageButton label="user turn" text={message.content.join('\n\n')} />
       </div>
     </div>
   )
@@ -191,7 +244,12 @@ function AssistantMessageBlock({
         />
       ) : null}
       {showAssistantContent ? (
-        <div className="px-4">{renderProse(message.content, message.format)}</div>
+        <div className="group/message relative px-4 pr-12">
+          {renderProse(message.content, message.format)}
+          <div className="absolute top-0 right-1">
+            <CopyMessageButton label="assistant turn" text={message.content.join('\n\n')} />
+          </div>
+        </div>
       ) : null}
     </div>
   )

--- a/src/app/components/sidebar/projects/sidebar-projects-create-popover.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-create-popover.tsx
@@ -1,4 +1,4 @@
-import { FolderPlus } from 'lucide-react'
+import { FolderPlus, Search } from 'lucide-react'
 import { type RefObject, useEffect, useRef, useState } from 'react'
 import { SidebarProjectsFolderBrowser } from './sidebar-projects-folder-browser'
 
@@ -11,9 +11,8 @@ type SidebarProjectsCreatePopoverProps = {
   errorMessage: string | null
   panelRef?: RefObject<HTMLDialogElement | null>
   onChangeDraft: (value: string) => void
-  onCreate: () => void
+  onCreate: (options?: { parentPath?: string | null }) => void
   onAddFolder: (path: string) => void
-  onCreateFolder: (parentPath: string, folderName: string) => void
   onClose: () => void
 }
 
@@ -28,12 +27,16 @@ export function SidebarProjectsCreatePopover({
   onChangeDraft,
   onCreate,
   onAddFolder,
-  onCreateFolder,
   onClose,
 }: SidebarProjectsCreatePopoverProps) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [browseOpen, setBrowseOpen] = useState(false)
-  const canCreate = draft.trim().length > 0 && !busy && Boolean(defaultLocation)
+  const [browseSearchQuery, setBrowseSearchQuery] = useState('')
+  const [currentFolderPath, setCurrentFolderPath] = useState<string | null>(null)
+  const canSubmit =
+    draft.trim().length > 0 &&
+    !busy &&
+    (Boolean(defaultLocation) || (browseOpen && Boolean(currentFolderPath)))
 
   useEffect(() => {
     if (!open) {
@@ -64,7 +67,7 @@ export function SidebarProjectsCreatePopover({
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
               event.preventDefault()
-              onCreate()
+              onCreate({ parentPath: browseOpen ? currentFolderPath : null })
             }
 
             if (event.key === 'Escape') {
@@ -79,29 +82,34 @@ export function SidebarProjectsCreatePopover({
 
         <button
           type="button"
+          className="sidebar-project-create-submit sidebar-project-browse-toggle"
+          onClick={() => setBrowseOpen((current) => !current)}
+          aria-label={browseOpen ? 'Hide folder browser' : 'Browse folders'}
+          aria-expanded={browseOpen}
+          data-enabled={browseOpen ? 'true' : 'false'}
+        >
+          <Search size={15} />
+        </button>
+
+        <button
+          type="button"
           className="sidebar-project-create-submit"
-          onClick={onCreate}
-          disabled={!canCreate}
-          data-enabled={canCreate ? 'true' : 'false'}
+          onClick={() => onCreate({ parentPath: browseOpen ? currentFolderPath : null })}
+          disabled={!canSubmit}
+          data-enabled={canSubmit ? 'true' : 'false'}
           aria-label={busy ? 'Adding project' : 'Add project'}
           data-tooltip={busy ? 'Adding project' : 'Add project'}
         >
           <FolderPlus size={15} />
         </button>
       </div>
-      <button
-        type="button"
-        className="sidebar-project-browse-toggle"
-        onClick={() => setBrowseOpen((current) => !current)}
-        aria-expanded={browseOpen}
-      >
-        {browseOpen ? 'Hide folders' : 'Browse folders'}
-      </button>
       {browseOpen ? (
         <SidebarProjectsFolderBrowser
           busy={busy}
+          searchQuery={browseSearchQuery}
           onAddFolder={onAddFolder}
-          onCreateFolder={onCreateFolder}
+          onCurrentPathChange={setCurrentFolderPath}
+          onSearchQueryChange={setBrowseSearchQuery}
         />
       ) : null}
       {errorMessage ? <div className="sidebar-inline-error">{errorMessage}</div> : null}

--- a/src/app/components/sidebar/projects/sidebar-projects-create-popover.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-create-popover.tsx
@@ -67,7 +67,9 @@ export function SidebarProjectsCreatePopover({
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
               event.preventDefault()
-              onCreate({ parentPath: browseOpen ? currentFolderPath : null })
+              if (canSubmit) {
+                onCreate({ parentPath: browseOpen ? currentFolderPath : null })
+              }
             }
 
             if (event.key === 'Escape') {

--- a/src/app/components/sidebar/projects/sidebar-projects-create-popover.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-create-popover.tsx
@@ -1,5 +1,6 @@
 import { FolderPlus } from 'lucide-react'
-import { type RefObject, useEffect, useRef } from 'react'
+import { type RefObject, useEffect, useRef, useState } from 'react'
+import { SidebarProjectsFolderBrowser } from './sidebar-projects-folder-browser'
 
 type SidebarProjectsCreatePopoverProps = {
   menuId: string
@@ -11,6 +12,8 @@ type SidebarProjectsCreatePopoverProps = {
   panelRef?: RefObject<HTMLDialogElement | null>
   onChangeDraft: (value: string) => void
   onCreate: () => void
+  onAddFolder: (path: string) => void
+  onCreateFolder: (parentPath: string, folderName: string) => void
   onClose: () => void
 }
 
@@ -24,9 +27,12 @@ export function SidebarProjectsCreatePopover({
   panelRef,
   onChangeDraft,
   onCreate,
+  onAddFolder,
+  onCreateFolder,
   onClose,
 }: SidebarProjectsCreatePopoverProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const [browseOpen, setBrowseOpen] = useState(false)
   const canCreate = draft.trim().length > 0 && !busy && Boolean(defaultLocation)
 
   useEffect(() => {
@@ -34,8 +40,8 @@ export function SidebarProjectsCreatePopover({
       return
     }
 
-    inputRef.current?.focus()
-  }, [open])
+    if (!browseOpen) inputRef.current?.focus()
+  }, [browseOpen, open])
 
   if (!open) {
     return null
@@ -83,6 +89,21 @@ export function SidebarProjectsCreatePopover({
           <FolderPlus size={15} />
         </button>
       </div>
+      <button
+        type="button"
+        className="sidebar-project-browse-toggle"
+        onClick={() => setBrowseOpen((current) => !current)}
+        aria-expanded={browseOpen}
+      >
+        {browseOpen ? 'Hide folders' : 'Browse folders'}
+      </button>
+      {browseOpen ? (
+        <SidebarProjectsFolderBrowser
+          busy={busy}
+          onAddFolder={onAddFolder}
+          onCreateFolder={onCreateFolder}
+        />
+      ) : null}
       {errorMessage ? <div className="sidebar-inline-error">{errorMessage}</div> : null}
     </dialog>
   )

--- a/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, Folder, FolderPlus, Home, Plus } from 'lucide-react'
+import { ChevronLeft, Folder, Home, Plus, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { DesktopRequestMap } from '../../../../../shared/desktop-ipc'
 import { listProjectDirectoryEntriesQuery } from '../../../query/desktop-query'
@@ -7,8 +7,10 @@ type ProjectDirectoryState = DesktopRequestMap['listProjectDirectoryEntries']['r
 
 type SidebarProjectsFolderBrowserProps = {
   busy: boolean
+  searchQuery: string
   onAddFolder: (path: string) => void
-  onCreateFolder: (parentPath: string, folderName: string) => void
+  onCurrentPathChange: (path: string | null) => void
+  onSearchQueryChange: (query: string) => void
 }
 
 const pathSegmentSeparatorPattern = /[\\/]/
@@ -25,37 +27,45 @@ function compactPath(path: string, homePath?: string) {
 
 export function SidebarProjectsFolderBrowser({
   busy,
+  searchQuery,
   onAddFolder,
-  onCreateFolder,
+  onCurrentPathChange,
+  onSearchQueryChange,
 }: SidebarProjectsFolderBrowserProps) {
   const [state, setState] = useState<ProjectDirectoryState | null>(null)
   const [loadingPath, setLoadingPath] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [folderNameDraft, setFolderNameDraft] = useState('')
 
-  const openDirectory = useCallback(async (path?: string | null) => {
-    setLoadingPath(path ?? '__home__')
-    setErrorMessage(null)
-    try {
-      const nextState = await listProjectDirectoryEntriesQuery(path ? { path } : {})
-      setState(nextState)
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'Unable to open folder.')
-    } finally {
-      setLoadingPath(null)
-    }
-  }, [])
+  const openDirectory = useCallback(
+    async (path?: string | null) => {
+      setLoadingPath(path ?? '__home__')
+      setErrorMessage(null)
+      try {
+        const nextState = await listProjectDirectoryEntriesQuery(path ? { path } : {})
+        setState(nextState)
+        onCurrentPathChange(nextState?.currentPath ?? null)
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : 'Unable to open folder.')
+      } finally {
+        setLoadingPath(null)
+      }
+    },
+    [onCurrentPathChange],
+  )
 
   useEffect(() => {
     void openDirectory()
   }, [openDirectory])
 
-  const trimmedFolderName = folderNameDraft.trim()
-  const canCreate = trimmedFolderName.length > 0 && Boolean(state?.currentPath) && !busy
   const currentLabel = useMemo(
     () => compactPath(state?.currentPath ?? 'Home', state?.homePath),
     [state?.currentPath, state?.homePath],
   )
+  const filteredEntries = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    if (!query) return state?.entries ?? []
+    return (state?.entries ?? []).filter((entry) => entry.name.toLowerCase().includes(query))
+  }, [searchQuery, state?.entries])
 
   return (
     <div className="sidebar-project-folder-browser">
@@ -92,11 +102,11 @@ export function SidebarProjectsFolderBrowser({
             disabled={busy}
           >
             <Plus size={13} />
-            <span>Add this folder</span>
+            <span>Initialise project in current folder</span>
           </button>
         ) : null}
 
-        {state?.entries.map((entry) => (
+        {filteredEntries.map((entry) => (
           <button
             key={entry.path}
             type="button"
@@ -113,43 +123,24 @@ export function SidebarProjectsFolderBrowser({
         {!state && loadingPath ? (
           <div className="sidebar-project-folder-empty">Loading…</div>
         ) : null}
-        {state && state.entries.length === 0 ? (
-          <div className="sidebar-project-folder-empty">No folders here.</div>
+        {state && filteredEntries.length === 0 ? (
+          <div className="sidebar-project-folder-empty">
+            {searchQuery.trim() ? 'No matching folders.' : 'No folders here.'}
+          </div>
         ) : null}
       </div>
 
-      <div className="sidebar-project-create-row">
+      <label className="sidebar-project-folder-search">
+        <Search size={12} />
         <input
-          value={folderNameDraft}
-          onChange={(event) => setFolderNameDraft(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' && canCreate && state) {
-              event.preventDefault()
-              onCreateFolder(state.currentPath, trimmedFolderName)
-              setFolderNameDraft('')
-            }
-          }}
-          className="sidebar-project-create-input"
-          placeholder="New folder name"
-          aria-label="New folder name"
+          value={searchQuery}
+          onChange={(event) => onSearchQueryChange(event.target.value)}
+          className="sidebar-project-folder-search-input"
+          placeholder="Search current folder"
+          aria-label="Search current folder"
           disabled={busy}
         />
-        <button
-          type="button"
-          className="sidebar-project-create-submit"
-          onClick={() => {
-            if (state && canCreate) {
-              onCreateFolder(state.currentPath, trimmedFolderName)
-              setFolderNameDraft('')
-            }
-          }}
-          disabled={!canCreate}
-          data-enabled={canCreate ? 'true' : 'false'}
-          aria-label="Create folder and add project"
-        >
-          <FolderPlus size={15} />
-        </button>
-      </div>
+      </label>
       {errorMessage ? <div className="sidebar-inline-error">{errorMessage}</div> : null}
     </div>
   )

--- a/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
@@ -41,6 +41,7 @@ function getPathTail(path: string) {
 function compactPath(path: string, homePath?: string) {
   if (homePath && path === homePath) return '~'
   if (homePath && path.startsWith(`${homePath}/`)) return `~/${path.slice(homePath.length + 1)}`
+  if (homePath && path.startsWith(`${homePath}\\`)) return `~/${path.slice(homePath.length + 1)}`
   return path
 }
 

--- a/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, Folder, Home, Plus, Search } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DesktopRequestMap } from '../../../../../shared/desktop-ipc'
 import { listProjectDirectoryEntriesQuery } from '../../../query/desktop-query'
 
@@ -13,7 +13,26 @@ type SidebarProjectsFolderBrowserProps = {
   onSearchQueryChange: (query: string) => void
 }
 
+type DirectoryLoadResult =
+  | { state: ProjectDirectoryState; errorMessage: null }
+  | { state: null; errorMessage: string }
+
 const pathSegmentSeparatorPattern = /[\\/]/
+
+async function loadDirectory(path?: string | null): Promise<DirectoryLoadResult> {
+  try {
+    const state = await listProjectDirectoryEntriesQuery(path ? { path } : {})
+    if (!state) {
+      return { state: null, errorMessage: 'Unable to open folder.' }
+    }
+    return { state, errorMessage: null }
+  } catch (error) {
+    return {
+      state: null,
+      errorMessage: error instanceof Error ? error.message : 'Unable to open folder.',
+    }
+  }
+}
 
 function getPathTail(path: string) {
   return path.split(pathSegmentSeparatorPattern).filter(Boolean).pop() ?? path
@@ -35,20 +54,26 @@ export function SidebarProjectsFolderBrowser({
   const [state, setState] = useState<ProjectDirectoryState | null>(null)
   const [loadingPath, setLoadingPath] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const requestIdRef = useRef(0)
+  const loading = Boolean(loadingPath)
 
   const openDirectory = useCallback(
     async (path?: string | null) => {
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
       setLoadingPath(path ?? '__home__')
       setErrorMessage(null)
-      try {
-        const nextState = await listProjectDirectoryEntriesQuery(path ? { path } : {})
-        setState(nextState)
-        onCurrentPathChange(nextState?.currentPath ?? null)
-      } catch (error) {
-        setErrorMessage(error instanceof Error ? error.message : 'Unable to open folder.')
-      } finally {
-        setLoadingPath(null)
+      const result = await loadDirectory(path)
+      if (requestIdRef.current !== requestId) {
+        return
       }
+      if (result.state) {
+        setState(result.state)
+        onCurrentPathChange(result.state.currentPath)
+      } else {
+        setErrorMessage(result.errorMessage)
+      }
+      setLoadingPath(null)
     },
     [onCurrentPathChange],
   )
@@ -74,7 +99,7 @@ export function SidebarProjectsFolderBrowser({
           type="button"
           className="sidebar-project-folder-icon-button"
           onClick={() => void openDirectory(state?.parentPath)}
-          disabled={!state?.parentPath || busy}
+          disabled={!state?.parentPath || busy || loading}
           aria-label="Go up"
         >
           <ChevronLeft size={13} />
@@ -83,7 +108,7 @@ export function SidebarProjectsFolderBrowser({
           type="button"
           className="sidebar-project-folder-icon-button"
           onClick={() => void openDirectory(state?.homePath)}
-          disabled={!state?.homePath || busy}
+          disabled={!state?.homePath || busy || loading}
           aria-label="Go home"
         >
           <Home size={13} />
@@ -99,7 +124,7 @@ export function SidebarProjectsFolderBrowser({
             type="button"
             className="sidebar-project-folder-row sidebar-project-folder-row--add"
             onClick={() => onAddFolder(state.currentPath)}
-            disabled={busy}
+            disabled={busy || loading}
           >
             <Plus size={13} />
             <span>Initialise project in current folder</span>
@@ -112,7 +137,7 @@ export function SidebarProjectsFolderBrowser({
             type="button"
             className="sidebar-project-folder-row"
             onClick={() => void openDirectory(entry.path)}
-            disabled={busy}
+            disabled={busy || loading}
             title={entry.path}
           >
             <Folder size={13} />
@@ -138,7 +163,7 @@ export function SidebarProjectsFolderBrowser({
           className="sidebar-project-folder-search-input"
           placeholder="Search current folder"
           aria-label="Search current folder"
-          disabled={busy}
+          disabled={busy || loading}
         />
       </label>
       {errorMessage ? <div className="sidebar-inline-error">{errorMessage}</div> : null}

--- a/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-folder-browser.tsx
@@ -1,0 +1,160 @@
+import { ChevronLeft, Folder, FolderPlus, Home, Plus } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { DesktopRequestMap } from '../../../../../shared/desktop-ipc'
+import { listProjectDirectoryEntriesQuery } from '../../../query/desktop-query'
+
+type ProjectDirectoryState = DesktopRequestMap['listProjectDirectoryEntries']['response']
+
+type SidebarProjectsFolderBrowserProps = {
+  busy: boolean
+  onAddFolder: (path: string) => void
+  onCreateFolder: (parentPath: string, folderName: string) => void
+}
+
+const pathSegmentSeparatorPattern = /[\\/]/
+
+function getPathTail(path: string) {
+  return path.split(pathSegmentSeparatorPattern).filter(Boolean).pop() ?? path
+}
+
+function compactPath(path: string, homePath?: string) {
+  if (homePath && path === homePath) return '~'
+  if (homePath && path.startsWith(`${homePath}/`)) return `~/${path.slice(homePath.length + 1)}`
+  return path
+}
+
+export function SidebarProjectsFolderBrowser({
+  busy,
+  onAddFolder,
+  onCreateFolder,
+}: SidebarProjectsFolderBrowserProps) {
+  const [state, setState] = useState<ProjectDirectoryState | null>(null)
+  const [loadingPath, setLoadingPath] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [folderNameDraft, setFolderNameDraft] = useState('')
+
+  const openDirectory = useCallback(async (path?: string | null) => {
+    setLoadingPath(path ?? '__home__')
+    setErrorMessage(null)
+    try {
+      const nextState = await listProjectDirectoryEntriesQuery(path ? { path } : {})
+      setState(nextState)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to open folder.')
+    } finally {
+      setLoadingPath(null)
+    }
+  }, [])
+
+  useEffect(() => {
+    void openDirectory()
+  }, [openDirectory])
+
+  const trimmedFolderName = folderNameDraft.trim()
+  const canCreate = trimmedFolderName.length > 0 && Boolean(state?.currentPath) && !busy
+  const currentLabel = useMemo(
+    () => compactPath(state?.currentPath ?? 'Home', state?.homePath),
+    [state?.currentPath, state?.homePath],
+  )
+
+  return (
+    <div className="sidebar-project-folder-browser">
+      <div className="sidebar-project-folder-header">
+        <button
+          type="button"
+          className="sidebar-project-folder-icon-button"
+          onClick={() => void openDirectory(state?.parentPath)}
+          disabled={!state?.parentPath || busy}
+          aria-label="Go up"
+        >
+          <ChevronLeft size={13} />
+        </button>
+        <button
+          type="button"
+          className="sidebar-project-folder-icon-button"
+          onClick={() => void openDirectory(state?.homePath)}
+          disabled={!state?.homePath || busy}
+          aria-label="Go home"
+        >
+          <Home size={13} />
+        </button>
+        <div className="sidebar-project-folder-path" title={state?.currentPath ?? undefined}>
+          {currentLabel}
+        </div>
+      </div>
+
+      <div className="sidebar-project-folder-list" aria-busy={loadingPath ? 'true' : 'false'}>
+        {state ? (
+          <button
+            type="button"
+            className="sidebar-project-folder-row sidebar-project-folder-row--add"
+            onClick={() => onAddFolder(state.currentPath)}
+            disabled={busy}
+          >
+            <Plus size={13} />
+            <span>Add this folder</span>
+          </button>
+        ) : null}
+
+        {state?.entries.map((entry) => (
+          <button
+            key={entry.path}
+            type="button"
+            className="sidebar-project-folder-row"
+            onClick={() => void openDirectory(entry.path)}
+            disabled={busy}
+            title={entry.path}
+          >
+            <Folder size={13} />
+            <span>{entry.name}</span>
+          </button>
+        ))}
+
+        {!state && loadingPath ? (
+          <div className="sidebar-project-folder-empty">Loading…</div>
+        ) : null}
+        {state && state.entries.length === 0 ? (
+          <div className="sidebar-project-folder-empty">No folders here.</div>
+        ) : null}
+      </div>
+
+      <div className="sidebar-project-create-row">
+        <input
+          value={folderNameDraft}
+          onChange={(event) => setFolderNameDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && canCreate && state) {
+              event.preventDefault()
+              onCreateFolder(state.currentPath, trimmedFolderName)
+              setFolderNameDraft('')
+            }
+          }}
+          className="sidebar-project-create-input"
+          placeholder="New folder name"
+          aria-label="New folder name"
+          disabled={busy}
+        />
+        <button
+          type="button"
+          className="sidebar-project-create-submit"
+          onClick={() => {
+            if (state && canCreate) {
+              onCreateFolder(state.currentPath, trimmedFolderName)
+              setFolderNameDraft('')
+            }
+          }}
+          disabled={!canCreate}
+          data-enabled={canCreate ? 'true' : 'false'}
+          aria-label="Create folder and add project"
+        >
+          <FolderPlus size={15} />
+        </button>
+      </div>
+      {errorMessage ? <div className="sidebar-inline-error">{errorMessage}</div> : null}
+    </div>
+  )
+}
+
+export function getSidebarFolderProjectName(projectPath: string) {
+  return getPathTail(projectPath)
+}

--- a/src/app/components/sidebar/projects/sidebar-projects-section.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-section.tsx
@@ -14,11 +14,14 @@ import {
   type SidebarProjectsFilterMode,
 } from './sidebar-projects.helpers'
 import { SidebarProjectsCreatePopover } from './sidebar-projects-create-popover'
+import { getSidebarFolderProjectName } from './sidebar-projects-folder-browser'
 
 type PendingProject = {
   key: string
   name: string
 }
+
+const trailingPathSeparatorsPattern = /[\\/]+$/
 
 type SidebarProjectsSectionProps = {
   activeView: View
@@ -112,6 +115,11 @@ function getCreateProjectPayload(draft: string) {
     pendingProjectName: repository?.folderName ?? draft,
     payload: repository ? { repoUrl: repository.canonicalUrl } : { projectName: draft },
   }
+}
+
+function joinProjectFolderPath(parentPath: string, folderName: string) {
+  const separator = parentPath.includes('\\') && !parentPath.includes('/') ? '\\' : '/'
+  return `${parentPath.replace(trailingPathSeparatorsPattern, '')}${separator}${folderName}`
 }
 
 function PendingProjectRow({ pendingProject }: { pendingProject: PendingProject }) {
@@ -384,6 +392,40 @@ export function SidebarProjectsSection({
     }
   }
 
+  const handleAddFolderProject = async (projectPath: string, options?: { create?: boolean }) => {
+    if (createBusy) return
+    const pendingProjectName = getSidebarFolderProjectName(projectPath)
+    setCreateErrorMessage(null)
+    setPendingProject({ key: `${Date.now()}:${projectPath}`, name: pendingProjectName })
+    setProjectNameDraft('')
+    setCreateOpen(false)
+    setCreateBusy(true)
+
+    try {
+      const result = await onAction('project.add', {
+        projectPath,
+        createIfMissing: options?.create === true,
+      })
+      const error = typeof result?.result?.error === 'string' ? result.result.error : null
+
+      if (error) {
+        setCreateErrorMessage(error)
+        setCreateOpen(true)
+        setPendingProject(null)
+        return
+      }
+
+      recordCreatedProject({ result, setCreatedProjectIds })
+      setPendingProject(null)
+    } catch (error) {
+      setCreateErrorMessage(error instanceof Error ? error.message : 'Unable to add project.')
+      setCreateOpen(true)
+      setPendingProject(null)
+    } finally {
+      setCreateBusy(false)
+    }
+  }
+
   if (!showProjects) {
     return <section className="sidebar-section" aria-hidden="true" />
   }
@@ -419,11 +461,6 @@ export function SidebarProjectsSection({
                 label="Add new project"
                 tooltipPlacement="right"
                 onClick={() => {
-                  if (!appSettings.preferredProjectLocation) {
-                    onOpenSettingsPanel()
-                    return
-                  }
-
                   setCreateErrorMessage(null)
                   setCreateOpen(true)
                 }}
@@ -445,6 +482,14 @@ export function SidebarProjectsSection({
             onChangeDraft={setProjectNameDraft}
             onCreate={() => {
               void handleCreateProject()
+            }}
+            onAddFolder={(projectPath) => {
+              void handleAddFolderProject(projectPath)
+            }}
+            onCreateFolder={(parentPath, folderName) => {
+              void handleAddFolderProject(joinProjectFolderPath(parentPath, folderName), {
+                create: true,
+              })
             }}
             onClose={() => {
               setCreateOpen(false)

--- a/src/app/components/sidebar/projects/sidebar-projects-section.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-section.tsx
@@ -21,8 +21,6 @@ type PendingProject = {
   name: string
 }
 
-const trailingPathSeparatorsPattern = /[\\/]+$/
-
 type SidebarProjectsSectionProps = {
   activeView: View
   appLaunchedAtMs: number
@@ -93,6 +91,7 @@ function recordCreatedProject(input: {
 function prepareCreateProject(input: {
   appSettings: AppSettings
   createBusy: boolean
+  parentPath?: string | null | undefined
   onOpenSettingsPanel: () => void
   projectNameDraft: string
   setCreateErrorMessage: (message: string | null) => void
@@ -100,7 +99,7 @@ function prepareCreateProject(input: {
 }) {
   if (input.createBusy) return null
   input.setCreateErrorMessage(null)
-  if (!input.appSettings.preferredProjectLocation) {
+  if (!(input.parentPath || input.appSettings.preferredProjectLocation)) {
     input.setCreateOpen(false)
     input.onOpenSettingsPanel()
     return null
@@ -109,17 +108,14 @@ function prepareCreateProject(input: {
   return draft || null
 }
 
-function getCreateProjectPayload(draft: string) {
+function getCreateProjectPayload(draft: string, parentPath?: string | null) {
   const repository = parseGitHubRepositoryUrl(draft)
   return {
     pendingProjectName: repository?.folderName ?? draft,
-    payload: repository ? { repoUrl: repository.canonicalUrl } : { projectName: draft },
+    payload: repository
+      ? { repoUrl: repository.canonicalUrl, parentPath: parentPath ?? undefined }
+      : { projectName: draft, parentPath: parentPath ?? undefined },
   }
-}
-
-function joinProjectFolderPath(parentPath: string, folderName: string) {
-  const separator = parentPath.includes('\\') && !parentPath.includes('/') ? '\\' : '/'
-  return `${parentPath.replace(trailingPathSeparatorsPattern, '')}${separator}${folderName}`
 }
 
 function PendingProjectRow({ pendingProject }: { pendingProject: PendingProject }) {
@@ -355,10 +351,11 @@ export function SidebarProjectsSection({
     refs: [createButtonRef, createPanelRef],
   })
 
-  const handleCreateProject = async () => {
+  const handleCreateProject = async (options?: { parentPath?: string | null }) => {
     const draft = prepareCreateProject({
       appSettings,
       createBusy,
+      parentPath: options?.parentPath,
       onOpenSettingsPanel,
       projectNameDraft,
       setCreateErrorMessage,
@@ -366,7 +363,7 @@ export function SidebarProjectsSection({
     })
     if (!draft) return
 
-    const { payload, pendingProjectName } = getCreateProjectPayload(draft)
+    const { payload, pendingProjectName } = getCreateProjectPayload(draft, options?.parentPath)
     setPendingProject({ key: `${Date.now()}:${draft}`, name: pendingProjectName })
     setProjectNameDraft('')
     setCreateOpen(false)
@@ -480,16 +477,11 @@ export function SidebarProjectsSection({
             errorMessage={createErrorMessage}
             panelRef={createPanelRef}
             onChangeDraft={setProjectNameDraft}
-            onCreate={() => {
-              void handleCreateProject()
+            onCreate={(options) => {
+              void handleCreateProject(options)
             }}
             onAddFolder={(projectPath) => {
               void handleAddFolderProject(projectPath)
-            }}
-            onCreateFolder={(parentPath, folderName) => {
-              void handleAddFolderProject(joinProjectFolderPath(parentPath, folderName), {
-                create: true,
-              })
             }}
             onClose={() => {
               setCreateOpen(false)

--- a/src/app/components/sidebar/projects/sidebar-projects-section.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-section.tsx
@@ -6,6 +6,7 @@ import { useDesktopBridgeAvailable } from '../../../hooks/useDesktopBridge'
 import { useDismissibleLayer } from '../../../hooks/useDismissibleLayer'
 import type { Project, View } from '../../../types'
 import { cn } from '../../../utils/cn'
+import type { SettingsOpenTarget } from '../../../views/settings/settingsTypes'
 import { IconButton } from '../../common/icon-button'
 import { ProjectTree } from '../project-tree'
 import { SidebarProjectsSkeleton } from '../sidebar-skeletons'
@@ -36,7 +37,7 @@ type SidebarProjectsSectionProps = {
   collapsedProjectIds: Record<string, boolean>
   onAction: DesktopActionInvoker
   onLoadProjectThreads: (projectId: string, options?: { chat?: boolean }) => Promise<unknown>
-  onOpenSettingsPanel: () => void
+  onOpenSettingsPanel: (target?: SettingsOpenTarget) => void
   onProjectSelect: (projectId: string) => void
   onProjectPrimeSelection: (projectId: string) => void
   onProjectReorder: (projectIds: string[]) => void
@@ -92,7 +93,7 @@ function prepareCreateProject(input: {
   appSettings: AppSettings
   createBusy: boolean
   parentPath?: string | null | undefined
-  onOpenSettingsPanel: () => void
+  onOpenSettingsPanel: (target?: SettingsOpenTarget) => void
   projectNameDraft: string
   setCreateErrorMessage: (message: string | null) => void
   setCreateOpen: (open: boolean) => void
@@ -101,7 +102,7 @@ function prepareCreateProject(input: {
   input.setCreateErrorMessage(null)
   if (!(input.parentPath || input.appSettings.preferredProjectLocation)) {
     input.setCreateOpen(false)
-    input.onOpenSettingsPanel()
+    input.onOpenSettingsPanel({ category: 'projects', settingId: 'projects.default-location' })
     return null
   }
   const draft = input.projectNameDraft.trim()

--- a/src/app/components/sidebar/settings-menu.tsx
+++ b/src/app/components/sidebar/settings-menu.tsx
@@ -3,6 +3,7 @@ import type { ReactNode, RefObject } from 'react'
 import { type FeatureStatusId, getFeatureStatusDataAttributes } from '../../features/feature-status'
 import { useAppUpdateFlow } from '../../hooks/useAppUpdateFlow'
 import { cn } from '../../utils/cn'
+import type { SettingsOpenTarget } from '../../views/settings/settingsTypes'
 import { FeatureStatusBadge } from '../common/feature-status-badge'
 import { SurfacePanel } from '../common/surface-panel'
 
@@ -11,7 +12,7 @@ type SettingsMenuProps = {
   open: boolean
   onOpenExtensionsView: () => void
   onOpenSkillsView: () => void
-  onOpenSettingsPanel: () => void
+  onOpenSettingsPanel: (target?: SettingsOpenTarget) => void
   onOpenArchivedThreads: () => void
   panelRef?: RefObject<HTMLDivElement | null>
 }

--- a/src/app/components/sidebar/sidebar.tsx
+++ b/src/app/components/sidebar/sidebar.tsx
@@ -17,6 +17,7 @@ import type {
 import { useAnimatedPresence } from '../../hooks/useAnimatedPresence'
 import { useDismissibleLayer } from '../../hooks/useDismissibleLayer'
 import type { Project, View } from '../../types'
+import type { SettingsOpenTarget } from '../../views/settings/settingsTypes'
 import { Tooltip } from '../common/tooltip'
 
 type SidebarNavigableView = Exclude<View, 'gitops'>
@@ -53,7 +54,7 @@ type SidebarProps = {
   onToggleSettings: () => void
   onOpenExtensionsView: () => void
   onOpenSkillsView: () => void
-  onOpenSettingsPanel: () => void
+  onOpenSettingsPanel: (target?: SettingsOpenTarget) => void
   onOpenArchivedThreads: () => void
   onDismissInboxThread: (thread: InboxThread) => void
   onCreateChatGroup: (name: string) => Promise<unknown>

--- a/src/app/components/workspace/composer.tsx
+++ b/src/app/components/workspace/composer.tsx
@@ -12,6 +12,7 @@ import type {
   ProjectGitState,
 } from '../../desktop/types'
 import type { View } from '../../types'
+import type { SettingsOpenTarget } from '../../views/settings/settingsTypes'
 import { ComposerPromptSurface } from './composer/composer-prompt-surface'
 import type { SavedDiffComment } from './diff/diffCommentStore'
 
@@ -52,7 +53,7 @@ export type ComposerProps = {
   promptResetKey: number
   onOpenTakeoverTerminal: () => void
   onOpenGitOpsView: () => void
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   onRestoredQueuedPromptApplied: () => void
   onToggleTerminal: () => void
   onToggleArtifacts?: (() => void) | undefined

--- a/src/app/components/workspace/composer/composer-dictation-controls.tsx
+++ b/src/app/components/workspace/composer/composer-dictation-controls.tsx
@@ -1,10 +1,12 @@
 import { AudioLines, Check, FileAudio, Mic, X } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { DesktopActionInvoker } from '../../../desktop/types'
 import { useAnimatedPresence } from '../../../hooks/useAnimatedPresence'
 import { useDismissibleLayer } from '../../../hooks/useDismissibleLayer'
-import { compactCardClass, compactIconButtonClass, iconButtonClass } from '../../../ui/classes'
+import { compactIconButtonClass, iconButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
+import type { SettingsOpenTarget } from '../../../views/settings/settingsTypes'
 import { TextButton } from '../../common/text-button'
 
 type ComposerDictationControlsProps = {
@@ -14,7 +16,7 @@ type ComposerDictationControlsProps = {
   dictationTranscribing: boolean
   placement?: 'inline' | 'trailing'
   onAction: DesktopActionInvoker
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   showDictationButton: boolean
   toggleDictation: () => Promise<'started' | 'stopped' | 'setup-required' | 'unavailable'>
 }
@@ -42,57 +44,99 @@ function getDictationButtonTooltip(input: {
 }
 
 function DictationPrompt({
+  anchorRef,
   onAction,
   onDismiss,
   onOpenSettingsView,
   open,
   promptRef,
 }: {
+  anchorRef: React.RefObject<HTMLButtonElement | null>
   onAction: DesktopActionInvoker
   onDismiss: () => void
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   open: boolean
   promptRef: React.RefObject<HTMLDivElement | null>
 }) {
-  return (
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null)
+
+  useLayoutEffect(() => {
+    if (!open) return
+
+    const updatePosition = () => {
+      const anchorRect = anchorRef.current?.getBoundingClientRect()
+      if (!anchorRect) return
+
+      const promptRect = promptRef.current?.getBoundingClientRect()
+      const viewportPadding = 12
+      const promptWidth = promptRect?.width ?? 312
+      const promptHeight = promptRect?.height ?? 42
+      const preferredLeft = anchorRect.right - promptWidth
+      const left = Math.min(
+        window.innerWidth - viewportPadding - promptWidth,
+        Math.max(viewportPadding, preferredLeft),
+      )
+      const topAbove = anchorRect.top - promptHeight - 10
+      const top =
+        topAbove >= viewportPadding
+          ? topAbove
+          : Math.min(window.innerHeight - viewportPadding - promptHeight, anchorRect.bottom + 10)
+
+      setPosition({ left, top })
+    }
+
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [anchorRef, open, promptRef])
+
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
     <div
       ref={promptRef}
       data-open={open ? 'true' : 'false'}
+      role="dialog"
+      aria-label="Install speech-to-text model"
+      style={position ? { left: `${position.left}px`, top: `${position.top}px` } : undefined}
       className={cn(
-        compactCardClass,
-        'absolute right-[calc(100%+8px)] top-1/2 z-20 inline-flex items-center gap-1.5 whitespace-nowrap -translate-y-1/2 rounded-full px-2 py-1 text-[10.5px] shadow-[0_18px_40px_rgba(0,0,0,0.28)] transition-[opacity,transform] duration-180 ease-out',
-        open ? 'translate-x-0 opacity-100' : 'pointer-events-none translate-x-2 opacity-0',
+        'fixed z-[140] inline-flex max-w-[calc(100vw-1.5rem)] items-center gap-1.5 rounded-full border border-[color:var(--border-strong)] bg-[color:var(--panel)] px-2 py-1 text-[11px] shadow-[0_18px_40px_rgba(0,0,0,0.34)] transition-[opacity,transform] duration-180 ease-out',
+        open ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-1 opacity-0',
+        !position && 'opacity-0',
       )}
     >
-      <span className="pr-1 text-[10.5px] text-[color:var(--text)] whitespace-nowrap">
+      <span className="whitespace-nowrap text-[11px] leading-4 text-[color:var(--text)]">
         No speech-to-text model detected. Install?
       </span>
-      <button
-        type="button"
-        className={cn(
-          compactIconButtonClass,
-          'h-6 w-6 rounded-full bg-[color:var(--accent)] text-[color:var(--accent-contrast)] hover:bg-[color:var(--accent)] hover:text-[color:var(--accent-contrast)]',
-        )}
-        onClick={() => {
-          onDismiss()
-          onOpenSettingsView()
-        }}
-        aria-label="Open app settings to install speech-to-text"
-        data-tooltip="Open app settings"
-      >
-        <Check size={12} />
-      </button>
-      <button
-        type="button"
-        className={cn(compactIconButtonClass, 'h-6 w-6 rounded-full')}
-        onClick={onDismiss}
-        aria-label="Dismiss dictation setup prompt"
-        data-tooltip="Dismiss"
-      >
-        <X size={12} />
-      </button>
+      <div className="inline-flex shrink-0 items-center justify-end gap-1">
+        <button
+          type="button"
+          className="inline-flex h-6 items-center gap-1 rounded-full bg-[color:var(--accent)] px-2 text-[10.5px] font-medium text-[color:var(--accent-contrast)] transition-transform active:scale-[0.96]"
+          onClick={() => {
+            onDismiss()
+            onOpenSettingsView({ category: 'dictation', settingId: 'dictation.models' })
+          }}
+          aria-label="Open dictation settings to install speech-to-text"
+        >
+          <Check size={12} />
+          Yes
+        </button>
+        <button
+          type="button"
+          className={cn(compactIconButtonClass, 'h-6 w-6 rounded-full')}
+          onClick={onDismiss}
+          aria-label="Dismiss dictation setup prompt"
+          data-tooltip="Dismiss"
+        >
+          <X size={12} />
+        </button>
+      </div>
       <TextButton
-        className="rounded-full border border-[color:var(--danger-border)] px-2 py-0.5 text-[10px] leading-4 whitespace-nowrap text-[color:var(--danger)] hover:border-[color:var(--danger-border)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]"
+        className="shrink-0 rounded-full border border-[color:var(--danger-border)] px-2 py-0.5 text-[10px] leading-4 whitespace-nowrap text-[color:var(--danger)] hover:border-[color:var(--danger-border)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]"
         onClick={() => {
           onDismiss()
           void onAction('settings.update', { key: 'showDictationButton', value: false })
@@ -100,7 +144,8 @@ function DictationPrompt({
       >
         Hide permanently
       </TextButton>
-    </div>
+    </div>,
+    document.body,
   )
 }
 
@@ -148,6 +193,7 @@ export function ComposerDictationControls({
     <div className={cn('relative', placement === 'trailing' && 'h-6 w-6 shrink-0')}>
       {dictationPromptPresent ? (
         <DictationPrompt
+          anchorRef={dictationButtonRef}
           onAction={onAction}
           onDismiss={() => setDictationPromptOpen(false)}
           onOpenSettingsView={onOpenSettingsView}
@@ -165,14 +211,14 @@ export function ComposerDictationControls({
         }}
         className={cn(
           placement === 'trailing'
-            ? 'inline-flex h-6 w-6 items-center justify-center rounded-full border border-transparent bg-transparent text-[color:var(--muted-2)] opacity-45 transition-colors hover:bg-[rgba(255,255,255,0.035)] hover:text-[color:var(--muted)] hover:opacity-70'
+            ? 'inline-flex h-6 w-6 items-center justify-center rounded-full border border-transparent bg-transparent text-[color:var(--muted-2)] transition-colors hover:bg-[rgba(255,255,255,0.035)] hover:text-[color:var(--muted)]'
             : iconButtonClass,
           dictationActive &&
-            'border-[color:var(--danger-border)] bg-[color:var(--danger-bg)] text-[color:var(--danger)] opacity-100',
+            'border-[color:var(--danger-border)] bg-[color:var(--danger-bg)] text-[color:var(--danger)]',
           dictationTranscribing &&
-            'border-[color:var(--accent-border)] bg-[color:var(--accent-bg)] text-[color:var(--text)] opacity-100',
+            'border-[color:var(--accent-border)] bg-[color:var(--accent-bg)] text-[color:var(--text)]',
           dictationPromptOpen &&
-            'border-[color:var(--accent-border)] bg-[color:var(--accent-bg-subtle)] text-[color:var(--text)] opacity-100',
+            'border-[color:var(--accent-border)] bg-[color:var(--accent-bg-subtle)] text-[color:var(--text)]',
         )}
         aria-label={getDictationButtonAriaLabel({ dictationActive, dictationTranscribing })}
         aria-pressed={dictationActive || dictationTranscribing || dictationPromptOpen}

--- a/src/app/components/workspace/composer/composer-diff-baseline-selector.tsx
+++ b/src/app/components/workspace/composer/composer-diff-baseline-selector.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { Check, GitBranch, Search } from 'lucide-react'
+import { Check, GitCompareArrows, Search } from 'lucide-react'
 import { type RefObject, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type {
@@ -505,7 +505,7 @@ export function ComposerDiffBaselineSelector({
         aria-label="Diff baseline selector"
         data-tooltip="Diff baseline"
       >
-        <GitBranch size={14} />
+        <GitCompareArrows size={14} />
       </button>
       {open ? (
         <BaselineSelectorPortal

--- a/src/app/components/workspace/composer/composer-git-ops-surface.tsx
+++ b/src/app/components/workspace/composer/composer-git-ops-surface.tsx
@@ -9,6 +9,7 @@ import type {
 import { getFeatureStatusDataAttributes } from '../../../features/feature-status'
 import { composerTextActionButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
+import type { SettingsOpenTarget } from '../../../views/settings/settingsTypes'
 import type { SavedDiffComment } from '../diff/diffCommentStore'
 import { ComposerDictationControls } from './composer-dictation-controls'
 import { ComposerGitOpsFooter } from './composer-git-ops-footer'
@@ -21,7 +22,7 @@ type ComposerGitOpsSurfaceProps = {
   dictationModelId: string | null
   dictationMaxDurationSeconds: number
   composerPanelRef: RefObject<HTMLDivElement | null>
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   projectGitState: ProjectGitState | null
   projectId: string
   sessionPath: string | null

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -434,6 +434,7 @@ export function ComposerPromptInputPanel({
                     />
                   ) : null
                 }
+                trailingAdornmentEnabled={showDictationButton}
                 trailingAdornment={
                   <ComposerDictationControls
                     dictationActive={dictationActive}

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -122,42 +122,6 @@ type ComposerKeyDownInput = {
   setDraft: (value: string) => void
 }
 
-function ComposerPromptDictationAdornment({
-  dictationActive,
-  dictationMissingModel,
-  dictationSupported,
-  dictationTranscribing,
-  onAction,
-  onOpenSettingsView,
-  showDictationButton,
-  toggleDictation,
-}: Pick<
-  ComposerPromptInputPanelProps,
-  | 'dictationActive'
-  | 'dictationMissingModel'
-  | 'dictationSupported'
-  | 'dictationTranscribing'
-  | 'onAction'
-  | 'onOpenSettingsView'
-  | 'showDictationButton'
-  | 'toggleDictation'
->) {
-  if (!showDictationButton) return null
-  return (
-    <ComposerDictationControls
-      dictationActive={dictationActive}
-      dictationMissingModel={dictationMissingModel}
-      dictationSupported={dictationSupported}
-      dictationTranscribing={dictationTranscribing}
-      placement="trailing"
-      onAction={onAction}
-      onOpenSettingsView={onOpenSettingsView}
-      showDictationButton={showDictationButton}
-      toggleDictation={toggleDictation}
-    />
-  )
-}
-
 function isCursorAtStart(textarea: HTMLTextAreaElement) {
   return textarea.selectionStart === textarea.selectionEnd && textarea.selectionStart === 0
 }
@@ -471,11 +435,12 @@ export function ComposerPromptInputPanel({
                   ) : null
                 }
                 trailingAdornment={
-                  <ComposerPromptDictationAdornment
+                  <ComposerDictationControls
                     dictationActive={dictationActive}
                     dictationMissingModel={dictationMissingModel}
                     dictationSupported={dictationSupported}
                     dictationTranscribing={dictationTranscribing}
+                    placement="trailing"
                     onAction={onAction}
                     onOpenSettingsView={onOpenSettingsView}
                     showDictationButton={showDictationButton}

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -3,6 +3,7 @@ import type { ClipboardEvent, KeyboardEvent, RefObject } from 'react'
 import type { ComposerAttachment, DesktopActionInvoker } from '../../../desktop/types'
 import { getPathForFileQuery } from '../../../query/desktop-query'
 import { cn } from '../../../utils/cn'
+import type { SettingsOpenTarget } from '../../../views/settings/settingsTypes'
 import { ComposerDictationControls } from './composer-dictation-controls'
 import { ComposerFileMentionPanel } from './composer-file-mention-panel'
 import { ComposerFilePicker } from './composer-file-picker'
@@ -269,7 +270,7 @@ type ComposerPromptInputPanelProps = {
     textarea: HTMLTextAreaElement
   }) => Promise<void>
   onAction: DesktopActionInvoker
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   onArrowNavigationOverride?: ((direction: 'previous' | 'next') => boolean) | undefined
   onEscapeOverride?: (() => boolean) | undefined
   onSubmitOverride?: (() => boolean) | undefined

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -269,7 +269,6 @@ type ComposerPromptInputPanelProps = {
     textarea: HTMLTextAreaElement
   }) => Promise<void>
   onAction: DesktopActionInvoker
-  onLayoutChange?: () => void
   onOpenSettingsView: () => void
   onArrowNavigationOverride?: ((direction: 'previous' | 'next') => boolean) | undefined
   onEscapeOverride?: (() => boolean) | undefined
@@ -316,7 +315,6 @@ export function ComposerPromptInputPanel({
   cancelDictation,
   handlePaste,
   onAction,
-  onLayoutChange,
   onOpenSettingsView,
   onArrowNavigationOverride,
   onEscapeOverride,
@@ -449,7 +447,6 @@ export function ComposerPromptInputPanel({
                     toggleDictation={toggleDictation}
                   />
                 }
-                onHeightChange={onLayoutChange}
               />
             </div>
           </div>

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -122,6 +122,42 @@ type ComposerKeyDownInput = {
   setDraft: (value: string) => void
 }
 
+function ComposerPromptDictationAdornment({
+  dictationActive,
+  dictationMissingModel,
+  dictationSupported,
+  dictationTranscribing,
+  onAction,
+  onOpenSettingsView,
+  showDictationButton,
+  toggleDictation,
+}: Pick<
+  ComposerPromptInputPanelProps,
+  | 'dictationActive'
+  | 'dictationMissingModel'
+  | 'dictationSupported'
+  | 'dictationTranscribing'
+  | 'onAction'
+  | 'onOpenSettingsView'
+  | 'showDictationButton'
+  | 'toggleDictation'
+>) {
+  if (!showDictationButton) return null
+  return (
+    <ComposerDictationControls
+      dictationActive={dictationActive}
+      dictationMissingModel={dictationMissingModel}
+      dictationSupported={dictationSupported}
+      dictationTranscribing={dictationTranscribing}
+      placement="trailing"
+      onAction={onAction}
+      onOpenSettingsView={onOpenSettingsView}
+      showDictationButton={showDictationButton}
+      toggleDictation={toggleDictation}
+    />
+  )
+}
+
 function isCursorAtStart(textarea: HTMLTextAreaElement) {
   return textarea.selectionStart === textarea.selectionEnd && textarea.selectionStart === 0
 }
@@ -435,12 +471,11 @@ export function ComposerPromptInputPanel({
                   ) : null
                 }
                 trailingAdornment={
-                  <ComposerDictationControls
+                  <ComposerPromptDictationAdornment
                     dictationActive={dictationActive}
                     dictationMissingModel={dictationMissingModel}
                     dictationSupported={dictationSupported}
                     dictationTranscribing={dictationTranscribing}
-                    placement="trailing"
                     onAction={onAction}
                     onOpenSettingsView={onOpenSettingsView}
                     showDictationButton={showDictationButton}

--- a/src/app/components/workspace/composer/composer-prompt-surface.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-surface.tsx
@@ -1,5 +1,6 @@
-import { Paperclip, Square, X } from 'lucide-react'
+import { Paperclip, X } from 'lucide-react'
 import { type RefObject, useEffect, useLayoutEffect, useRef } from 'react'
+import { getPersistedSessionPath } from '../../../../../shared/session-paths'
 import { compactIconButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
 import type { ComposerProps } from '../composer'
@@ -403,6 +404,7 @@ export function ComposerPromptSurface({
   const askQuestionsSubmitRef = useRef<(() => boolean) | null>(null)
   const placeholderText = getComposerPlaceholderText({ activeView, errorMessage, showAskQuestions })
   const attachmentButtonLabel = attachments.length > 0 ? 'Manage attachments' : 'Add attachment'
+  const persistedSessionPath = getPersistedSessionPath(sessionPath)
   const canStopComposer = (composerIsStreaming || extensionRunning) && !isSending && !!sessionPath
   return (
     <div className="relative grid w-full grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible">
@@ -570,7 +572,7 @@ export function ComposerPromptSurface({
             onOpenTakeoverTerminal={onOpenTakeoverTerminal}
             onSelectBaseline={onSetDiffBaseline}
             onSelectModel={(availableModel) => {
-              if (isConversationComposerView(activeView)) {
+              if (isConversationComposerView(activeView) && !persistedSessionPath) {
                 void runComposerAction(
                   'settings.update',
                   {
@@ -595,7 +597,7 @@ export function ComposerPromptSurface({
               )
             }}
             onSelectThinkingLevel={(level) => {
-              if (isConversationComposerView(activeView)) {
+              if (isConversationComposerView(activeView) && !persistedSessionPath) {
                 void runComposerAction('settings.update', {
                   key: composerMode === 'chat' ? 'chatThinkingLevel' : 'codeThinkingLevel',
                   value: level,
@@ -634,9 +636,9 @@ export function ComposerPromptSurface({
             type="button"
             className={cn(
               compactIconButtonClass,
-              'h-7 w-7 shrink-0 rounded-full text-[color:var(--danger)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
+              'composer-stop-button relative h-7 w-7 shrink-0 text-[color:var(--danger)] hover:bg-[color:var(--danger-bg)] hover:text-[color:var(--danger)]',
               canStopComposer
-                ? 'bg-[color:var(--danger-bg)] opacity-80'
+                ? 'composer-stop-button--active bg-[color:var(--danger-bg)] opacity-95'
                 : 'bg-transparent opacity-25 hover:opacity-45',
             )}
             onClick={() => void stop()}
@@ -644,7 +646,24 @@ export function ComposerPromptSurface({
             aria-label="Stop Pi"
             data-tooltip="Stop Pi"
           >
-            <Square size={11} fill="currentColor" />
+            {canStopComposer ? (
+              <svg
+                className="composer-stop-button__spinner absolute text-[color:var(--danger)]"
+                viewBox="0 0 28 28"
+                aria-hidden="true"
+              >
+                <g className="activity-spinner__rotor" fill="currentColor">
+                  <circle cx="14" cy="1.5" r="1.3" opacity=".14" />
+                  <circle cx="20.2" cy="3.05" r="1.3" opacity=".29" />
+                  <circle cx="24.95" cy="7.8" r="1.3" opacity=".43" />
+                  <circle cx="26.5" cy="14" r="1.3" opacity=".57" />
+                  <circle cx="24.95" cy="20.2" r="1.3" opacity=".71" />
+                  <circle cx="20.2" cy="24.95" r="1.3" opacity=".86" />
+                  <circle cx="14" cy="26.5" r="1.3" />
+                </g>
+              </svg>
+            ) : null}
+            <span className="composer-stop-button__square" aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/src/app/components/workspace/composer/composer-prompt-surface.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-surface.tsx
@@ -1,7 +1,7 @@
 import { Paperclip, X } from 'lucide-react'
 import { type RefObject, useEffect, useLayoutEffect, useRef } from 'react'
 import { getPersistedSessionPath } from '../../../../../shared/session-paths'
-import { compactIconButtonClass } from '../../../ui/classes'
+import { compactIconButtonClass, compactRoundIconButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
 import type { ComposerProps } from '../composer'
 import { AskQuestionsCard } from './ask-questions-card'
@@ -442,7 +442,7 @@ export function ComposerPromptSurface({
             aria-label={attachmentButtonLabel}
             data-tooltip={attachmentButtonLabel}
           >
-            <span className={cn(compactIconButtonClass, 'h-7 w-7 shrink-0 rounded-full')}>
+            <span className={cn(compactRoundIconButtonClass, 'shrink-0')}>
               <Paperclip size={15} />
             </span>
           </button>

--- a/src/app/components/workspace/composer/composer-prompt-surface.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-surface.tsx
@@ -80,7 +80,6 @@ export function ComposerPromptSurface({
   artifactsAvailable,
   onSetDiffBaseline,
   onOpenGitOps,
-  onLayoutChange,
   onOverlayHeightChange,
   showTerminalControls = true,
 }: ComposerPromptSurfaceProps) {
@@ -523,7 +522,6 @@ export function ComposerPromptSurface({
               hoverToBlur={hoverToBlur}
               hoverBoundaryRef={composerPanelRef}
               onAction={onAction}
-              onLayoutChange={onLayoutChange}
               onOpenSettingsView={onOpenSettingsView}
               openPickerDirectory={openPickerDirectory}
               openPickerRoot={openPickerRoot}

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -147,11 +147,9 @@ function ComposerExpandButton({
 }
 
 function TrailingAdornment({
-  lineHeight,
   position,
   trailingAdornment,
 }: {
-  lineHeight: number
   position: { left: number; top: number } | null
   trailingAdornment: ReactNode
 }) {
@@ -159,7 +157,7 @@ function TrailingAdornment({
   return (
     <span
       className="absolute z-10 inline-flex items-center"
-      style={{ left: `${position.left}px`, top: `${position.top}px`, height: `${lineHeight}px` }}
+      style={{ right: 0, top: `${position.top}px` }}
     >
       {trailingAdornment}
     </span>
@@ -319,20 +317,10 @@ export function ComposerTextField({
         placeholder,
         textarea,
       })
-      const markerLeft = markerPosition.left
       const markerTop = markerPosition.top
-      const lineHeight = markerPosition.lineHeight || lineHeightRef.current
-      const adornmentWidth = 24
-      const adornmentGap = 6
-      const shouldWrapAdornment = markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth
-      const nextLeft = shouldWrapAdornment ? 0 : markerLeft + adornmentGap
-      const nextTop = Math.max(0, markerTop + (shouldWrapAdornment ? lineHeight : 0) - 1.5)
-      const canGrowForAdornment = textarea.scrollHeight <= textarea.offsetHeight + 1
-      const maxContainerHeight = textarea.offsetHeight + (canGrowForAdornment ? lineHeight : 0)
-      const nextContainerHeight = Math.min(
-        maxContainerHeight,
-        Math.max(textarea.offsetHeight, nextTop + lineHeight),
-      )
+      const nextLeft = 0
+      const nextTop = Math.max(0, markerTop - 1.5)
+      const nextContainerHeight = textarea.offsetHeight
 
       setTrailingAdornmentPosition((current) =>
         current?.left === nextLeft && current.top === nextTop
@@ -474,7 +462,6 @@ export function ComposerTextField({
         />
         {inlinePopoverElement}
         <TrailingAdornment
-          lineHeight={lineHeightRef.current}
           position={trailingAdornmentPosition}
           trailingAdornment={trailingAdornment}
         />

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -445,8 +445,7 @@ export function ComposerTextField({
           rows={1}
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
-            canExpandField &&
-              'composer-textarea-scroll-above-button relative left-[0.25rem] w-[calc(100%-0.25rem)]',
+            canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',
             placeholderTone === 'error'
               ? 'placeholder:text-[color:var(--danger)]'

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -479,7 +479,7 @@ export function ComposerTextField({
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
             trailingAdornmentVisible && 'pr-[1.875rem]',
-            '[hyphens:auto] [overflow-wrap:normal] [word-break:normal]',
+            'overflow-x-hidden [hyphens:auto] [overflow-wrap:break-word] [word-break:normal]',
             canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',
             placeholderTone === 'error'

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -147,9 +147,11 @@ function ComposerExpandButton({
 }
 
 function TrailingAdornment({
+  lineHeight,
   position,
   trailingAdornment,
 }: {
+  lineHeight: number
   position: { left: number; top: number } | null
   trailingAdornment: ReactNode
 }) {
@@ -157,7 +159,7 @@ function TrailingAdornment({
   return (
     <span
       className="absolute z-10 inline-flex items-center"
-      style={{ right: 0, top: `${position.top}px` }}
+      style={{ left: `${position.left}px`, top: `${position.top}px`, height: `${lineHeight}px` }}
     >
       {trailingAdornment}
     </span>
@@ -317,10 +319,20 @@ export function ComposerTextField({
         placeholder,
         textarea,
       })
+      const markerLeft = markerPosition.left
       const markerTop = markerPosition.top
-      const nextLeft = 0
-      const nextTop = Math.max(0, markerTop - 1.5)
-      const nextContainerHeight = textarea.offsetHeight
+      const lineHeight = markerPosition.lineHeight || lineHeightRef.current
+      const adornmentWidth = 24
+      const adornmentGap = 6
+      const shouldWrapAdornment = markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth
+      const nextLeft = shouldWrapAdornment ? 0 : markerLeft + adornmentGap
+      const nextTop = Math.max(0, markerTop + (shouldWrapAdornment ? lineHeight : 0) - 1.5)
+      const canGrowForAdornment = textarea.scrollHeight <= textarea.offsetHeight + 1
+      const maxContainerHeight = textarea.offsetHeight + (canGrowForAdornment ? lineHeight : 0)
+      const nextContainerHeight = Math.min(
+        maxContainerHeight,
+        Math.max(textarea.offsetHeight, nextTop + lineHeight),
+      )
 
       setTrailingAdornmentPosition((current) =>
         current?.left === nextLeft && current.top === nextTop
@@ -462,6 +474,7 @@ export function ComposerTextField({
         />
         {inlinePopoverElement}
         <TrailingAdornment
+          lineHeight={lineHeightRef.current}
           position={trailingAdornmentPosition}
           trailingAdornment={trailingAdornment}
         />

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -257,13 +257,17 @@ export function ComposerTextField({
     top: number
   } | null>(null)
   const [trailingContainerHeight, setTrailingContainerHeight] = useState<number | null>(null)
-  const [textareaWidth, setTextareaWidth] = useState<number | null>(null)
+  const [textareaMetrics, setTextareaMetrics] = useState<{ height: number; width: number } | null>(
+    null,
+  )
   const [fieldExpanded, setFieldExpanded] = useState(false)
   const [canExpandField, setCanExpandField] = useState(false)
   const lineHeightRef = useRef(20)
   const trailingAdornmentVisible =
     trailingAdornmentEnabled &&
-    (textareaWidth === null || textareaWidth >= MIN_TRAILING_ADORNMENT_TEXTAREA_WIDTH)
+    (textareaMetrics === null ||
+      (textareaMetrics.width >= MIN_TRAILING_ADORNMENT_TEXTAREA_WIDTH &&
+        textareaMetrics.height <= lineHeightRef.current * 1.8))
 
   const focusTextareaAtEnd = useCallback(() => {
     const textarea = textareaRef.current
@@ -318,15 +322,22 @@ export function ComposerTextField({
     const textarea = textareaRef.current
     if (!textarea) return
 
-    const updateTextareaWidth = () => {
-      const nextWidth = Math.floor(textarea.clientWidth)
-      setTextareaWidth((current) => (current === nextWidth ? current : nextWidth))
+    const updateTextareaMetrics = () => {
+      const nextMetrics = {
+        height: Math.floor(textarea.offsetHeight),
+        width: Math.floor(textarea.clientWidth),
+      }
+      setTextareaMetrics((current) =>
+        current?.height === nextMetrics.height && current.width === nextMetrics.width
+          ? current
+          : nextMetrics,
+      )
     }
 
-    updateTextareaWidth()
+    updateTextareaMetrics()
 
     if (typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(updateTextareaWidth)
+    const observer = new ResizeObserver(updateTextareaMetrics)
     observer.observe(textarea)
     return () => observer.disconnect()
   }, [])
@@ -345,7 +356,7 @@ export function ComposerTextField({
 
     const measureTrailingAdornmentPosition = () => {
       const markerPosition = measureTextareaMarkerPosition({
-        adornmentWidth: trailingAdornmentVisible ? 30 : 0,
+        adornmentWidth: 0,
         markerText: value,
         placeholder,
         textarea,
@@ -393,7 +404,7 @@ export function ComposerTextField({
     const measureInlinePopoverPosition = () => {
       const cursorPosition = textarea.selectionStart ?? value.length
       const markerPosition = measureTextareaMarkerPosition({
-        adornmentWidth: trailingAdornmentVisible ? 30 : 0,
+        adornmentWidth: 0,
         markerText: value.slice(0, cursorPosition),
         placeholder,
         textarea,
@@ -434,7 +445,7 @@ export function ComposerTextField({
       textarea.removeEventListener('click', measureInlinePopoverPosition)
       textarea.removeEventListener('input', measureInlinePopoverPosition)
     }
-  }, [inlinePopover, placeholder, trailingAdornmentVisible, value])
+  }, [inlinePopover, placeholder, value])
 
   const inlinePopoverElement =
     inlinePopover && inlinePopoverPosition && typeof document !== 'undefined'
@@ -478,7 +489,6 @@ export function ComposerTextField({
           rows={1}
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
-            trailingAdornmentVisible && 'pr-[1.875rem]',
             'overflow-x-hidden [hyphens:auto] [overflow-wrap:break-word] [word-break:normal]',
             canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -271,7 +271,7 @@ export function ComposerTextField({
     blurOnLeave: hoverToBlur,
   })
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const textarea = textareaRef.current
     if (!textarea) return
     updateComposerTextareaHeight({

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -30,6 +30,7 @@ type ComposerTextFieldProps = {
   reservedLineCount?: number
   inlinePopover?: ReactNode
   trailingAdornment?: ReactNode
+  trailingAdornmentEnabled?: boolean
   readOnly?: boolean
   hoverToFocus?: boolean
   hoverToBlur?: boolean
@@ -150,15 +151,20 @@ function TrailingAdornment({
   lineHeight,
   position,
   trailingAdornment,
+  visible,
 }: {
   lineHeight: number
   position: { left: number; top: number } | null
   trailingAdornment: ReactNode
+  visible: boolean
 }) {
   if (!(trailingAdornment && position)) return null
   return (
     <span
-      className="absolute z-10 inline-flex items-center"
+      className={cn(
+        'absolute z-10 inline-flex items-center',
+        !visible && 'pointer-events-none invisible',
+      )}
       style={{ left: `${position.left}px`, top: `${position.top}px`, height: `${lineHeight}px` }}
     >
       {trailingAdornment}
@@ -167,6 +173,7 @@ function TrailingAdornment({
 }
 
 function measureTextareaMarkerPosition(input: {
+  adornmentWidth: number
   markerText: string
   placeholder: string
   textarea: HTMLTextAreaElement
@@ -183,7 +190,7 @@ function measureTextareaMarkerPosition(input: {
   mirror.style.overflowWrap = 'break-word'
   mirror.style.wordBreak = 'break-word'
   mirror.style.boxSizing = computedStyle.boxSizing
-  mirror.style.width = `${input.textarea.clientWidth}px`
+  mirror.style.width = `${Math.max(1, input.textarea.clientWidth - input.adornmentWidth)}px`
   mirror.style.font = computedStyle.font
   mirror.style.fontFamily = computedStyle.fontFamily
   mirror.style.fontSize = computedStyle.fontSize
@@ -221,6 +228,7 @@ export function ComposerTextField({
   reservedLineCount = 4,
   inlinePopover = null,
   trailingAdornment = null,
+  trailingAdornmentEnabled = Boolean(trailingAdornment),
   readOnly = false,
   hoverToFocus = true,
   hoverToBlur = false,
@@ -302,7 +310,7 @@ export function ComposerTextField({
   })
 
   useLayoutEffect(() => {
-    if (!trailingAdornment) {
+    if (!trailingAdornmentEnabled) {
       setTrailingAdornmentPosition(null)
       setTrailingContainerHeight(null)
       return
@@ -315,6 +323,7 @@ export function ComposerTextField({
 
     const measureTrailingAdornmentPosition = () => {
       const markerPosition = measureTextareaMarkerPosition({
+        adornmentWidth: trailingAdornmentEnabled ? 30 : 0,
         markerText: value,
         placeholder,
         textarea,
@@ -324,7 +333,8 @@ export function ComposerTextField({
       const lineHeight = markerPosition.lineHeight || lineHeightRef.current
       const adornmentWidth = 24
       const adornmentGap = 6
-      const shouldWrapAdornment = markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth
+      const shouldWrapAdornment =
+        markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth && value.length > 0
       const nextLeft = shouldWrapAdornment ? 0 : markerLeft + adornmentGap
       const nextTop = Math.max(0, markerTop + (shouldWrapAdornment ? lineHeight : 0) - 1.5)
       const canGrowForAdornment = textarea.scrollHeight <= textarea.offsetHeight + 1
@@ -347,7 +357,7 @@ export function ComposerTextField({
     measureTrailingAdornmentPosition()
     window.addEventListener('resize', measureTrailingAdornmentPosition)
     return () => window.removeEventListener('resize', measureTrailingAdornmentPosition)
-  }, [placeholder, trailingAdornment, value])
+  }, [placeholder, trailingAdornmentEnabled, value])
 
   useLayoutEffect(() => {
     if (!inlinePopover) {
@@ -361,6 +371,7 @@ export function ComposerTextField({
     const measureInlinePopoverPosition = () => {
       const cursorPosition = textarea.selectionStart ?? value.length
       const markerPosition = measureTextareaMarkerPosition({
+        adornmentWidth: trailingAdornmentEnabled ? 30 : 0,
         markerText: value.slice(0, cursorPosition),
         placeholder,
         textarea,
@@ -401,7 +412,7 @@ export function ComposerTextField({
       textarea.removeEventListener('click', measureInlinePopoverPosition)
       textarea.removeEventListener('input', measureInlinePopoverPosition)
     }
-  }, [inlinePopover, placeholder, value])
+  }, [inlinePopover, placeholder, trailingAdornmentEnabled, value])
 
   const inlinePopoverElement =
     inlinePopover && inlinePopoverPosition && typeof document !== 'undefined'
@@ -477,6 +488,7 @@ export function ComposerTextField({
           lineHeight={lineHeightRef.current}
           position={trailingAdornmentPosition}
           trailingAdornment={trailingAdornment}
+          visible={trailingAdornmentEnabled}
         />
       </div>
     </div>

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -17,7 +17,6 @@ import { cn } from '../../../utils/cn'
 
 const COLLAPSED_VISIBLE_LINE_COUNT = 5
 const EXPANDED_VISIBLE_LINE_COUNT = 15
-const MIN_TRAILING_ADORNMENT_TEXTAREA_WIDTH = 180
 
 type ComposerTextFieldProps = {
   value: string
@@ -257,17 +256,11 @@ export function ComposerTextField({
     top: number
   } | null>(null)
   const [trailingContainerHeight, setTrailingContainerHeight] = useState<number | null>(null)
-  const [textareaMetrics, setTextareaMetrics] = useState<{ height: number; width: number } | null>(
-    null,
-  )
+  const [textareaLayoutVersion, setTextareaLayoutVersion] = useState(0)
   const [fieldExpanded, setFieldExpanded] = useState(false)
   const [canExpandField, setCanExpandField] = useState(false)
   const lineHeightRef = useRef(20)
-  const trailingAdornmentVisible =
-    trailingAdornmentEnabled &&
-    (textareaMetrics === null ||
-      (textareaMetrics.width >= MIN_TRAILING_ADORNMENT_TEXTAREA_WIDTH &&
-        textareaMetrics.height <= lineHeightRef.current * 1.8))
+  const trailingAdornmentVisible = trailingAdornmentEnabled
 
   const focusTextareaAtEnd = useCallback(() => {
     const textarea = textareaRef.current
@@ -289,6 +282,7 @@ export function ComposerTextField({
   })
 
   useLayoutEffect(() => {
+    void textareaLayoutVersion
     const textarea = textareaRef.current
     if (!textarea) return
     updateComposerTextareaHeight({
@@ -306,7 +300,15 @@ export function ComposerTextField({
       value,
       wrapperRef,
     })
-  }, [fieldExpanded, onExpandedChange, onHeightChange, reservedHeight, reservedLineCount, value])
+  }, [
+    fieldExpanded,
+    onExpandedChange,
+    onHeightChange,
+    reservedHeight,
+    reservedLineCount,
+    textareaLayoutVersion,
+    value,
+  ])
 
   useEffect(() => {
     const height = wrapperRef.current?.getBoundingClientRect().height
@@ -322,22 +324,10 @@ export function ComposerTextField({
     const textarea = textareaRef.current
     if (!textarea) return
 
-    const updateTextareaMetrics = () => {
-      const nextMetrics = {
-        height: Math.floor(textarea.offsetHeight),
-        width: Math.floor(textarea.clientWidth),
-      }
-      setTextareaMetrics((current) =>
-        current?.height === nextMetrics.height && current.width === nextMetrics.width
-          ? current
-          : nextMetrics,
-      )
-    }
-
-    updateTextareaMetrics()
-
     if (typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(updateTextareaMetrics)
+    const observer = new ResizeObserver(() => {
+      setTextareaLayoutVersion((current) => current + 1)
+    })
     observer.observe(textarea)
     return () => observer.disconnect()
   }, [])

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -456,6 +456,7 @@ export function ComposerTextField({
           rows={1}
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
+            trailingAdornmentEnabled && 'pr-[1.875rem]',
             canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',
             placeholderTone === 'error'

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -17,6 +17,7 @@ import { cn } from '../../../utils/cn'
 
 const COLLAPSED_VISIBLE_LINE_COUNT = 5
 const EXPANDED_VISIBLE_LINE_COUNT = 15
+const MIN_TRAILING_ADORNMENT_TEXTAREA_WIDTH = 180
 
 type ComposerTextFieldProps = {
   value: string
@@ -256,9 +257,13 @@ export function ComposerTextField({
     top: number
   } | null>(null)
   const [trailingContainerHeight, setTrailingContainerHeight] = useState<number | null>(null)
+  const [textareaWidth, setTextareaWidth] = useState<number | null>(null)
   const [fieldExpanded, setFieldExpanded] = useState(false)
   const [canExpandField, setCanExpandField] = useState(false)
   const lineHeightRef = useRef(20)
+  const trailingAdornmentVisible =
+    trailingAdornmentEnabled &&
+    (textareaWidth === null || textareaWidth >= MIN_TRAILING_ADORNMENT_TEXTAREA_WIDTH)
 
   const focusTextareaAtEnd = useCallback(() => {
     const textarea = textareaRef.current
@@ -310,7 +315,24 @@ export function ComposerTextField({
   })
 
   useLayoutEffect(() => {
-    if (!trailingAdornmentEnabled) {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const updateTextareaWidth = () => {
+      const nextWidth = Math.floor(textarea.clientWidth)
+      setTextareaWidth((current) => (current === nextWidth ? current : nextWidth))
+    }
+
+    updateTextareaWidth()
+
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(updateTextareaWidth)
+    observer.observe(textarea)
+    return () => observer.disconnect()
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!trailingAdornmentVisible) {
       setTrailingAdornmentPosition(null)
       setTrailingContainerHeight(null)
       return
@@ -323,7 +345,7 @@ export function ComposerTextField({
 
     const measureTrailingAdornmentPosition = () => {
       const markerPosition = measureTextareaMarkerPosition({
-        adornmentWidth: trailingAdornmentEnabled ? 30 : 0,
+        adornmentWidth: trailingAdornmentVisible ? 30 : 0,
         markerText: value,
         placeholder,
         textarea,
@@ -357,7 +379,7 @@ export function ComposerTextField({
     measureTrailingAdornmentPosition()
     window.addEventListener('resize', measureTrailingAdornmentPosition)
     return () => window.removeEventListener('resize', measureTrailingAdornmentPosition)
-  }, [placeholder, trailingAdornmentEnabled, value])
+  }, [placeholder, trailingAdornmentVisible, value])
 
   useLayoutEffect(() => {
     if (!inlinePopover) {
@@ -371,7 +393,7 @@ export function ComposerTextField({
     const measureInlinePopoverPosition = () => {
       const cursorPosition = textarea.selectionStart ?? value.length
       const markerPosition = measureTextareaMarkerPosition({
-        adornmentWidth: trailingAdornmentEnabled ? 30 : 0,
+        adornmentWidth: trailingAdornmentVisible ? 30 : 0,
         markerText: value.slice(0, cursorPosition),
         placeholder,
         textarea,
@@ -412,7 +434,7 @@ export function ComposerTextField({
       textarea.removeEventListener('click', measureInlinePopoverPosition)
       textarea.removeEventListener('input', measureInlinePopoverPosition)
     }
-  }, [inlinePopover, placeholder, trailingAdornmentEnabled, value])
+  }, [inlinePopover, placeholder, trailingAdornmentVisible, value])
 
   const inlinePopoverElement =
     inlinePopover && inlinePopoverPosition && typeof document !== 'undefined'
@@ -456,7 +478,8 @@ export function ComposerTextField({
           rows={1}
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
-            trailingAdornmentEnabled && 'pr-[1.875rem]',
+            trailingAdornmentVisible && 'pr-[1.875rem]',
+            '[hyphens:auto] [overflow-wrap:normal] [word-break:normal]',
             canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',
             placeholderTone === 'error'
@@ -489,7 +512,7 @@ export function ComposerTextField({
           lineHeight={lineHeightRef.current}
           position={trailingAdornmentPosition}
           trailingAdornment={trailingAdornment}
-          visible={trailingAdornmentEnabled}
+          visible={trailingAdornmentVisible}
         />
       </div>
     </div>

--- a/src/app/components/workspace/composer/queued-prompts-card.tsx
+++ b/src/app/components/workspace/composer/queued-prompts-card.tsx
@@ -21,50 +21,52 @@ export function QueuedPromptsCard({
   }
 
   return (
-    <div
-      className={cn(
-        'relative -left-1 mx-auto grid w-full max-w-[664px] gap-1.5 rounded-t-xl rounded-b-none border border-[color:var(--border)] bg-[color:var(--panel)] px-2.5 py-2',
-      )}
-    >
-      <div className="pl-3.5 text-[12px] text-[color:var(--muted)]">
-        Queued messages. Click to edit.
-      </div>
+    <div className="grid w-full grid-cols-[2rem_minmax(0,1fr)_2rem] items-end gap-2 overflow-visible">
+      <div
+        className={cn(
+          'col-start-2 mx-auto grid w-full max-w-[664px] gap-1.5 rounded-t-xl rounded-b-none border border-[color:var(--border)] bg-[color:var(--panel)] px-2.5 py-2',
+        )}
+      >
+        <div className="pl-3.5 text-[12px] text-[color:var(--muted)]">
+          Queued messages. Click to edit.
+        </div>
 
-      <div className="grid gap-1">
-        {prompts.map((prompt) => {
-          const isPending = pendingPromptIds.includes(prompt.id)
+        <div className="grid gap-1">
+          {prompts.map((prompt) => {
+            const isPending = pendingPromptIds.includes(prompt.id)
 
-          return (
-            <div
-              key={prompt.id}
-              className={cn(
-                compactCardClass,
-                'group grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-xl border-transparent px-1 py-0 text-[12px] shadow-none hover:border-[color:var(--border)]',
-                isPending && 'opacity-60',
-              )}
-            >
-              <button
-                type="button"
-                className="min-w-0 px-2.5 py-1 text-left text-[12px] leading-5 text-[color:var(--text)]/88 disabled:cursor-default"
-                onClick={() => onEditPrompt(prompt)}
-                disabled={isPending}
+            return (
+              <div
+                key={prompt.id}
+                className={cn(
+                  compactCardClass,
+                  'group grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-xl border-transparent px-1 py-0 text-[12px] shadow-none hover:border-[color:var(--border)]',
+                  isPending && 'opacity-60',
+                )}
               >
-                <span className="block truncate">{prompt.text}</span>
-              </button>
+                <button
+                  type="button"
+                  className="min-w-0 px-2.5 py-1 text-left text-[12px] leading-5 text-[color:var(--text)]/88 disabled:cursor-default"
+                  onClick={() => onEditPrompt(prompt)}
+                  disabled={isPending}
+                >
+                  <span className="block truncate">{prompt.text}</span>
+                </button>
 
-              <button
-                type="button"
-                className={cn(compactIconButtonClass, 'mr-1 shrink-0')}
-                onClick={() => onRemovePrompt(prompt)}
-                aria-label="Remove queued"
-                disabled={isPending}
-                data-tooltip="Remove queued"
-              >
-                <X size={12} />
-              </button>
-            </div>
-          )
-        })}
+                <button
+                  type="button"
+                  className={cn(compactIconButtonClass, 'mr-1 shrink-0')}
+                  onClick={() => onRemovePrompt(prompt)}
+                  aria-label="Remove queued"
+                  disabled={isPending}
+                  data-tooltip="Remove queued"
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/src/app/components/workspace/composer/useComposerSlashCommands.ts
+++ b/src/app/components/workspace/composer/useComposerSlashCommands.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../../shared/composer-slash-commands'
 import type { ComposerSlashCommand } from '../../../desktop/types'
 import { getComposerSlashCommandsQuery } from '../../../query/desktop-query'
+import type { SettingsOpenTarget } from '../../../views/settings/settingsTypes'
 
 const slashCommandSourceOrder: Record<ComposerSlashCommand['source'], number> = {
   prompt: 0,
@@ -60,7 +61,7 @@ type UseComposerSlashCommandsOptions = {
   setDraft: (draft: string) => void
   send: () => void
   sendExtensionCommand?: () => void
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
 }
 
 export type ComposerSlashCommands = ReturnType<typeof useComposerSlashCommands>

--- a/src/app/components/workspace/git-ops-composer-panel.tsx
+++ b/src/app/components/workspace/git-ops-composer-panel.tsx
@@ -7,6 +7,7 @@ import type {
   ProjectDiffRenderMode,
   ProjectGitState,
 } from '../../desktop/types'
+import type { SettingsOpenTarget } from '../../views/settings/settingsTypes'
 import { ComposerGitOpsSurface } from './composer/composer-git-ops-surface'
 import type { SavedDiffComment } from './diff/diffCommentStore'
 
@@ -32,7 +33,7 @@ type GitOpsComposerPanelProps = {
   onAction: DesktopActionInvoker
   onLayoutChange: () => void
   onBack: () => void
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
 }
 
 function GitOpsErrorDetails({ detail, onDismiss }: { detail: string; onDismiss: () => void }) {

--- a/src/app/components/workspace/inbox/inbox-composer.tsx
+++ b/src/app/components/workspace/inbox/inbox-composer.tsx
@@ -22,6 +22,7 @@ import type {
 import { useDismissibleLayer } from '../../../hooks/useDismissibleLayer'
 import { compactIconButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
+import type { SettingsOpenTarget } from '../../../views/settings/settingsTypes'
 import { IconButton } from '../../common/icon-button'
 import { ToolbarButton } from '../../common/toolbar-button'
 import { Tooltip } from '../../common/tooltip'
@@ -80,7 +81,7 @@ type InboxComposerProps = {
     rootPath?: string | null
   }) => Promise<ComposerFilePickerState | null>
   onOpenThread: () => void
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   onSend: (input: { draft: string; attachments: ComposerAttachment[] }) => Promise<void> | void
   onStop: () => void
 }

--- a/src/app/components/workspace/thread/thread-timeline-row-chrome.tsx
+++ b/src/app/components/workspace/thread/thread-timeline-row-chrome.tsx
@@ -62,13 +62,19 @@ function isInteractiveTarget(target: EventTarget | null) {
   )
 }
 
-function hasActiveTextSelection() {
+function hasActiveTextSelectionWithin(container: Element) {
   const selection = window.getSelection?.()
   if (!selection || selection.isCollapsed) {
     return false
   }
 
-  return selection.toString().trim().length > 0
+  const anchorNode = selection.anchorNode
+  const focusNode = selection.focusNode
+  return (
+    selection.toString().trim().length > 0 &&
+    Boolean(anchorNode && container.contains(anchorNode)) &&
+    Boolean(focusNode && container.contains(focusNode))
+  )
 }
 
 export function RowLeadToggleSurface({
@@ -78,7 +84,8 @@ export function RowLeadToggleSurface({
   onToggle?: (() => void) | undefined
   children: ReactNode
 }) {
-  const pointerStartRef = useRef<{ id: number; x: number; y: number; time: number } | null>(null)
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const pointerStartRef = useRef<{ id: number; x: number; y: number } | null>(null)
 
   if (!onToggle) {
     return <>{children}</>
@@ -87,12 +94,12 @@ export function RowLeadToggleSurface({
   return (
     <div
       className="block w-full min-w-0 cursor-pointer text-left"
+      ref={surfaceRef}
       onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
         pointerStartRef.current = {
           id: event.pointerId,
           x: event.clientX,
           y: event.clientY,
-          time: performance.now(),
         }
       }}
       onPointerUp={(event: PointerEvent<HTMLDivElement>) => {
@@ -108,8 +115,8 @@ export function RowLeadToggleSurface({
 
         const deltaX = Math.abs(event.clientX - start.x)
         const deltaY = Math.abs(event.clientY - start.y)
-        const elapsedMs = performance.now() - start.time
-        if (deltaX > 4 || deltaY > 4 || elapsedMs > 250 || hasActiveTextSelection()) {
+        const surface = surfaceRef.current
+        if (deltaX > 4 || deltaY > 4 || (surface && hasActiveTextSelectionWithin(surface))) {
           return
         }
 

--- a/src/app/components/workspace/thread/thread-timeline-row-chrome.tsx
+++ b/src/app/components/workspace/thread/thread-timeline-row-chrome.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import type { PointerEvent, ReactNode } from 'react'
+import { useRef } from 'react'
 import { chatRowShellClass } from './thread-layout'
 
 const clampOneLineClass =
@@ -61,6 +62,15 @@ function isInteractiveTarget(target: EventTarget | null) {
   )
 }
 
+function hasActiveTextSelection() {
+  const selection = window.getSelection?.()
+  if (!selection || selection.isCollapsed) {
+    return false
+  }
+
+  return selection.toString().trim().length > 0
+}
+
 export function RowLeadToggleSurface({
   onToggle,
   children,
@@ -68,6 +78,8 @@ export function RowLeadToggleSurface({
   onToggle?: (() => void) | undefined
   children: ReactNode
 }) {
+  const pointerStartRef = useRef<{ id: number; x: number; y: number; time: number } | null>(null)
+
   if (!onToggle) {
     return <>{children}</>
   }
@@ -75,8 +87,29 @@ export function RowLeadToggleSurface({
   return (
     <div
       className="block w-full min-w-0 cursor-pointer text-left"
+      onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
+        pointerStartRef.current = {
+          id: event.pointerId,
+          x: event.clientX,
+          y: event.clientY,
+          time: performance.now(),
+        }
+      }}
       onPointerUp={(event: PointerEvent<HTMLDivElement>) => {
         if (isInteractiveTarget(event.target)) {
+          return
+        }
+
+        const start = pointerStartRef.current
+        pointerStartRef.current = null
+        if (!start || start.id !== event.pointerId) {
+          return
+        }
+
+        const deltaX = Math.abs(event.clientX - start.x)
+        const deltaY = Math.abs(event.clientY - start.y)
+        const elapsedMs = performance.now() - start.time
+        if (deltaX > 4 || deltaY > 4 || elapsedMs > 250 || hasActiveTextSelection()) {
           return
         }
 

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -136,6 +136,8 @@ export function installDevWebDesktopBridge() {
     closeSkillCreatorSession: (sessionId: string) =>
       invokeRequest('closeSkillCreatorSession', { sessionId }),
     pickComposerAttachments: () => Promise.resolve([] satisfies ComposerAttachment[]),
+    listProjectDirectoryEntries: (request = {}) =>
+      invokeRequest('listProjectDirectoryEntries', request),
     readClipboardSnapshot: (formats: string[] | null = null) =>
       invokeRequest('readClipboardSnapshot', { formats }),
     readClipboardFilePaths: () => invokeRequest('readClipboardFilePaths', {}),

--- a/src/app/features/AGENTS.md
+++ b/src/app/features/AGENTS.md
@@ -1,0 +1,1 @@
+- Artifact previews must not share fragile editor deps: keep HTML/React preview paths independent of MDXEditor/Prism, and pin React artifact `react`/`react-dom` imports to Howcode's bundled runtime copy.

--- a/src/app/features/chat/chat-workspace-view.tsx
+++ b/src/app/features/chat/chat-workspace-view.tsx
@@ -274,7 +274,7 @@ function ChatComposer(props: ChatWorkspaceContentProps) {
       onOpenGitOpsView={() => {
         /* Already in chat workspace. */
       }}
-      onOpenSettingsView={() => controller.handleShowView('settings')}
+      onOpenSettingsView={(target) => controller.handleShowView('settings', target)}
       onRestoredQueuedPromptApplied={markRestoredQueuedPromptApplied}
       onToggleTerminal={handleToggleTerminal}
       onToggleArtifacts={getToggleArtifacts(props)}

--- a/src/app/features/code/code-workspace-main-view.tsx
+++ b/src/app/features/code/code-workspace-main-view.tsx
@@ -16,6 +16,7 @@ import type { Project, View } from '../../types'
 import { ArchivedThreadsView } from '../../views/archived-threads-view'
 import { InboxView } from '../../views/inbox-view'
 import { LandingView } from '../../views/landing-view'
+import type { SettingsOpenTarget } from '../../views/settings/settingsTypes'
 import { SettingsView } from '../../views/settings-view'
 import { ThreadView } from '../../views/thread-view'
 
@@ -44,6 +45,7 @@ type CodeWorkspaceMainViewProps = {
   currentProjectName: string
   selectedInboxThread: InboxThread | null
   projects: Project[]
+  settingsOpenTarget?: SettingsOpenTarget | null | undefined
   selectedProjectId: string
   workspaceContentClass: string
   threadData: ThreadData | null
@@ -59,7 +61,7 @@ type CodeWorkspaceMainViewProps = {
   }) => Promise<ComposerFilePickerState | null>
   onCloseUtilityView: () => void
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   sidebarCollapsed: boolean
   sidebarCompactMode: boolean
   onToggleSidebar: () => void
@@ -84,6 +86,7 @@ export function CodeWorkspaceMainView({
   currentProjectName,
   selectedInboxThread,
   projects,
+  settingsOpenTarget,
   selectedProjectId,
   workspaceContentClass,
   threadData,
@@ -156,6 +159,7 @@ export function CodeWorkspaceMainView({
         availableThinkingLevels={availableThinkingLevels}
         currentModel={currentModel}
         projects={projects}
+        openTarget={settingsOpenTarget}
         onAction={onAction}
         onClose={onCloseUtilityView}
       />

--- a/src/app/features/code/code-workspace-view.tsx
+++ b/src/app/features/code/code-workspace-view.tsx
@@ -219,6 +219,7 @@ function CodeWorkspaceMainArea(props: CodeWorkspaceContentProps) {
               currentProjectName={currentProjectName}
               selectedInboxThread={controller.selectedInboxThread}
               projects={controller.projects}
+              settingsOpenTarget={controller.settingsOpenTarget}
               selectedProjectId={controller.state.selectedProjectId}
               workspaceContentClass={workspaceContentClass}
               threadData={activeThreadData}
@@ -229,7 +230,7 @@ function CodeWorkspaceMainArea(props: CodeWorkspaceContentProps) {
               onDismissInboxThread={controller.handleDismissInboxThread}
               onListAttachmentEntries={listComposerAttachmentEntries}
               onOpenThread={controller.handleThreadOpen}
-              onOpenSettingsView={() => controller.handleShowView('settings')}
+              onOpenSettingsView={(target) => controller.handleShowView('settings', target)}
               sidebarCollapsed={sidebarCollapsed}
               sidebarCompactMode={sidebarCompactMode}
               onToggleSidebar={onToggleSidebar}
@@ -340,7 +341,7 @@ function CodeGitOpsComposer(props: CodeWorkspaceContentProps) {
         onLayoutChange={() => setComposerLayoutVersion((current: number) => current + 1)}
         onAction={handleAction}
         onBack={handleCloseGitOpsView}
-        onOpenSettingsView={() => controller.handleShowView('settings')}
+        onOpenSettingsView={(target) => controller.handleShowView('settings', target)}
       />
     </div>
   )
@@ -444,7 +445,7 @@ function CodeThreadComposer(props: CodeWorkspaceContentProps) {
       workspaceFooterRef={footerRef}
       onOpenTakeoverTerminal={handleShowTakeoverTerminal}
       onOpenGitOpsView={handleOpenGitOpsView}
-      onOpenSettingsView={() => controller.handleShowView('settings')}
+      onOpenSettingsView={(target) => controller.handleShowView('settings', target)}
       onRestoredQueuedPromptApplied={markRestoredQueuedPromptApplied}
       onToggleTerminal={handleToggleTerminal}
       terminalVisible={state.terminalVisible}

--- a/src/app/features/code/code-workspace-view.tsx
+++ b/src/app/features/code/code-workspace-view.tsx
@@ -512,7 +512,7 @@ function CodeWorkspaceThreadFooter(props: CodeWorkspaceContentProps) {
       ref={footerRef}
       className={cn(
         'motion-terminal-drawer-offset pointer-events-none absolute inset-x-0 z-10 px-5 pb-4',
-        showThreadFooter ? 'transition-[top,transform] duration-300 ease-out' : 'bottom-0',
+        centerThreadFooter ? 'transition-[top,transform] duration-300 ease-out' : 'bottom-0',
         centerThreadFooter && '-translate-y-1/2',
         showThreadFooter && !centerThreadFooter && 'translate-y-0',
       )}
@@ -714,10 +714,9 @@ export function CodeWorkspaceView({
     ? { right: TERMINAL_DRAWER_OFFSET }
     : undefined
   const threadFooterStyle = showThreadFooter
-    ? {
-        ...terminalDrawerInsetStyle,
-        top: centerThreadFooter ? NEW_THREAD_COMPOSER_TOP : `calc(100% - ${footerHeight}px)`,
-      }
+    ? centerThreadFooter
+      ? { ...terminalDrawerInsetStyle, top: NEW_THREAD_COMPOSER_TOP }
+      : { ...terminalDrawerInsetStyle, bottom: 0 }
     : terminalDrawerInsetStyle
   const threadTimelineLoading = state.activeView === 'thread' && controller.activeThreadLoading
 

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -1,6 +1,7 @@
 const pathSeparatorPattern = /[\\/]/
 
 import { fallbackAppSlashCommands } from '../../../shared/composer-slash-commands'
+import type { DesktopRequestMap } from '../../../shared/desktop-ipc'
 import { getPersistedSessionPath } from '../../../shared/session-paths'
 import type {
   AppUpdateState,
@@ -306,6 +307,12 @@ export async function pickComposerAttachmentsQuery(
   projectId?: string | null | undefined,
 ): Promise<ComposerAttachment[]> {
   return (await window.piDesktop?.pickComposerAttachments?.(projectId ?? null)) ?? []
+}
+
+export async function listProjectDirectoryEntriesQuery(
+  request: DesktopRequestMap['listProjectDirectoryEntries']['params'] = {},
+): Promise<DesktopRequestMap['listProjectDirectoryEntries']['response'] | null> {
+  return (await window.piDesktop?.listProjectDirectoryEntries?.(request)) ?? null
 }
 
 export async function clearClipboardImagesQuery() {

--- a/src/app/views/inbox-view.tsx
+++ b/src/app/views/inbox-view.tsx
@@ -18,6 +18,7 @@ import type {
   InboxThread,
 } from '../desktop/types'
 import { WORKSPACE_CONTENT_MAX_WIDTH_CLASS } from '../ui/layout'
+import type { SettingsOpenTarget } from './settings/settingsTypes'
 
 type InboxViewProps = {
   appSettings: AppSettings
@@ -38,7 +39,7 @@ type InboxViewProps = {
     rootPath?: string | null
   }) => Promise<ComposerFilePickerState | null>
   onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void
-  onOpenSettingsView: () => void
+  onOpenSettingsView: (target?: SettingsOpenTarget) => void
   sidebarCollapsed: boolean
   sidebarCompactMode: boolean
   onToggleSidebar: () => void

--- a/src/app/views/settings-view.tsx
+++ b/src/app/views/settings-view.tsx
@@ -23,7 +23,7 @@ import {
   groupSettingsByCategory,
   settingsCategories,
 } from './settings/settingsGroups'
-import type { SettingsCategoryId } from './settings/settingsTypes'
+import type { SettingsCategoryId, SettingsOpenTarget } from './settings/settingsTypes'
 import { SettingRow } from './settings/settingsUi'
 import { useSettingsController } from './settings/useSettingsController'
 
@@ -37,6 +37,7 @@ type SettingsViewProps = {
   projects: Project[]
   onAction: DesktopActionInvoker
   onClose: () => void
+  openTarget?: SettingsOpenTarget | null | undefined
 }
 
 function getDatasetValue(element: HTMLElement, key: string) {
@@ -53,6 +54,7 @@ export function SettingsView({
   projects,
   onAction,
   onClose,
+  openTarget = null,
 }: SettingsViewProps) {
   const controller = useSettingsController({ appSettings, projects, onAction })
   const [draftPiSettings, setDraftPiSettings] = useState(piSettings)
@@ -67,9 +69,21 @@ export function SettingsView({
   const [openSelectId, setOpenSelectId] = useState<string | null>(null)
   const [dictationModelDraft, setDictationModelDraft] = useState<DictationModelId | null>(null)
   const [showHelp, setShowHelp] = useState(false)
+  const [highlightedSettingId, setHighlightedSettingId] = useState<string | null>(null)
+  const [highlightedCategoryId, setHighlightedCategoryId] = useState<SettingsCategoryId | null>(
+    null,
+  )
   const [helpColumnAvailable, setHelpColumnAvailable] = useState(false)
   const [settingRowHeights, setSettingRowHeights] = useState<Record<string, number>>({})
   const normalizedFilter = filter.trim().toLowerCase()
+
+  useEffect(() => {
+    if (!openTarget) return
+    setFilter('')
+    setActiveCategory(openTarget.category ?? null)
+    setHighlightedSettingId(openTarget.settingId ?? null)
+    setHighlightedCategoryId(openTarget.category ?? null)
+  }, [openTarget])
 
   useEffect(() => {
     const query = window.matchMedia('(min-width: 1024px)')
@@ -274,6 +288,28 @@ export function SettingsView({
     }
   }, [showHelp, visibleSettingIds])
 
+  useEffect(() => {
+    if (!highlightedSettingId) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      const target = settingsScrollRef.current?.querySelector<HTMLElement>(
+        `[data-setting-id="${CSS.escape(highlightedSettingId)}"]`,
+      )
+      target?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    })
+    const timeoutId = window.setTimeout(() => setHighlightedSettingId(null), 2200)
+    return () => {
+      window.cancelAnimationFrame(frameId)
+      window.clearTimeout(timeoutId)
+    }
+  }, [highlightedSettingId])
+
+  useEffect(() => {
+    if (!highlightedCategoryId) return
+    const timeoutId = window.setTimeout(() => setHighlightedCategoryId(null), 1800)
+    return () => window.clearTimeout(timeoutId)
+  }, [highlightedCategoryId])
+
   return (
     <ViewShell
       className="h-full content-stretch grid-rows-[auto_minmax(0,1fr)] overflow-hidden !pb-0"
@@ -425,7 +461,13 @@ export function SettingsView({
           {visibleGroups.length > 0 ? (
             visibleGroups.map((group) => (
               <Fragment key={group.id}>
-                <section className={cn(settingsSectionClass, 'min-w-0 gap-1 p-2.5')}>
+                <section
+                  className={cn(
+                    settingsSectionClass,
+                    'motion-surface-pulse motion-settings-section-pulse min-w-0 gap-1 p-2.5',
+                  )}
+                  data-pulse-active={group.id === highlightedCategoryId ? 'true' : 'false'}
+                >
                   <div className="flex items-baseline justify-between gap-3 px-1 pt-1 pb-1">
                     <h2 className="text-[15px] font-semibold text-[color:var(--text)]">
                       {group.label}

--- a/src/app/views/settings/settingsTypes.ts
+++ b/src/app/views/settings/settingsTypes.ts
@@ -2,6 +2,11 @@ import type { ReactNode } from 'react'
 
 export type SettingsCategoryId = 'models' | 'pi-runtime' | 'pi-tui' | 'projects' | 'dictation'
 
+export type SettingsOpenTarget = {
+  category?: SettingsCategoryId | undefined
+  settingId?: string | undefined
+}
+
 export type SettingDescriptor = {
   id: string
   category: SettingsCategoryId

--- a/src/electron/main/app/create-main-window.ts
+++ b/src/electron/main/app/create-main-window.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { app, BrowserWindow, shell } from 'electron'
+import { app, BrowserWindow, type BrowserWindowConstructorOptions, shell } from 'electron'
 import { resolveConfiguredDevServerUrl } from '../../../../shared/dev-server'
 import { getElectronBuildDirectory, getRendererDistDirectory } from '../runtime/app-paths'
 import { isTrustedRendererUrl, shouldOpenUrlExternally } from './navigation-security'
@@ -33,22 +33,36 @@ function getRendererTrustConfig() {
   }
 }
 
-export function createMainWindow() {
-  const mainWindow = new BrowserWindow({
+export function getMainWindowOptions(): BrowserWindowConstructorOptions {
+  const macWindowOptions: BrowserWindowConstructorOptions =
+    process.platform === 'darwin'
+      ? {
+          titleBarStyle: 'hiddenInset',
+          trafficLightPosition: { x: 18, y: 17 },
+        }
+      : {}
+
+  return {
     title: 'howcode',
     width: 1480,
     height: 980,
     x: 120,
     y: 80,
     autoHideMenuBar: true,
+    backgroundColor: '#1b1d28',
     icon: getWindowIconPath(),
+    ...macWindowOptions,
     webPreferences: {
       preload: path.join(getElectronBuildDirectory(), 'preload', 'index.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
     },
-  })
+  }
+}
+
+export function createMainWindow() {
+  const mainWindow = new BrowserWindow(getMainWindowOptions())
 
   const rendererTrustConfig = getRendererTrustConfig()
 

--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -10,6 +10,7 @@ import { registerDesktopRuntimeShutdown } from './runtime/shutdown'
 import { AppUpdater } from './updater/app-updater'
 
 let currentMainWindow: BrowserWindow | null = null
+let quitRequested = false
 const devtoolsDebuggingPort = configureDevtoolsRemoteDebugging()
 
 app.setName('howcode')
@@ -41,11 +42,19 @@ async function bootstrap() {
   void appUpdater.checkForUpdate()
 
   app.on('activate', async () => {
+    if (quitRequested) {
+      return
+    }
+
     if (BrowserWindow.getAllWindows().length === 0) {
       await openMainWindow()
     }
   })
 }
+
+app.on('before-quit', () => {
+  quitRequested = true
+})
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/src/electron/main/ipc/request-handlers/system.ts
+++ b/src/electron/main/ipc/request-handlers/system.ts
@@ -2,8 +2,8 @@ const pathSeparatorPattern = /[\\/]/
 const leadingDotsPattern = /^\.+/
 
 import { randomUUID } from 'node:crypto'
-import { mkdir, open, readdir, rm, stat, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { mkdir, open, readdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
 import path from 'node:path'
 import { app, clipboard, dialog, shell } from 'electron'
 import { getAttachmentKind } from '../../../../../shared/composer-attachments'
@@ -21,6 +21,7 @@ type SystemRequestHandlers = Pick<
   DesktopRequestHandlerMap,
   | 'clearClipboardImages'
   | 'pickComposerAttachments'
+  | 'listProjectDirectoryEntries'
   | 'readClipboardSnapshot'
   | 'readClipboardFilePaths'
   | 'readClipboardImage'
@@ -107,6 +108,45 @@ async function writeUniqueTextFile(directoryPath: string, fileName: string, cont
   throw new Error('Could not find an unused file name in Downloads.')
 }
 
+async function listProjectDirectoryEntries(request: { path?: string | null | undefined }) {
+  const homePath = homedir()
+  const requestedPath = request.path?.trim() ? request.path : homePath
+  const currentPath = await realpath(path.resolve(requestedPath)).catch(() =>
+    path.resolve(requestedPath),
+  )
+  const directoryEntries = await readdir(currentPath, { withFileTypes: true })
+
+  const entries = directoryEntries
+    .filter(
+      (entry) => !entry.name.startsWith('.') && (entry.isDirectory() || entry.isSymbolicLink()),
+    )
+    .map(async (entry) => {
+      const entryPath = path.join(currentPath, entry.name)
+      if (entry.isDirectory())
+        return { path: entryPath, name: entry.name, kind: 'directory' as const }
+
+      try {
+        const stats = await stat(entryPath)
+        return stats.isDirectory()
+          ? { path: entryPath, name: entry.name, kind: 'directory' as const }
+          : null
+      } catch {
+        return null
+      }
+    })
+
+  return {
+    homePath,
+    currentPath,
+    parentPath: path.dirname(currentPath) === currentPath ? null : path.dirname(currentPath),
+    entries: (await Promise.all(entries))
+      .filter((entry): entry is { path: string; name: string; kind: 'directory' } => Boolean(entry))
+      .sort((left, right) =>
+        left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }),
+      ),
+  }
+}
+
 export function createSystemHandlers(): SystemRequestHandlers {
   return {
     clearClipboardImages: clearClipboardImageTempFiles,
@@ -130,6 +170,7 @@ export function createSystemHandlers(): SystemRequestHandlers {
           kind: getAttachmentKind(filePath),
         }))
     },
+    listProjectDirectoryEntries,
     readClipboardSnapshot: ({ formats: requestedFormats }) => {
       const formats = Array.isArray(requestedFormats)
         ? requestedFormats.filter((format) => typeof format === 'string' && format.length > 0)

--- a/src/electron/main/ipc/request-handlers/system.ts
+++ b/src/electron/main/ipc/request-handlers/system.ts
@@ -110,7 +110,8 @@ async function writeUniqueTextFile(directoryPath: string, fileName: string, cont
 
 async function listProjectDirectoryEntries(request: { path?: string | null | undefined }) {
   const homePath = homedir()
-  const requestedPath = request.path?.trim() ? request.path : homePath
+  const trimmedRequestPath = request.path?.trim() ?? ''
+  const requestedPath = trimmedRequestPath || homePath
   const currentPath = await realpath(path.resolve(requestedPath)).catch(() =>
     path.resolve(requestedPath),
   )

--- a/src/electron/main/runtime/shutdown.ts
+++ b/src/electron/main/runtime/shutdown.ts
@@ -48,7 +48,7 @@ export function registerDesktopRuntimeShutdown(runtime: DesktopRuntimeModules) {
       })
       .finally(() => {
         cleanupFinished = true
-        app.quit()
+        app.exit(0)
       })
   })
 }

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -96,6 +96,8 @@ export function createDesktopApi() {
       invokeRequest('closeSkillCreatorSession', { sessionId }),
     pickComposerAttachments: (projectId: string | null = null) =>
       invokeRequest('pickComposerAttachments', { projectId }),
+    listProjectDirectoryEntries: (request = {}) =>
+      invokeRequest('listProjectDirectoryEntries', request),
     readClipboardSnapshot: (formats: string[] | null = null) =>
       invokeRequest('readClipboardSnapshot', { formats }),
     readClipboardFilePaths: () => invokeRequest('readClipboardFilePaths', {}),

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -86,6 +86,11 @@
   animation: standardSurfacePulse 2.8s ease-in-out infinite;
 }
 
+.motion-settings-section-pulse[data-pulse-active="true"]::before {
+  opacity: 1;
+  animation: standardSurfacePulse 1.15s ease-out 1;
+}
+
 .motion-overlay-panel {
   opacity: 0;
   transform: translateY(var(--motion-slide-y-md));

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -95,6 +95,33 @@
   animation-delay: -0.5s;
 }
 
+.composer-stop-button {
+  border-radius: 9999px;
+}
+
+.composer-stop-button--active {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--danger) 16%, transparent);
+}
+
+.composer-stop-button__spinner {
+  inset: -0.5rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  opacity: 0.95;
+  pointer-events: none;
+}
+
+.composer-stop-button__square {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  margin: auto;
+  width: 0.5625rem;
+  height: 0.5625rem;
+  border-radius: 0.125rem;
+  background: currentColor;
+}
+
 button[data-tooltip] {
   position: relative;
 }

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -113,13 +113,14 @@
 
 .composer-stop-button__square {
   position: absolute;
-  inset: 0;
+  top: 50%;
+  left: 50%;
   z-index: 1;
-  margin: auto;
   width: 0.5625rem;
   height: 0.5625rem;
   border-radius: 0.125rem;
   background: currentColor;
+  transform: translate(-50%, -50%);
 }
 
 button[data-tooltip] {

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -279,6 +279,10 @@ button[data-tooltip][data-tooltip-size="wide"]::after {
   color: var(--text);
 }
 
+.composer-textarea-scroll-above-button {
+  width: calc(100% + 0.25rem);
+}
+
 .composer-textarea-scroll-above-button::-webkit-scrollbar-track {
   margin-bottom: 1.25rem;
 }

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -255,7 +255,7 @@
 
 .sidebar-project-create-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 32px;
+  grid-template-columns: minmax(0, 1fr) 32px 32px;
   align-items: center;
   gap: 0.25rem;
 }
@@ -309,14 +309,8 @@
 }
 
 .sidebar-project-browse-toggle {
-  justify-self: start;
-  border-radius: 0.5rem;
-  padding: 0.125rem 0.375rem;
+  background: var(--surface-hover);
   color: var(--muted);
-  font-size: 11px;
-  transition:
-    background-color 150ms ease-out,
-    color 150ms ease-out;
 }
 
 .sidebar-project-browse-toggle:hover {
@@ -404,6 +398,31 @@
   color: var(--muted-2);
   font-size: 12px;
   text-align: center;
+}
+
+.sidebar-project-folder-search {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 0.75rem;
+  background: var(--surface-hover);
+  padding: 0 0.5rem;
+  color: var(--muted);
+}
+
+.sidebar-project-folder-search-input {
+  height: 1.875rem;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 12px;
+  outline: none;
+}
+
+.sidebar-project-folder-search-input::placeholder {
+  color: var(--muted);
 }
 
 .sidebar-inline-error {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -308,6 +308,104 @@
   opacity: 0.45;
 }
 
+.sidebar-project-browse-toggle {
+  justify-self: start;
+  border-radius: 0.5rem;
+  padding: 0.125rem 0.375rem;
+  color: var(--muted);
+  font-size: 11px;
+  transition:
+    background-color 150ms ease-out,
+    color 150ms ease-out;
+}
+
+.sidebar-project-browse-toggle:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.sidebar-project-folder-browser {
+  display: grid;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.sidebar-project-folder-header {
+  display: grid;
+  grid-template-columns: 24px 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.sidebar-project-folder-icon-button {
+  display: inline-flex;
+  height: 1.5rem;
+  width: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: var(--muted);
+}
+
+.sidebar-project-folder-icon-button:not(:disabled):hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.sidebar-project-folder-icon-button:disabled {
+  opacity: 0.35;
+}
+
+.sidebar-project-folder-path {
+  overflow: hidden;
+  color: var(--muted-2);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-project-folder-list {
+  display: grid;
+  max-height: 12rem;
+  gap: 0.125rem;
+  overflow-y: auto;
+}
+
+.sidebar-project-folder-row {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  border-radius: 0.5rem;
+  padding: 0.3125rem 0.375rem;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: left;
+}
+
+.sidebar-project-folder-row:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.sidebar-project-folder-row span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-project-folder-row--add {
+  color: var(--accent);
+}
+
+.sidebar-project-folder-empty {
+  padding: 0.75rem 0.375rem;
+  color: var(--muted-2);
+  font-size: 12px;
+  text-align: center;
+}
+
 .sidebar-inline-error {
   padding-inline: 0.25rem;
   color: var(--danger);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,4 @@
+import type { DesktopRequestMap } from '../shared/desktop-ipc'
 import type { DesktopAction } from './app/desktop/actions'
 import type {
   AnyDesktopActionPayload,
@@ -135,6 +136,9 @@ declare global {
       pickComposerAttachments?: (
         projectId?: string | null | undefined,
       ) => Promise<ComposerAttachment[]>
+      listProjectDirectoryEntries?: (
+        request?: DesktopRequestMap['listProjectDirectoryEntries']['params'],
+      ) => Promise<DesktopRequestMap['listProjectDirectoryEntries']['response']>
       readClipboardSnapshot?: (formats?: string[] | null) => Promise<DesktopClipboardSnapshot>
       readClipboardFilePaths?: () => Promise<DesktopClipboardFilePaths>
       readClipboardImage?: () => Promise<DesktopClipboardImage>


### PR DESCRIPTION
## Summary

- Fixes a batch of small UI rough edges across chat, composer, sidebar, terminal, and macOS window chrome.
- Adds the in-app project folder browser and tightens project creation edge cases.
- Preserves session-local composer model/thinking choices for persisted chats.
- Adds the 0.1.64 changelog entry.

## Notable details

- Chat messages now have copy controls and safer row toggling during text selection.
- Composer controls got responsiveness fixes, compact polish, and the working-state stop button treatment.
- Setup prompts can route directly to the relevant Settings card.
- The project folder browser guards against stale async directory responses.

## Validation

- `bun run ai:check`
- push hook: `bun run ai:check`
