### PR TITLE
Improve Pi message status details

### DIFF
--- a/desktop/runtime-host/live-tool-progress.ts
+++ b/desktop/runtime-host/live-tool-progress.ts
@@ -52,9 +52,12 @@ export function getLiveToolProgressMessages(runtime: PiRuntime) {
         ]
     return {
       role: 'toolResult',
+      toolCallId: entry.toolCallId,
       toolName: entry.toolName,
       isError: Boolean(entry.isError),
       content: displayContent,
+      args: entry.args,
+      running: !entry.terminal,
       timestamp: `tool-progress:${entry.toolCallId}`,
     } as unknown as AgentMessage
   })

--- a/desktop/runtime/thread-publisher.ts
+++ b/desktop/runtime/thread-publisher.ts
@@ -72,9 +72,12 @@ function getLiveToolProgressMessages(runtime: PiRuntime) {
 
     return {
       role: 'toolResult',
+      toolCallId: entry.toolCallId,
       toolName: entry.toolName,
       isError: Boolean(entry.isError),
       content: displayContent,
+      args: entry.args,
+      running: !entry.terminal,
       timestamp: `tool-progress:${entry.toolCallId}`,
     } as unknown as AgentMessage
   })

--- a/shared/desktop-contracts.ts
+++ b/shared/desktop-contracts.ts
@@ -90,6 +90,7 @@ export type {
 } from './desktop-settings-contracts'
 export type {
   ArchivedThread,
+  AssistantUsageSummary,
   BashExecutionMessage,
   CustomThreadMessage,
   InboxThread,

--- a/shared/desktop-thread-contracts.ts
+++ b/shared/desktop-thread-contracts.ts
@@ -66,18 +66,33 @@ export type ProseMessage = {
   role: 'assistant' | 'user'
   format?: 'prose' | 'list' | undefined
   content: string[]
+  isError?: boolean | undefined
+  stopReason?: 'length' | 'error' | 'aborted' | undefined
+  usage?: AssistantUsageSummary | undefined
   thinkingContent?: string[] | undefined
   thinkingHeaders?: string[] | undefined
   thinkingRedacted?: boolean | undefined
 }
 
+export type AssistantUsageSummary = {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  totalTokens: number
+  costTotal: number
+}
+
 export type ToolResultMessage = {
   id: string
   role: 'toolResult'
+  toolCallId?: string | undefined
   toolName: string
   content: string[]
   images?: ToolResultImage[] | undefined
   isError: boolean
+  args?: string | undefined
+  running?: boolean | undefined
 }
 
 export type ToolResultImage = {
@@ -101,6 +116,7 @@ export type CustomThreadMessage = {
   role: 'custom'
   customType: string
   content: string[]
+  isError?: boolean | undefined
 }
 
 export type SystemThreadMessage = {

--- a/shared/pi-message-mapper.ts
+++ b/shared/pi-message-mapper.ts
@@ -88,6 +88,7 @@ const paragraphBreakPattern = /\n{2,}/
 const markdownHeadingPattern = /^#{1,6}\s+(.+)$/
 const boldOnlyPattern = /^\*\*(.+?)\*\*$/
 const underscoreBoldOnlyPattern = /^__(.+?)__$/
+const maxToolArgsDisplayLength = 4000
 
 function splitParagraphs(text: string) {
   return text
@@ -335,13 +336,19 @@ function mapToolResultMessage(id: string, runtimeMessage: RuntimeMessage): Messa
 
 function formatToolArgs(args: unknown) {
   if (args === undefined || args === null) return undefined
-  if (typeof args === 'string') return args.trim() || undefined
+  if (typeof args === 'string') return truncateToolArgs(args.trim())
 
   try {
-    return JSON.stringify(args, null, 2)
+    return truncateToolArgs(JSON.stringify(args, null, 2))
   } catch {
-    return String(args)
+    return truncateToolArgs(String(args))
   }
+}
+
+function truncateToolArgs(value: string | undefined) {
+  if (!value) return undefined
+  if (value.length <= maxToolArgsDisplayLength) return value
+  return `${value.slice(0, maxToolArgsDisplayLength)}\n… truncated ${value.length - maxToolArgsDisplayLength} chars`
 }
 
 function mapCustomMessage(id: string, runtimeMessage: RuntimeMessage): Message | null {

--- a/shared/pi-message-mapper.ts
+++ b/shared/pi-message-mapper.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from '@earendil-works/pi-agent-core'
-import type { Message, ToolResultImage } from './desktop-contracts'
+import type { AssistantUsageSummary, Message, ToolResultImage } from './desktop-contracts'
 
 type TextPart = {
   type?: string | undefined
@@ -30,7 +30,11 @@ type RuntimeMessage = {
       >
   timestamp?: string | undefined | number
   errorMessage?: string | undefined
+  stopReason?: string | undefined
+  toolCallId?: string | undefined
   toolName?: string | undefined
+  args?: unknown
+  running?: boolean | undefined
   isError?: boolean | undefined
   command?: string | undefined
   output?: string | undefined
@@ -38,7 +42,40 @@ type RuntimeMessage = {
   cancelled?: boolean | undefined
   truncated?: boolean | undefined
   customType?: string | undefined
+  label?: string | undefined
   summary?: string | undefined
+  usage?:
+    | {
+        input?: number | undefined
+        output?: number | undefined
+        cacheRead?: number | undefined
+        cacheWrite?: number | undefined
+        totalTokens?: number | undefined
+        cost?: { total?: number | undefined } | undefined
+      }
+    | undefined
+}
+
+function normalizeAssistantStopReason(value: string | undefined) {
+  return value === 'length' || value === 'error' || value === 'aborted' ? value : undefined
+}
+
+function getNumberValue(value: number | undefined) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function mapAssistantUsage(runtimeMessage: RuntimeMessage): AssistantUsageSummary | undefined {
+  const usage = runtimeMessage.usage
+  if (!usage) return undefined
+
+  return {
+    input: getNumberValue(usage.input),
+    output: getNumberValue(usage.output),
+    cacheRead: getNumberValue(usage.cacheRead),
+    cacheWrite: getNumberValue(usage.cacheWrite),
+    totalTokens: getNumberValue(usage.totalTokens),
+    costTotal: getNumberValue(usage.cost?.total),
+  }
 }
 
 type SessionBranchEntry = {
@@ -271,6 +308,9 @@ function mapAssistantMessage(id: string, runtimeMessage: RuntimeMessage): Messag
     id,
     role: 'assistant',
     content,
+    isError: runtimeMessage.stopReason === 'error' || undefined,
+    stopReason: normalizeAssistantStopReason(runtimeMessage.stopReason),
+    usage: mapAssistantUsage(runtimeMessage),
     thinkingContent: thinkingContent.length > 0 ? thinkingContent : undefined,
     thinkingHeaders: thinkingHeaders.length > 0 ? [...new Set(thinkingHeaders)] : undefined,
     thinkingRedacted: thinkingRedacted || undefined,
@@ -283,23 +323,46 @@ function mapToolResultMessage(id: string, runtimeMessage: RuntimeMessage): Messa
   return {
     id,
     role: 'toolResult',
+    toolCallId: runtimeMessage.toolCallId?.trim() || undefined,
     toolName: runtimeMessage.toolName ?? 'tool',
     content: text.length > 0 ? text : [runtimeMessage.isError ? 'Tool failed.' : 'Tool finished.'],
     images: images.length > 0 ? images : undefined,
     isError: Boolean(runtimeMessage.isError),
+    args: formatToolArgs(runtimeMessage.args),
+    running: runtimeMessage.running || undefined,
+  }
+}
+
+function formatToolArgs(args: unknown) {
+  if (args === undefined || args === null) return undefined
+  if (typeof args === 'string') return args.trim() || undefined
+
+  try {
+    return JSON.stringify(args, null, 2)
+  } catch {
+    return String(args)
   }
 }
 
 function mapCustomMessage(id: string, runtimeMessage: RuntimeMessage): Message | null {
   const content = extractDisplayContent(runtimeMessage.content)
-  return content.length === 0
-    ? null
-    : { id, role: 'custom', customType: runtimeMessage.customType ?? 'custom', content }
+  if (content.length === 0) return null
+
+  const customType = runtimeMessage.customType ?? 'custom'
+  return {
+    id,
+    role: 'custom',
+    customType,
+    content,
+    isError: customType === 'howcode.extension.error' || undefined,
+  }
 }
 
 function mapSystemMessage(id: string, runtimeMessage: RuntimeMessage): Message | null {
   const content = extractDisplayContent(runtimeMessage.content)
-  return content.length === 0 ? null : { id, role: 'system', label: 'System', content }
+  return content.length === 0
+    ? null
+    : { id, role: 'system', label: runtimeMessage.label?.trim() || 'System', content }
 }
 
 function mapSummaryMessage(id: string, runtimeMessage: RuntimeMessage): Message | null {

--- a/shared/thread-history.ts
+++ b/shared/thread-history.ts
@@ -9,14 +9,28 @@ export type SessionPathEntry = {
   content?: string | undefined | unknown[]
   display?: boolean | undefined
   summary?: string | undefined
+  provider?: string | undefined
+  modelId?: string | undefined
+  thinkingLevel?: string | undefined
   tokensBefore?: number | undefined
   firstKeptEntryId?: string | undefined
 }
 
 function isDisplayableEntry(entry: SessionPathEntry) {
   return (
-    entry.type === 'message' || entry.type === 'custom_message' || entry.type === 'branch_summary'
+    entry.type === 'message' ||
+    entry.type === 'custom_message' ||
+    entry.type === 'branch_summary' ||
+    entry.type === 'model_change' ||
+    entry.type === 'thinking_level_change'
   )
+}
+
+function modelChangeConsumesNextEntry(
+  entry: SessionPathEntry,
+  nextEntry: SessionPathEntry | undefined,
+) {
+  return entry.type === 'model_change' && nextEntry?.type === 'thinking_level_change'
 }
 
 function countDisplayableEntriesInRange(
@@ -30,13 +44,61 @@ function countDisplayableEntriesInRange(
     const entry = entries[index]
     if (entry && isDisplayableEntry(entry)) {
       count += 1
+      if (modelChangeConsumesNextEntry(entry, entries[index + 1])) {
+        index += 1
+      }
     }
   }
 
   return count
 }
 
-function appendEntryMessage(messages: AgentMessage[], entry: SessionPathEntry) {
+function appendModelChangeMessage(
+  messages: AgentMessage[],
+  entry: SessionPathEntry,
+  nextEntry: SessionPathEntry | undefined,
+) {
+  const provider = entry.provider?.trim()
+  const modelId = entry.modelId?.trim()
+  if (!(provider && modelId)) {
+    return false
+  }
+
+  const thinkingLevel =
+    nextEntry?.type === 'thinking_level_change' ? nextEntry.thinkingLevel?.trim() : undefined
+  const modelLabel = thinkingLevel
+    ? `${provider}/${modelId}/${thinkingLevel}`
+    : `${provider}/${modelId}`
+
+  messages.push({
+    role: 'system',
+    content: [{ type: 'text', text: modelLabel }],
+    label: 'Model changed',
+    timestamp: entry.timestamp ?? Date.now(),
+  } as unknown as AgentMessage)
+
+  return Boolean(thinkingLevel)
+}
+
+function appendThinkingLevelChangeMessage(messages: AgentMessage[], entry: SessionPathEntry) {
+  const thinkingLevel = entry.thinkingLevel?.trim()
+  if (!thinkingLevel) {
+    return
+  }
+
+  messages.push({
+    role: 'system',
+    content: [{ type: 'text', text: thinkingLevel }],
+    label: 'Reasoning changed',
+    timestamp: entry.timestamp ?? Date.now(),
+  } as unknown as AgentMessage)
+}
+
+function appendEntryMessage(
+  messages: AgentMessage[],
+  entry: SessionPathEntry,
+  nextEntry: SessionPathEntry | undefined,
+) {
   switch (entry.type) {
     case 'message':
       if (entry.message) {
@@ -66,6 +128,11 @@ function appendEntryMessage(messages: AgentMessage[], entry: SessionPathEntry) {
         timestamp: entry.timestamp ?? Date.now(),
       } as unknown as AgentMessage)
       return
+    case 'model_change':
+      return appendModelChangeMessage(messages, entry, nextEntry)
+    case 'thinking_level_change':
+      appendThinkingLevelChangeMessage(messages, entry)
+      return false
     case 'compaction':
       if (!entry.summary?.trim()) {
         return
@@ -77,9 +144,9 @@ function appendEntryMessage(messages: AgentMessage[], entry: SessionPathEntry) {
         tokensBefore: entry.tokensBefore ?? 0,
         timestamp: entry.timestamp ?? Date.now(),
       } as unknown as AgentMessage)
-      return
+      return false
     default:
-      return
+      return false
   }
 }
 
@@ -100,7 +167,10 @@ function appendSourceMessagesFromEntryRange(
   for (let index = startIndex; index < endIndex; index += 1) {
     const entry = pathEntries[index]
     if (entry) {
-      appendEntryMessage(messages, entry)
+      const consumedNextEntry = appendEntryMessage(messages, entry, pathEntries[index + 1])
+      if (consumedNextEntry) {
+        index += 1
+      }
     }
   }
 }

--- a/src/app/components/common/thread-message.tsx
+++ b/src/app/components/common/thread-message.tsx
@@ -230,6 +230,8 @@ function AssistantMessageBlock({
 }: Omit<ThreadMessageProps, 'message'> & { message: ProseMessage }) {
   const hasThinking = Boolean(message.thinkingContent && message.thinkingContent.length > 0)
   const showAssistantContent = message.content.length > 0 && !(firstCardOnly && hasThinking)
+  const statusLabel = getAssistantStatusLabel(message)
+  const statusClassName = getAssistantStatusClassName(message)
   return (
     <div className="min-w-0">
       {hasThinking ? (
@@ -244,7 +246,18 @@ function AssistantMessageBlock({
         />
       ) : null}
       {showAssistantContent ? (
-        <div className="group/message relative px-4 pr-12">
+        <div
+          className={
+            statusClassName
+              ? `group/message relative rounded-2xl px-4 py-3 pr-12 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] ${statusClassName}`
+              : 'group/message relative px-4 pr-12'
+          }
+        >
+          {statusLabel ? (
+            <div className="mb-2 text-[11px] font-semibold tracking-[0.08em] uppercase opacity-85">
+              {statusLabel}
+            </div>
+          ) : null}
           {renderProse(message.content, message.format)}
           <div className="absolute top-0 right-1">
             <CopyMessageButton label="assistant turn" text={message.content.join('\n\n')} />
@@ -253,6 +266,29 @@ function AssistantMessageBlock({
       ) : null}
     </div>
   )
+}
+
+function getAssistantStatusLabel(message: ProseMessage) {
+  if (message.isError || message.stopReason === 'error') return 'Error'
+  if (message.stopReason === 'length') return 'Stopped · length limit'
+  if (message.stopReason === 'aborted') return 'Stopped'
+  return null
+}
+
+function getAssistantStatusClassName(message: ProseMessage) {
+  if (message.isError || message.stopReason === 'error') {
+    return 'bg-[color:color-mix(in_srgb,var(--danger-bg)_50%,transparent)] text-[color:var(--danger)]'
+  }
+
+  if (message.stopReason === 'length') {
+    return 'bg-[color:var(--warning-bg)] text-[color:var(--warning)]/50'
+  }
+
+  if (message.stopReason === 'aborted') {
+    return 'bg-[color:var(--warning-bg)] text-[color:var(--warning)]/50'
+  }
+
+  return null
 }
 
 function ToolResultMessageBlock({ message }: { message: ToolResultMessage }) {
@@ -301,10 +337,16 @@ function BashExecutionMessageBlock({ message }: { message: BashExecutionMessage 
 }
 
 function CustomMessageBlock({ message }: { message: CustomThreadMessage }) {
+  const customStatusClassName = message.isError
+    ? 'border-transparent bg-[color:color-mix(in_srgb,var(--danger-bg)_50%,transparent)] text-[color:var(--danger)]'
+    : 'border-dashed border-[color:var(--border)] bg-[color:var(--message-tool-bg)] text-[color:var(--text)]/84'
+
   return (
-    <div className="grid min-w-0 gap-2 rounded-2xl border border-dashed border-[color:var(--border)] bg-[color:var(--message-tool-bg)] px-4 py-3 text-[13px] text-[color:var(--text)]/84">
+    <div
+      className={`grid min-w-0 gap-2 rounded-2xl border px-4 py-3 text-[13px] ${customStatusClassName}`}
+    >
       <div className="break-words text-[12px] uppercase tracking-[0.08em] text-[color:var(--muted)] [overflow-wrap:anywhere]">
-        {message.customType}
+        {message.isError ? 'Extension error' : message.customType}
       </div>
       {renderProse(message.content)}
     </div>
@@ -312,6 +354,21 @@ function CustomMessageBlock({ message }: { message: CustomThreadMessage }) {
 }
 
 function SystemMessageBlock({ message }: { message: SystemThreadMessage }) {
+  const isModelStatus = message.label === 'Model changed' || message.label === 'Reasoning changed'
+
+  if (isModelStatus) {
+    return (
+      <div className="inline-flex max-w-full items-center gap-1.5 px-1 text-[11.5px] text-[color:var(--muted-2)]/78">
+        <span className="shrink-0 text-[10px] font-medium tracking-[0.06em] uppercase opacity-80">
+          {message.label}
+        </span>
+        <span className="min-w-0 truncate font-mono text-[11px] not-italic text-[color:var(--muted)]/82">
+          {message.content.join('')}
+        </span>
+      </div>
+    )
+  }
+
   return (
     <div className="grid min-w-0 gap-2 rounded-xl border border-[color:var(--border)] bg-[color:var(--message-tool-bg)] px-3 py-2 text-[12.5px] italic text-[color:var(--muted)]/92">
       <div className="break-words text-[11px] not-italic uppercase tracking-[0.08em] text-[color:var(--muted-2)]/84 [overflow-wrap:anywhere]">

--- a/src/app/components/workspace/composer.tsx
+++ b/src/app/components/workspace/composer.tsx
@@ -11,7 +11,7 @@ import type {
   ProjectDiffRenderMode,
   ProjectGitState,
 } from '../../desktop/types'
-import type { View } from '../../types'
+import type { Message, View } from '../../types'
 import type { SettingsOpenTarget } from '../../views/settings/settingsTypes'
 import { ComposerPromptSurface } from './composer/composer-prompt-surface'
 import type { SavedDiffComment } from './diff/diffCommentStore'
@@ -20,6 +20,7 @@ export type ComposerProps = {
   activeView: View
   model: ComposerModel | null
   contextUsage: ComposerContextUsage | null
+  messages?: Message[] | undefined
   availableModels: ComposerModel[]
   isStreaming: boolean
   replyActivityKey: string

--- a/src/app/components/workspace/composer/composer-context-meter.tsx
+++ b/src/app/components/workspace/composer/composer-context-meter.tsx
@@ -1,11 +1,13 @@
 import { type MouseEvent, useCallback, useEffect, useRef, useState } from 'react'
 import type { ComposerContextUsage } from '../../../desktop/types'
 import { useDismissibleLayer } from '../../../hooks/useDismissibleLayer'
+import type { Message } from '../../../types'
 import { ghostButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
 
 type ComposerContextMeterProps = {
   contextUsage: ComposerContextUsage | null
+  messages?: Message[] | undefined
   isCompacting: boolean
   compactDisabled: boolean
   onCompact: () => void
@@ -16,6 +18,21 @@ const tokenFormatter = new Intl.NumberFormat('en', {
   maximumFractionDigits: 1,
 })
 const numberFormatter = new Intl.NumberFormat('en')
+const costFormatter = new Intl.NumberFormat('en', {
+  currency: 'USD',
+  maximumFractionDigits: 4,
+  style: 'currency',
+})
+
+type UsageTotals = {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  totalTokens: number
+  costTotal: number
+  count: number
+}
 
 function formatTokens(value: number | null | undefined, options: { compact?: boolean } = {}) {
   if (value === null || value === undefined) {
@@ -23,6 +40,38 @@ function formatTokens(value: number | null | undefined, options: { compact?: boo
   }
 
   return options.compact ? tokenFormatter.format(value) : numberFormatter.format(value)
+}
+
+function formatCost(value: number | null | undefined) {
+  if (value === null || value === undefined) return 'Unknown'
+  return costFormatter.format(value)
+}
+
+function getMessageUsageTotals(messages: Message[] | undefined): UsageTotals | null {
+  if (!messages || messages.length === 0) return null
+
+  const totals: UsageTotals = {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    costTotal: 0,
+    count: 0,
+  }
+
+  for (const message of messages) {
+    if (message.role !== 'assistant' || !message.usage) continue
+    totals.input += message.usage.input
+    totals.output += message.usage.output
+    totals.cacheRead += message.usage.cacheRead
+    totals.cacheWrite += message.usage.cacheWrite
+    totals.totalTokens += message.usage.totalTokens
+    totals.costTotal += message.usage.costTotal
+    totals.count += 1
+  }
+
+  return totals.count === 0 ? null : totals
 }
 
 function getMeterTone(percent: number | null | undefined) {
@@ -132,12 +181,14 @@ function createHoverTriangleCleanup(input: {
 
 export function ComposerContextMeter({
   contextUsage,
+  messages,
   isCompacting,
   compactDisabled,
   onCompact,
 }: ComposerContextMeterProps) {
   const [hovered, setHovered] = useState(false)
   const [pinned, setPinned] = useState(false)
+  const [usageTotals, setUsageTotals] = useState<UsageTotals | null>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const clearHoverTriangleRef = useRef<(() => void) | null>(null)
@@ -146,6 +197,7 @@ export function ComposerContextMeter({
   const tone = getMeterTone(percent)
   const open = hovered || pinned
   const label = getContextMeterLabel(isCompacting, percent)
+  const usageSourceVersion = messages?.length ?? 0
 
   useDismissibleLayer({
     open: pinned,
@@ -158,10 +210,15 @@ export function ComposerContextMeter({
     clearHoverTriangleRef.current = null
   }, [])
 
+  const loadUsageTotals = useCallback(() => {
+    setUsageTotals((current) => current ?? getMessageUsageTotals(messages))
+  }, [messages])
+
   const openHoverPreview = useCallback(() => {
     clearHoverTriangle()
+    loadUsageTotals()
     setHovered(true)
-  }, [clearHoverTriangle])
+  }, [clearHoverTriangle, loadUsageTotals])
 
   const closeHoverPreview = useCallback(() => {
     clearHoverTriangle()
@@ -195,6 +252,10 @@ export function ComposerContextMeter({
   )
 
   useEffect(() => clearHoverTriangle, [clearHoverTriangle])
+  useEffect(() => {
+    void usageSourceVersion
+    setUsageTotals(null)
+  }, [usageSourceVersion])
 
   return (
     <div
@@ -208,6 +269,7 @@ export function ComposerContextMeter({
         type="button"
         className="relative inline-flex h-7 w-7 items-center justify-center rounded-full text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
         onClick={() => setPinned((current) => !current)}
+        onPointerDown={loadUsageTotals}
         aria-label={label}
         aria-expanded={open}
       >
@@ -228,6 +290,46 @@ export function ComposerContextMeter({
           onMouseEnter={openHoverPreview}
           onMouseDown={(event) => event.preventDefault()}
         >
+          {usageTotals ? (
+            <div className="grid gap-1 border-b border-[color:var(--border)] pb-2">
+              <div className="flex justify-between gap-4">
+                <span>Tokens</span>
+                <span className="font-mono text-[color:var(--text)]">
+                  {formatTokens(usageTotals.totalTokens)}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span>Input</span>
+                <span className="font-mono text-[color:var(--text)]">
+                  {formatTokens(usageTotals.input)}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span>Output</span>
+                <span className="font-mono text-[color:var(--text)]">
+                  {formatTokens(usageTotals.output)}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span>Cache read</span>
+                <span className="font-mono text-[color:var(--text)]">
+                  {formatTokens(usageTotals.cacheRead)}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span>Cache write</span>
+                <span className="font-mono text-[color:var(--text)]">
+                  {formatTokens(usageTotals.cacheWrite)}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span>Cost</span>
+                <span className="font-mono text-[color:var(--text)]">
+                  {formatCost(usageTotals.costTotal)}
+                </span>
+              </div>
+            </div>
+          ) : null}
           <div className="grid gap-1">
             <div className="flex justify-between gap-3">
               <span>Used</span>

--- a/src/app/components/workspace/composer/composer-context-meter.tsx
+++ b/src/app/components/workspace/composer/composer-context-meter.tsx
@@ -197,7 +197,6 @@ export function ComposerContextMeter({
   const tone = getMeterTone(percent)
   const open = hovered || pinned
   const label = getContextMeterLabel(isCompacting, percent)
-  const usageSourceVersion = messages?.length ?? 0
 
   useDismissibleLayer({
     open: pinned,
@@ -211,7 +210,7 @@ export function ComposerContextMeter({
   }, [])
 
   const loadUsageTotals = useCallback(() => {
-    setUsageTotals((current) => current ?? getMessageUsageTotals(messages))
+    setUsageTotals(getMessageUsageTotals(messages))
   }, [messages])
 
   const openHoverPreview = useCallback(() => {
@@ -252,11 +251,6 @@ export function ComposerContextMeter({
   )
 
   useEffect(() => clearHoverTriangle, [clearHoverTriangle])
-  useEffect(() => {
-    void usageSourceVersion
-    setUsageTotals(null)
-  }, [usageSourceVersion])
-
   return (
     <div
       role="application"

--- a/src/app/components/workspace/composer/composer-footer.tsx
+++ b/src/app/components/workspace/composer/composer-footer.tsx
@@ -7,6 +7,7 @@ import type {
   ProjectDiffBaseline,
   ProjectGitState,
 } from '../../../desktop/types'
+import type { Message } from '../../../types'
 import { compactIconButtonClass, iconActionButtonDisabledClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
 import { PiLogoMark } from '../../common/pi-logo-mark'
@@ -28,6 +29,7 @@ type ComposerFooterProps = {
   diffBaseline: ProjectDiffBaseline
   model: ComposerModel | null
   contextUsage: ComposerContextUsage | null
+  messages?: Message[] | undefined
   compactDisabled: boolean
   isCompacting: boolean
   modelButtonRef: RefObject<HTMLButtonElement | null>
@@ -60,6 +62,7 @@ export function ComposerFooter({
   diffBaseline,
   model,
   contextUsage,
+  messages,
   compactDisabled,
   isCompacting,
   modelButtonRef,
@@ -127,6 +130,7 @@ export function ComposerFooter({
         <div className="absolute top-0 right-0">
           <ComposerContextMeter
             contextUsage={contextUsage}
+            messages={messages}
             compactDisabled={compactDisabled}
             isCompacting={isCompacting}
             onCompact={onCompact}

--- a/src/app/components/workspace/composer/composer-prompt-surface.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-surface.tsx
@@ -46,6 +46,7 @@ export function ComposerPromptSurface({
   workspaceFooterRef,
   model,
   contextUsage,
+  messages,
   availableModels,
   isStreaming,
   replyActivityKey,
@@ -562,6 +563,7 @@ export function ComposerPromptSurface({
             diffBaseline={diffBaseline}
             model={model}
             contextUsage={contextUsage}
+            messages={messages}
             compactDisabled={isStreaming || isCompacting || !sessionPath}
             isCompacting={isCompacting}
             modelButtonRef={modelButtonRef}
@@ -648,7 +650,7 @@ export function ComposerPromptSurface({
           >
             {canStopComposer ? (
               <svg
-                className="composer-stop-button__spinner absolute text-[color:var(--danger)]"
+                className="composer-stop-button__spinner absolute text-white/50"
                 viewBox="0 0 28 28"
                 aria-hidden="true"
               >

--- a/src/app/components/workspace/thread/buildTimelineRows.ts
+++ b/src/app/components/workspace/thread/buildTimelineRows.ts
@@ -40,7 +40,7 @@ export function buildTimelineRows({
   let pendingToolMessages: ToolCallMessage[] = []
   let currentTurn: Extract<TimelineRow, { kind: 'turn' }> | null = null
   let pendingImplicitTurnId: string | null = null
-  let conversationStarted = false
+  let conversationStarted = previousMessageCount > 0
 
   const flushPendingToolMessages = () => {
     if (pendingToolMessages.length === 0) {

--- a/src/app/components/workspace/thread/buildTimelineRows.ts
+++ b/src/app/components/workspace/thread/buildTimelineRows.ts
@@ -17,6 +17,21 @@ function isSummaryMessage(
   return message.role === 'branchSummary' || message.role === 'compactionSummary'
 }
 
+function isStandaloneStatusMessage(message: Message) {
+  return (
+    message.role === 'system' &&
+    (message.label === 'Model changed' || message.label === 'Reasoning changed')
+  )
+}
+
+function getToolGroupMessageKey(message: ToolCallMessage) {
+  if (message.role === 'toolResult') {
+    return message.toolCallId ?? message.id
+  }
+
+  return message.id
+}
+
 export function buildTimelineRows({
   messages,
   previousMessageCount,
@@ -25,6 +40,7 @@ export function buildTimelineRows({
   let pendingToolMessages: ToolCallMessage[] = []
   let currentTurn: Extract<TimelineRow, { kind: 'turn' }> | null = null
   let pendingImplicitTurnId: string | null = null
+  let conversationStarted = false
 
   const flushPendingToolMessages = () => {
     if (pendingToolMessages.length === 0) {
@@ -32,10 +48,10 @@ export function buildTimelineRows({
     }
 
     const firstMessage = pendingToolMessages[0]
-    const lastMessage = pendingToolMessages[pendingToolMessages.length - 1]
+    const toolGroupKey = pendingToolMessages.map(getToolGroupMessageKey).join(':')
     const toolGroup: Extract<TimelineTurnItem, { kind: 'tool-group' }> = {
       kind: 'tool-group',
-      id: `tool-group:${firstMessage?.id ?? 'start'}:${lastMessage?.id ?? 'end'}:${pendingToolMessages.length}`,
+      id: `tool-group:${toolGroupKey || firstMessage?.id || 'start'}:${pendingToolMessages.length}`,
       messages: pendingToolMessages,
     }
 
@@ -63,6 +79,32 @@ export function buildTimelineRows({
     currentTurn = null
   }
 
+  const appendStandaloneMessage = (
+    timelineMessage: Extract<TimelineTurnItem, { kind: 'message' }>,
+  ) => {
+    const { message } = timelineMessage
+    if (isSummaryMessage(message)) {
+      flushCurrentTurn()
+      nextRows.push({
+        kind: 'summary',
+        id: `summary:${message.id}`,
+        message,
+      })
+      pendingImplicitTurnId =
+        message.role === 'compactionSummary' ? `turn:post-summary:${message.id}` : null
+      return true
+    }
+
+    if (!(conversationStarted || currentTurn) && isStandaloneStatusMessage(message)) {
+      flushCurrentTurn()
+      nextRows.push(timelineMessage)
+      pendingImplicitTurnId = null
+      return true
+    }
+
+    return false
+  }
+
   if (previousMessageCount > 0) {
     nextRows.push({
       kind: 'history-divider',
@@ -88,6 +130,7 @@ export function buildTimelineRows({
     if (message.role === 'user') {
       flushCurrentTurn()
       pendingImplicitTurnId = null
+      conversationStarted = true
       currentTurn = {
         kind: 'turn',
         id: `turn:${message.id}`,
@@ -97,17 +140,11 @@ export function buildTimelineRows({
       continue
     }
 
-    if (isSummaryMessage(message)) {
-      flushCurrentTurn()
-      nextRows.push({
-        kind: 'summary',
-        id: `summary:${message.id}`,
-        message,
-      })
-      pendingImplicitTurnId =
-        message.role === 'compactionSummary' ? `turn:post-summary:${message.id}` : null
+    if (appendStandaloneMessage(timelineMessage)) {
       continue
     }
+
+    conversationStarted = true
 
     if (currentTurn) {
       currentTurn.items.push(timelineMessage)

--- a/src/app/components/workspace/thread/tool-calls-card.tsx
+++ b/src/app/components/workspace/thread/tool-calls-card.tsx
@@ -24,6 +24,16 @@ function renderToolCallBody(message: ToolCallMessage) {
             : 'grid min-w-0 gap-2 text-[13px] text-[color:var(--muted-2)]/88'
         }
       >
+        {message.args ? (
+          <div className="grid min-w-0 gap-1 rounded-lg bg-[rgba(255,255,255,0.03)] px-2 py-1.5 font-mono text-[11.5px] text-[color:var(--muted-2)]/82">
+            <div className="font-sans text-[10.5px] tracking-[0.08em] text-[color:var(--muted-2)]/70 uppercase">
+              Arguments
+            </div>
+            <pre className="m-0 max-h-44 overflow-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+              {message.args}
+            </pre>
+          </div>
+        ) : null}
         {message.content.map((paragraph) => (
           <p
             key={paragraph}
@@ -112,6 +122,7 @@ export function ToolCallsCard({
           const title = getToolCallTitle(message)
           const preview = getToolCallPreview(message)
           const isError = message.role === 'toolResult' && message.isError
+          const isRunning = message.role === 'toolResult' && message.running
 
           return (
             <ExpandablePanel
@@ -142,6 +153,11 @@ export function ToolCallsCard({
                   {isError ? (
                     <span className="shrink-0 text-[10.5px] font-medium text-[color:var(--danger)]">
                       Error
+                    </span>
+                  ) : null}
+                  {isRunning ? (
+                    <span className="shrink-0 text-[10.5px] font-medium text-[color:var(--accent)]">
+                      Running
                     </span>
                   ) : null}
                 </>

--- a/src/app/features/chat/chat-workspace-view.tsx
+++ b/src/app/features/chat/chat-workspace-view.tsx
@@ -231,6 +231,7 @@ function ChatComposer(props: ChatWorkspaceContentProps) {
       activeView={state.activeView}
       model={activeComposerState?.currentModel ?? null}
       contextUsage={activeComposerState?.contextUsage ?? null}
+      messages={activeThreadData?.messages}
       availableModels={activeComposerState?.availableModels ?? []}
       isStreaming={activeThreadData?.isStreaming ?? false}
       replyActivityKey={getReplyActivityKey(activeThreadData?.messages ?? [])}

--- a/src/app/features/code/code-workspace-view.tsx
+++ b/src/app/features/code/code-workspace-view.tsx
@@ -407,6 +407,7 @@ function CodeThreadComposer(props: CodeWorkspaceContentProps) {
       activeView={state.activeView}
       model={activeComposerState?.currentModel ?? null}
       contextUsage={activeComposerState?.contextUsage ?? null}
+      messages={activeThreadData?.messages}
       availableModels={activeComposerState?.availableModels ?? []}
       isStreaming={activeThreadData?.isStreaming ?? false}
       replyActivityKey={getReplyActivityKey(activeThreadData?.messages ?? [])}

--- a/src/app/utils/thread-previews.ts
+++ b/src/app/utils/thread-previews.ts
@@ -28,7 +28,11 @@ export function getToolCallTitle(message: ToolCallMessage) {
 
 export function getToolCallPreview(message: ToolCallMessage) {
   if (message.role === 'toolResult') {
-    return message.content[0] ?? (message.isError ? 'Tool failed.' : 'Tool finished.')
+    return (
+      message.args ??
+      message.content[0] ??
+      (message.running ? 'Running…' : message.isError ? 'Tool failed.' : 'Tool finished.')
+    )
   }
 
   return message.command || 'No command'

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -107,7 +107,7 @@
   inset: -0.5rem;
   width: 2.75rem;
   height: 2.75rem;
-  opacity: 0.95;
+  opacity: 1;
   pointer-events: none;
 }
 

--- a/src/test/pi-message-mapper.test.ts
+++ b/src/test/pi-message-mapper.test.ts
@@ -5,6 +5,7 @@ import {
   mapAgentMessagesToUiMessages,
   normalizeThreadTitle,
 } from '../../shared/pi-message-mapper'
+import { buildSourceMessagesFromPathEntries } from '../../shared/thread-history'
 
 describe('pi message mapper', () => {
   it('normalizes titles and derives the first user title', () => {
@@ -123,6 +124,115 @@ describe('pi message mapper', () => {
     ])
   })
 
+  it('marks errored assistant messages for desktop styling', () => {
+    expect(
+      mapAgentMessagesToUiMessages([
+        {
+          role: 'assistant',
+          timestamp: 1,
+          content: [],
+          stopReason: 'error',
+          errorMessage: 'Provider request failed',
+        },
+      ] as never[]),
+    ).toEqual([
+      {
+        id: '1-assistant',
+        role: 'assistant',
+        content: ['Provider request failed'],
+        isError: true,
+        stopReason: 'error',
+      },
+    ])
+  })
+
+  it('keeps aborted assistant messages distinct from errors', () => {
+    expect(
+      mapAgentMessagesToUiMessages([
+        {
+          role: 'assistant',
+          timestamp: 1,
+          content: [],
+          stopReason: 'aborted',
+          errorMessage: 'Request was aborted.',
+        },
+      ] as never[]),
+    ).toEqual([
+      {
+        id: '1-assistant',
+        role: 'assistant',
+        content: ['Request was aborted.'],
+        stopReason: 'aborted',
+      },
+    ])
+  })
+
+  it('preserves assistant stop reasons that affect desktop display', () => {
+    expect(
+      mapAgentMessagesToUiMessages([
+        {
+          role: 'assistant',
+          timestamp: 1,
+          content: [{ type: 'text', text: 'Partial answer' }],
+          stopReason: 'length',
+        },
+        {
+          role: 'assistant',
+          timestamp: 2,
+          content: [{ type: 'text', text: 'Cancelled answer' }],
+          stopReason: 'aborted',
+        },
+      ] as never[]),
+    ).toEqual([
+      {
+        id: '1-assistant',
+        role: 'assistant',
+        content: ['Partial answer'],
+        stopReason: 'length',
+      },
+      {
+        id: '2-assistant',
+        role: 'assistant',
+        content: ['Cancelled answer'],
+        stopReason: 'aborted',
+      },
+    ])
+  })
+
+  it('preserves assistant usage summaries for lazy composer details', () => {
+    expect(
+      mapAgentMessagesToUiMessages([
+        {
+          role: 'assistant',
+          timestamp: 1,
+          content: [{ type: 'text', text: 'Done' }],
+          usage: {
+            input: 100,
+            output: 25,
+            cacheRead: 40,
+            cacheWrite: 10,
+            totalTokens: 175,
+            cost: { total: 0.0123 },
+          },
+        },
+      ] as never[]),
+    ).toEqual([
+      {
+        id: '1-assistant',
+        role: 'assistant',
+        content: ['Done'],
+        usage: {
+          input: 100,
+          output: 25,
+          cacheRead: 40,
+          cacheWrite: 10,
+          totalTokens: 175,
+          costTotal: 0.0123,
+        },
+      },
+    ])
+  })
+
   it('preserves tool result images for desktop rendering', () => {
     expect(
       mapAgentMessagesToUiMessages([
@@ -151,6 +261,34 @@ describe('pi message mapper', () => {
           },
         ],
         isError: false,
+      },
+    ])
+  })
+
+  it('preserves live tool progress arguments and running state', () => {
+    expect(
+      mapAgentMessagesToUiMessages([
+        {
+          role: 'toolResult',
+          timestamp: 'tool-progress:abc',
+          toolCallId: 'abc-call',
+          toolName: 'read',
+          isError: false,
+          running: true,
+          args: { path: 'src/app.tsx' },
+          content: [{ type: 'text', text: 'Running read...' }],
+        },
+      ] as never[]),
+    ).toEqual([
+      {
+        id: 'tool-progress:abc-toolResult',
+        role: 'toolResult',
+        toolCallId: 'abc-call',
+        toolName: 'read',
+        content: ['Running read...'],
+        isError: false,
+        args: '{\n  "path": "src/app.tsx"\n}',
+        running: true,
       },
     ])
   })
@@ -193,6 +331,74 @@ describe('pi message mapper', () => {
         role: 'system',
         label: 'extensionNotice',
         content: ['A non-standard Pi message'],
+      },
+    ])
+  })
+
+  it('marks Howcode extension error messages for desktop styling', () => {
+    expect(
+      mapAgentMessagesToUiMessages([
+        {
+          role: 'custom',
+          timestamp: 1,
+          customType: 'howcode.extension.error',
+          content: 'Test extension error: boom',
+        },
+      ] as never[]),
+    ).toEqual([
+      {
+        id: '1-custom',
+        role: 'custom',
+        customType: 'howcode.extension.error',
+        content: ['Test extension error: boom'],
+        isError: true,
+      },
+    ])
+  })
+
+  it('surfaces model and thinking changes as muted system messages', () => {
+    const messages = buildSourceMessagesFromPathEntries([
+      {
+        type: 'model_change',
+        id: 'model-1',
+        timestamp: 1,
+        provider: 'openai',
+        modelId: 'gpt-5',
+      },
+      {
+        type: 'thinking_level_change',
+        id: 'thinking-1',
+        timestamp: 2,
+        thinkingLevel: 'high',
+      },
+    ])
+
+    expect(mapAgentMessagesToUiMessages(messages)).toEqual([
+      {
+        id: '1-system',
+        role: 'system',
+        label: 'Model changed',
+        content: ['openai/gpt-5/high'],
+      },
+    ])
+  })
+
+  it('surfaces standalone thinking changes as reasoning messages', () => {
+    const messages = buildSourceMessagesFromPathEntries([
+      {
+        type: 'thinking_level_change',
+        id: 'thinking-1',
+        timestamp: 1,
+        thinkingLevel: 'medium',
+      },
+    ])
+
+    expect(mapAgentMessagesToUiMessages(messages)).toEqual([
+      {
+        id: '1-system',
+        role: 'system',
+        label: 'Reasoning changed',
+        content: ['medium'],
       },
     ])
   })

--- a/src/test/pi-message-mapper.test.ts
+++ b/src/test/pi-message-mapper.test.ts
@@ -293,6 +293,25 @@ describe('pi message mapper', () => {
     ])
   })
 
+  it('truncates large live tool progress arguments', () => {
+    const [message] = mapAgentMessagesToUiMessages([
+      {
+        role: 'toolResult',
+        timestamp: 'tool-progress:large',
+        toolName: 'write',
+        isError: false,
+        running: true,
+        args: { content: 'x'.repeat(5000) },
+        content: [{ type: 'text', text: 'Running write...' }],
+      },
+    ] as never[])
+
+    expect(message?.role).toBe('toolResult')
+    if (message?.role !== 'toolResult') return
+    expect(message.args?.length).toBeLessThan(4100)
+    expect(message.args).toContain('… truncated')
+  })
+
   it('preserves displayed extension and system messages', () => {
     expect(
       mapAgentMessagesToUiMessages([


### PR DESCRIPTION
## Summary
- Surface Pi assistant stop states, model/reasoning changes, extension errors, and usage totals in the desktop UI.
- Improve live tool progress rendering with running state and arguments so tool calls are visible before final results land.
- Soften stop/error visual treatment and reduce stop-button spinner emphasis.

## Details
- Maps assistant `stopReason`, usage summaries, tool call IDs/args/running state, and extension error status through shared thread contracts.
- Shows initial model/reasoning setup outside foldable turns, while later model/reasoning changes stay with their turn.
- Adds lazy usage aggregation to the composer context popover so totals are computed only when the popover opens.
- Stabilizes live-to-final tool group identity using `toolCallId` to reduce layout jumps.

## Validation
- `bun run ai:check`
