### PR TITLE
Implement project overview landing

### DIFF
--- a/desktop/pi-threads.ts
+++ b/desktop/pi-threads.ts
@@ -17,6 +17,7 @@ export {
   searchPiPackages,
 } from './pi-packages/index.ts'
 export { handleDesktopAction } from './pi-threads/action-router.ts'
+export { loadProjectUsageSummary } from './pi-threads/project-usage-summary.ts'
 export {
   captureProjectDiffBaseline,
   disposeDesktopRuntime,

--- a/desktop/pi-threads/project-usage-summary.ts
+++ b/desktop/pi-threads/project-usage-summary.ts
@@ -1,0 +1,298 @@
+import { createReadStream } from 'node:fs'
+import { createInterface } from 'node:readline'
+import type {
+  ProjectUsageSessionSummary,
+  ProjectUsageSummary,
+} from '../../shared/desktop-contracts.ts'
+import { listArchivedProjectThreads, listProjectThreads } from '../thread-state-db.ts'
+import { mapWithConcurrency } from './map-with-concurrency.ts'
+
+type UsageEntry = {
+  type?: string | undefined
+  message?: {
+    role?: string | undefined
+    usage?: {
+      input?: number | undefined
+      output?: number | undefined
+      cacheRead?: number | undefined
+      cacheWrite?: number | undefined
+      totalTokens?: number | undefined
+      cost?: { total?: number | undefined } | undefined
+    }
+  }
+}
+
+const PROJECT_USAGE_SCAN_CONCURRENCY = 6
+const TOP_USAGE_SESSION_LIMIT = 10
+
+type UsageTotals = Pick<
+  ProjectUsageSummary,
+  | 'assistantTurnCount'
+  | 'cacheRead'
+  | 'cacheWrite'
+  | 'costTotal'
+  | 'input'
+  | 'output'
+  | 'totalTokens'
+>
+
+type ArchivedUsageCacheEntry = {
+  summary: ProjectUsageSummary | null
+  threadSignature: string
+  promise: Promise<ProjectUsageSummary> | null
+}
+
+type ThreadUsageCacheEntry = {
+  summary: ProjectUsageSessionSummary
+  signature: string
+}
+
+const archivedUsageCache = new Map<string, ArchivedUsageCacheEntry>()
+const threadUsageCache = new Map<string, ThreadUsageCacheEntry>()
+
+function finiteNumber(value: number | undefined) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function emptySessionSummary(input: {
+  threadId: string
+  title: string
+  sessionPath: string
+  lastModifiedMs?: number | undefined
+}): ProjectUsageSessionSummary {
+  return {
+    threadId: input.threadId,
+    title: input.title,
+    sessionPath: input.sessionPath,
+    lastModifiedMs: input.lastModifiedMs,
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    costTotal: 0,
+    assistantTurnCount: 0,
+  }
+}
+
+function parseUsageEntry(line: string) {
+  if (!line.trim()) return null
+  try {
+    return JSON.parse(line) as UsageEntry
+  } catch {
+    return null
+  }
+}
+
+async function summarizeSession(input: {
+  threadId: string
+  title: string
+  sessionPath: string
+  lastModifiedMs?: number | undefined
+}) {
+  const summary = emptySessionSummary(input)
+  const lines = createInterface({
+    input: createReadStream(input.sessionPath, { encoding: 'utf8' }),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  })
+
+  for await (const line of lines) {
+    const entry = parseUsageEntry(line)
+    const usage =
+      entry?.type === 'message' && entry.message?.role === 'assistant'
+        ? entry.message.usage
+        : undefined
+    if (!usage) continue
+
+    summary.input += finiteNumber(usage.input)
+    summary.output += finiteNumber(usage.output)
+    summary.cacheRead += finiteNumber(usage.cacheRead)
+    summary.cacheWrite += finiteNumber(usage.cacheWrite)
+    summary.totalTokens += finiteNumber(usage.totalTokens)
+    summary.costTotal += finiteNumber(usage.cost?.total)
+    summary.assistantTurnCount += 1
+  }
+
+  return summary
+}
+
+function getThreadSignature(threads: Array<{ id: string; lastModifiedMs?: number | undefined }>) {
+  return threads.map((thread) => `${thread.id}:${thread.lastModifiedMs ?? 0}`).join('|')
+}
+
+function getSessionUsageCacheKey(input: {
+  sessionPath: string
+  lastModifiedMs?: number | undefined
+}) {
+  return `${input.sessionPath}:${input.lastModifiedMs ?? 0}`
+}
+
+function sumSessionUsage(sessionSummaries: ProjectUsageSessionSummary[]): UsageTotals {
+  return sessionSummaries.reduce(
+    (current, session) => ({
+      assistantTurnCount: current.assistantTurnCount + session.assistantTurnCount,
+      cacheRead: current.cacheRead + session.cacheRead,
+      cacheWrite: current.cacheWrite + session.cacheWrite,
+      costTotal: current.costTotal + session.costTotal,
+      input: current.input + session.input,
+      output: current.output + session.output,
+      totalTokens: current.totalTokens + session.totalTokens,
+    }),
+    {
+      assistantTurnCount: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      costTotal: 0,
+      input: 0,
+      output: 0,
+      totalTokens: 0,
+    },
+  )
+}
+
+function combineTotals(left: UsageTotals, right: UsageTotals): UsageTotals {
+  return {
+    assistantTurnCount: left.assistantTurnCount + right.assistantTurnCount,
+    cacheRead: left.cacheRead + right.cacheRead,
+    cacheWrite: left.cacheWrite + right.cacheWrite,
+    costTotal: left.costTotal + right.costTotal,
+    input: left.input + right.input,
+    output: left.output + right.output,
+    totalTokens: left.totalTokens + right.totalTokens,
+  }
+}
+
+async function summarizeThreads(projectId: string, threads: ReturnType<typeof listProjectThreads>) {
+  const sessionSummaries = await mapWithConcurrency(
+    threads,
+    PROJECT_USAGE_SCAN_CONCURRENCY,
+    async (thread) => {
+      if (!thread.sessionPath) {
+        return emptySessionSummary({
+          threadId: thread.id,
+          title: thread.title,
+          sessionPath: '',
+          lastModifiedMs: thread.lastModifiedMs,
+        })
+      }
+
+      try {
+        const cacheKey = getSessionUsageCacheKey({
+          sessionPath: thread.sessionPath,
+          lastModifiedMs: thread.lastModifiedMs,
+        })
+        const cached = threadUsageCache.get(thread.sessionPath)
+        if (cached?.signature === cacheKey) return cached.summary
+        const summary = await summarizeSession({
+          threadId: thread.id,
+          title: thread.title,
+          sessionPath: thread.sessionPath,
+          lastModifiedMs: thread.lastModifiedMs,
+        })
+        threadUsageCache.set(thread.sessionPath, { summary, signature: cacheKey })
+        return summary
+      } catch (error) {
+        console.warn(`Failed to summarize project usage for ${thread.sessionPath}.`, error)
+        return emptySessionSummary({
+          threadId: thread.id,
+          title: thread.title,
+          sessionPath: thread.sessionPath,
+          lastModifiedMs: thread.lastModifiedMs,
+        })
+      }
+    },
+  )
+  const totals = sumSessionUsage(sessionSummaries)
+
+  return {
+    projectId,
+    sessionCount: threads.length,
+    sessionsWithUsageCount: sessionSummaries.filter((session) => session.assistantTurnCount > 0)
+      .length,
+    ...totals,
+    topSessions: getTopSessions(sessionSummaries),
+  }
+}
+
+function getTopSessions(sessionSummaries: ProjectUsageSessionSummary[]) {
+  return sessionSummaries
+    .filter((session) => session.assistantTurnCount > 0)
+    .sort((left, right) =>
+      right.costTotal === left.costTotal
+        ? right.totalTokens - left.totalTokens
+        : right.costTotal - left.costTotal,
+    )
+    .slice(0, TOP_USAGE_SESSION_LIMIT)
+}
+
+function getArchivedUsage(projectId: string) {
+  const archivedThreads = listArchivedProjectThreads(projectId)
+  const threadSignature = getThreadSignature(archivedThreads)
+  const cached = archivedUsageCache.get(projectId)
+  if (cached?.threadSignature === threadSignature) {
+    return { summary: cached.summary, refreshing: Boolean(cached.promise) }
+  }
+
+  if (cached?.promise) {
+    return { summary: cached.summary, refreshing: true }
+  }
+
+  const promise = summarizeThreads(projectId, archivedThreads)
+    .then((summary) => {
+      archivedUsageCache.set(projectId, { summary, threadSignature, promise: null })
+      return summary
+    })
+    .catch((error) => {
+      console.warn(`Failed to summarize archived project usage for ${projectId}.`, error)
+      archivedUsageCache.set(projectId, {
+        summary: cached?.summary ?? null,
+        threadSignature,
+        promise: null,
+      })
+      return cached?.summary ?? summarizeEmptyProject(projectId)
+    })
+
+  archivedUsageCache.set(projectId, {
+    summary: cached?.summary ?? null,
+    threadSignature,
+    promise,
+  })
+  return { summary: cached?.summary ?? null, refreshing: true }
+}
+
+function summarizeEmptyProject(projectId: string): ProjectUsageSummary {
+  return {
+    projectId,
+    sessionCount: 0,
+    sessionsWithUsageCount: 0,
+    assistantTurnCount: 0,
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    costTotal: 0,
+    topSessions: [],
+  }
+}
+
+export async function loadProjectUsageSummary(projectId: string): Promise<ProjectUsageSummary> {
+  const threads = listProjectThreads(projectId)
+  const activeSummary = await summarizeThreads(projectId, threads)
+  const archivedUsage = getArchivedUsage(projectId)
+  const archivedSummary = archivedUsage.summary
+  const totals = archivedSummary ? combineTotals(activeSummary, archivedSummary) : activeSummary
+
+  return {
+    projectId,
+    sessionCount: activeSummary.sessionCount + (archivedSummary?.sessionCount ?? 0),
+    sessionsWithUsageCount:
+      activeSummary.sessionsWithUsageCount + (archivedSummary?.sessionsWithUsageCount ?? 0),
+    ...totals,
+    archivedUsageRefreshing: archivedUsage.refreshing,
+    topSessions: getTopSessions([
+      ...activeSummary.topSessions,
+      ...(archivedSummary?.topSessions ?? []),
+    ]),
+  }
+}

--- a/desktop/thread-state-db.ts
+++ b/desktop/thread-state-db.ts
@@ -7,6 +7,7 @@ export {
   hasInboxItem,
   hasProject,
   hasRunningProjectThread,
+  listArchivedProjectThreads,
   listArchivedThreads,
   listInboxThreads,
   listProjectSessionPaths,

--- a/desktop/thread-state-db/queries.ts
+++ b/desktop/thread-state-db/queries.ts
@@ -226,6 +226,43 @@ export function listProjectThreads(
     )
 }
 
+export function listArchivedProjectThreads(
+  projectId: string,
+  options: { chat?: boolean | undefined } = {},
+): Thread[] {
+  const db = getThreadStateDatabase()
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          threads.id AS id,
+          threads.title AS title,
+          threads.session_path AS sessionPath,
+          COALESCE(inbox_items.last_assistant_preview, threads.last_assistant_preview) AS summary,
+          threads.running AS running,
+          COALESCE(inbox_items.unread, 0) AS unread,
+          threads.pinned AS pinned,
+          threads.last_modified_ms AS lastModifiedMs
+        FROM threads
+        LEFT JOIN inbox_items ON inbox_items.session_path = threads.session_path
+        WHERE threads.cwd = ? AND threads.archived = 1
+        ORDER BY threads.last_modified_ms DESC, threads.title COLLATE NOCASE ASC
+      `,
+    )
+    .all(projectId) as ThreadRow[]
+
+  return rows
+    .filter((row) => matchesThreadScope(row.sessionPath, options))
+    .map((row) =>
+      mapThreadRow({
+        ...row,
+        running: getEffectiveThreadRunningState(row.running, getLiveThread(row.sessionPath))
+          ? 1
+          : 0,
+      }),
+    )
+}
+
 export function listInboxThreads(): InboxThread[] {
   const db = getThreadStateDatabase()
   const rows = db

--- a/scripts/dev-web-bridge-node.ts
+++ b/scripts/dev-web-bridge-node.ts
@@ -137,6 +137,7 @@ const handlers: DesktopRequestHandlerMap = {
   clearClipboardImages: () => ({ clearedCount: 0, clearFailedCount: 0 }),
   getShellState: () => piThreads.loadShellState(getDesktopWorkingDirectory()),
   getProjectGitState: ({ projectId }) => piThreads.loadProjectGitState(projectId),
+  getProjectUsageSummary: ({ projectId }) => piThreads.loadProjectUsageSummary(projectId),
   getProjectDiff: ({ projectId, baseline }) =>
     piThreads.loadProjectDiff(projectId, baseline ?? null),
   getProjectDiffStats: ({ projectId, baseline }) =>

--- a/shared/desktop-contracts.ts
+++ b/shared/desktop-contracts.ts
@@ -97,6 +97,8 @@ export type {
   Message,
   Project,
   ProjectImportCandidate,
+  ProjectUsageSessionSummary,
+  ProjectUsageSummary,
   ProseMessage,
   SummaryThreadMessage,
   SystemThreadMessage,

--- a/shared/desktop-ipc.ts
+++ b/shared/desktop-ipc.ts
@@ -37,6 +37,7 @@ import type {
   ProjectDiffResult,
   ProjectDiffStatsResult,
   ProjectGitState,
+  ProjectUsageSummary,
   ReactArtifactCompileResult,
   ShellState,
   SkillCreatorSessionState,
@@ -67,6 +68,7 @@ export type DesktopRequestMap = {
   }
   getShellState: { params: Record<string, never>; response: ShellState }
   getProjectGitState: { params: { projectId: string }; response: ProjectGitState | null }
+  getProjectUsageSummary: { params: { projectId: string }; response: ProjectUsageSummary }
   getProjectDiff: {
     params: { projectId: string; baseline?: ProjectDiffBaseline | null }
     response: ProjectDiffResult | null

--- a/shared/desktop-thread-contracts.ts
+++ b/shared/desktop-thread-contracts.ts
@@ -43,6 +43,35 @@ export type Project = {
   repoOriginChecked?: boolean | undefined
 }
 
+export type ProjectUsageSessionSummary = {
+  threadId: string
+  title: string
+  sessionPath: string
+  lastModifiedMs?: number | undefined
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  totalTokens: number
+  costTotal: number
+  assistantTurnCount: number
+}
+
+export type ProjectUsageSummary = {
+  projectId: string
+  sessionCount: number
+  sessionsWithUsageCount: number
+  assistantTurnCount: number
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  totalTokens: number
+  costTotal: number
+  archivedUsageRefreshing?: boolean | undefined
+  topSessions: ProjectUsageSessionSummary[]
+}
+
 export type ProjectImportCandidate = {
   projectId: string
   name: string

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -82,9 +82,21 @@ function clearSelectedThreadIfIncluded(ctx: PostEffectsContext, threadIds: strin
   })
 }
 
+async function invalidateProjectUsage(ctx: PostEffectsContext, projectIds: string[]) {
+  const uniqueProjectIds = [...new Set(projectIds.filter((projectId) => projectId.length > 0))]
+  await Promise.all(
+    uniqueProjectIds.map((projectId) =>
+      ctx.queryClient.invalidateQueries({
+        queryKey: desktopQueryKeys.projectUsageSummary(projectId),
+      }),
+    ),
+  )
+}
+
 async function handleArchivedThreadEffects(ctx: PostEffectsContext) {
   const projectId = getPayloadProjectId(ctx.contextualPayload)
   if (projectId) await ctx.loadProjectThreads(projectId)
+  if (projectId) await invalidateProjectUsage(ctx, [projectId])
   if (ctx.action === 'thread.archive' || ctx.action === 'thread.archive-many') {
     await refreshArchivedThreadsIfOpen({
       archivedThreadsVisible: ctx.workspaceState.activeView === 'archived',
@@ -108,9 +120,11 @@ async function refreshMutatedThreadProjects(ctx: PostEffectsContext) {
     await ctx.refreshShellState()
     const projectIds = [...new Set(getPayloadProjectIds(ctx.contextualPayload))]
     if (projectIds.length > 0) await Promise.all(projectIds.map((id) => ctx.loadProjectThreads(id)))
+    await invalidateProjectUsage(ctx, projectIds)
     return
   }
   if (projectId) await ctx.loadProjectThreads(projectId)
+  if (projectId) await invalidateProjectUsage(ctx, [projectId])
 }
 
 function getDeletedThreadIds(ctx: PostEffectsContext) {
@@ -147,6 +161,7 @@ async function refreshArchivedIfVisible(ctx: PostEffectsContext) {
 async function handleProjectArchiveThreadsEffects(ctx: PostEffectsContext) {
   const projectId = getPayloadProjectId(ctx.contextualPayload)
   if (projectId) await ctx.loadProjectThreads(projectId)
+  if (projectId) await invalidateProjectUsage(ctx, [projectId])
   await ctx.refreshShellState()
   await refreshArchivedIfVisible(ctx)
   if (ctx.contextualPayload.projectId === ctx.workspaceState.selectedProjectId)

--- a/src/app/app-shell/useDesktopEventSync.ts
+++ b/src/app/app-shell/useDesktopEventSync.ts
@@ -240,6 +240,9 @@ function refreshThreadEndState(input: {
     projectId: input.event.projectId,
     queryClient: input.runtime.queryClient,
   })
+  void input.runtime.queryClient.invalidateQueries({
+    queryKey: desktopQueryKeys.projectUsageSummary(input.event.projectId),
+  })
   if (input.event.projectId === input.latestComposerProjectId) {
     void input.runtime
       .loadProjectGitState(input.event.projectId)

--- a/src/app/components/sidebar/project-tree.tsx
+++ b/src/app/components/sidebar/project-tree.tsx
@@ -17,7 +17,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { type ReactNode, useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useRef, useState } from 'react'
 import type { DesktopActionInvoker } from '../../desktop/types'
 import type { Project, View } from '../../types'
 import { ProjectActionMenu } from './project-action-menu'
@@ -108,6 +108,7 @@ export function ProjectTree({
   const [draggingProjectId, setDraggingProjectId] = useState<string | null>(null)
   const [expandedOldProjectIds, setExpandedOldProjectIds] = useState<Record<string, boolean>>({})
   const [renameDraft, setRenameDraft] = useState('')
+  const suppressProjectClickAfterDragRef = useRef(false)
   const { containerRef } = useProjectMenuDismiss(openProjectMenuId !== null, () =>
     setOpenProjectMenuId(null),
   )
@@ -122,11 +123,19 @@ export function ProjectTree({
 
   const handleDragStart = (event: DragStartEvent) => {
     setDraggingProjectId(typeof event.active.id === 'string' ? event.active.id : null)
+    suppressProjectClickAfterDragRef.current = true
     setOpenProjectMenuId(null)
+  }
+
+  const clearDragClickSuppression = () => {
+    window.setTimeout(() => {
+      suppressProjectClickAfterDragRef.current = false
+    }, 250)
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
     setDraggingProjectId(null)
+    clearDragClickSuppression()
 
     const { active, over } = event
     if (!over || active.id === over.id) {
@@ -177,7 +186,10 @@ export function ProjectTree({
         collisionDetection={closestCorners}
         modifiers={[restrictToVerticalAxis, restrictToParentElement]}
         onDragStart={handleDragStart}
-        onDragCancel={() => setDraggingProjectId(null)}
+        onDragCancel={() => {
+          setDraggingProjectId(null)
+          clearDragClickSuppression()
+        }}
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={projectIds} strategy={verticalListSortingStrategy}>
@@ -216,6 +228,10 @@ export function ProjectTree({
                         onChangeRenameDraft={setRenameDraft}
                         onEdit={() => handleStartEdit(project.id, project.name)}
                         onSelect={() => {
+                          if (suppressProjectClickAfterDragRef.current) {
+                            return
+                          }
+
                           onProjectSelect(project.id)
                           if (activeView !== 'extensions' && activeView !== 'skills') {
                             void onAction('project.select', { projectId: project.id })
@@ -224,10 +240,13 @@ export function ProjectTree({
                         }}
                         onSubmitEdit={() => handleSubmitEdit(project.id)}
                         onCreateSession={() => {
-                          if (activeView !== 'chat') {
+                          if (activeView === 'chat') {
+                            void onAction('thread.new', { projectId: project.id })
+                          } else if (activeView === 'extensions' || activeView === 'skills') {
                             onProjectPrimeSelection(project.id)
+                          } else {
+                            onProjectSelect(project.id)
                           }
-                          void onAction('thread.new', { projectId: project.id })
                           setOpenProjectMenuId(null)
                         }}
                         onToggleActions={() =>

--- a/src/app/components/sidebar/project-tree/project-row.tsx
+++ b/src/app/components/sidebar/project-tree/project-row.tsx
@@ -213,6 +213,10 @@ export function ProjectRow({
   }, [])
 
   const handleRowClick = () => {
+    if (isDragging) {
+      return
+    }
+
     clearClickTimeout(clickTimeoutRef)
     clickTimeoutRef.current = window.setTimeout(() => {
       onSelect()

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -66,6 +66,8 @@ export type {
   ProjectDiffStatsResult,
   ProjectGitState,
   ProjectImportCandidate,
+  ProjectUsageSessionSummary,
+  ProjectUsageSummary,
   ReactArtifactCompileResult,
   ShellState,
   SkillCreatorSessionMessage,

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -115,6 +115,8 @@ export function installDevWebDesktopBridge() {
     clearClipboardImages: () => invokeRequest('clearClipboardImages', {}),
     getShellState: () => invokeRequest('getShellState', {}),
     getProjectGitState: (projectId: string) => invokeRequest('getProjectGitState', { projectId }),
+    getProjectUsageSummary: (projectId: string) =>
+      invokeRequest('getProjectUsageSummary', { projectId }),
     getProjectDiff: (projectId: string, baseline = null) =>
       invokeRequest('getProjectDiff', { projectId, baseline }),
     getProjectDiffStats: (projectId: string, baseline = null) =>

--- a/src/app/features/code/code-workspace-main-view.tsx
+++ b/src/app/features/code/code-workspace-main-view.tsx
@@ -222,7 +222,9 @@ export function CodeWorkspaceMainView({
         projectName={currentProjectName}
         projects={projects}
         selectedProjectId={selectedProjectId}
+        composerOverlayHeight={composerOverlayHeight}
         onAction={onAction}
+        onOpenThread={onOpenThread}
         onSelectProject={onSelectProject}
       />
     </div>

--- a/src/app/features/code/code-workspace-view.tsx
+++ b/src/app/features/code/code-workspace-view.tsx
@@ -40,7 +40,7 @@ type CodeWorkspaceViewProps = {
 }
 
 const TERMINAL_DRAWER_OFFSET = 'min(28rem, calc(100% - 2.5rem))'
-const NEW_THREAD_COMPOSER_TOP = '60%'
+const EMPTY_COMPOSER_TOP = '60%'
 const FALLBACK_APP_SETTINGS = {
   chatModel: null,
   chatThinkingLevel: null,
@@ -514,8 +514,10 @@ function CodeWorkspaceThreadFooter(props: CodeWorkspaceContentProps) {
       ref={footerRef}
       className={cn(
         'motion-terminal-drawer-offset pointer-events-none absolute inset-x-0 z-10 px-5 pb-4',
-        centerThreadFooter ? 'transition-[top,transform] duration-300 ease-out' : 'bottom-0',
-        centerThreadFooter && '-translate-y-1/2',
+        centerThreadFooter || state.activeView === 'code'
+          ? 'transition-[top,transform] duration-300 ease-out'
+          : 'bottom-0',
+        (centerThreadFooter || state.activeView === 'code') && '-translate-y-1/2',
         showThreadFooter && !centerThreadFooter && 'translate-y-0',
       )}
       style={threadFooterStyle}
@@ -598,13 +600,54 @@ function shouldShowDesktopTerminalDrawer(
   return activeView === 'thread' && terminalDrawerVisible && !terminalDrawerOverlay
 }
 
-function getCodeWorkspaceFlags(activeView: AppShellController['state']['activeView']) {
+function getFloatingFooterStyle(input: {
+  centerDashboardFooter: boolean
+  centerThreadFooter: boolean
+  showThreadFooter: boolean
+  terminalDrawerInsetStyle: { right: string } | undefined
+}) {
+  if (input.centerDashboardFooter) {
+    return { ...input.terminalDrawerInsetStyle, top: EMPTY_COMPOSER_TOP }
+  }
+
+  if (!input.showThreadFooter) {
+    return input.terminalDrawerInsetStyle
+  }
+
+  return input.centerThreadFooter
+    ? { ...input.terminalDrawerInsetStyle, top: EMPTY_COMPOSER_TOP }
+    : { ...input.terminalDrawerInsetStyle, bottom: 0 }
+}
+
+function getFloatingFooterLayoutState(input: {
+  activeView: AppShellController['state']['activeView']
+  activeThreadData: Message[] | undefined
+  activeThreadLoading: boolean
+  showThreadFooter: boolean
+}) {
+  const hasThreadConversation = input.showThreadFooter && (input.activeThreadData?.length ?? 0) > 0
+  const hasThreadConversationLayout = hasThreadConversation || input.activeThreadLoading
+  const centerDashboardFooter = input.activeView === 'code'
+  const centerThreadFooter = input.showThreadFooter && !hasThreadConversationLayout
   return {
-    showWorkspaceFooter: activeView === 'thread' || activeView === 'gitops',
-    showThreadFooter: activeView === 'thread',
-    showCodeSidebarFooter: activeView === 'code',
-    showUtilitySidebarButton: isCodeUtilityView(activeView),
-    showDiffInMainView: activeView === 'gitops',
+    centerDashboardFooter,
+    centerThreadFooter,
+    floatingWorkspaceFooter: centerThreadFooter || centerDashboardFooter,
+  }
+}
+
+function getCodeWorkspaceFlags(input: {
+  activeView: AppShellController['state']['activeView']
+  selectedProjectId: string
+}) {
+  const showCodeDashboardFooter = input.activeView === 'code' && Boolean(input.selectedProjectId)
+  return {
+    showWorkspaceFooter:
+      input.activeView === 'thread' || input.activeView === 'gitops' || showCodeDashboardFooter,
+    showThreadFooter: input.activeView === 'thread',
+    showCodeSidebarFooter: false,
+    showUtilitySidebarButton: isCodeUtilityView(input.activeView),
+    showDiffInMainView: input.activeView === 'gitops',
   }
 }
 
@@ -654,7 +697,10 @@ export function CodeWorkspaceView({
     showCodeSidebarFooter,
     showUtilitySidebarButton,
     showDiffInMainView,
-  } = getCodeWorkspaceFlags(state.activeView)
+  } = getCodeWorkspaceFlags({
+    activeView: state.activeView,
+    selectedProjectId: state.selectedProjectId,
+  })
   const showDesktopTerminalDrawer = shouldShowDesktopTerminalDrawer(
     state.activeView,
     terminalDrawerVisible,
@@ -680,10 +726,14 @@ export function CodeWorkspaceView({
     footerRef,
     visible: showWorkspaceFooter,
   })
-  const hasThreadConversation = showThreadFooter && (activeThreadData?.messages.length ?? 0) > 0
-  const hasThreadConversationLayout = hasThreadConversation || controller.activeThreadLoading
-  const centerThreadFooter = showThreadFooter && !hasThreadConversationLayout
-  const footerInset = showWorkspaceFooter && !centerThreadFooter ? footerHeight : 0
+  const { centerDashboardFooter, centerThreadFooter, floatingWorkspaceFooter } =
+    getFloatingFooterLayoutState({
+      activeThreadData: activeThreadData?.messages,
+      activeThreadLoading: controller.activeThreadLoading,
+      activeView: state.activeView,
+      showThreadFooter,
+    })
+  const footerInset = showWorkspaceFooter && !floatingWorkspaceFooter ? footerHeight : 0
   const {
     diffCommentCount,
     diffCommentError,
@@ -715,11 +765,12 @@ export function CodeWorkspaceView({
   const terminalDrawerInsetStyle = showDesktopTerminalDrawer
     ? { right: TERMINAL_DRAWER_OFFSET }
     : undefined
-  const threadFooterStyle = showThreadFooter
-    ? centerThreadFooter
-      ? { ...terminalDrawerInsetStyle, top: NEW_THREAD_COMPOSER_TOP }
-      : { ...terminalDrawerInsetStyle, bottom: 0 }
-    : terminalDrawerInsetStyle
+  const threadFooterStyle = getFloatingFooterStyle({
+    centerDashboardFooter,
+    centerThreadFooter,
+    showThreadFooter,
+    terminalDrawerInsetStyle,
+  })
   const threadTimelineLoading = state.activeView === 'thread' && controller.activeThreadLoading
 
   return (

--- a/src/app/query/desktop-query.ts
+++ b/src/app/query/desktop-query.ts
@@ -27,6 +27,7 @@ import type {
   ProjectDiffResult,
   ProjectDiffStatsResult,
   ProjectGitState,
+  ProjectUsageSummary,
   ShellState,
   SkillCreatorSessionState,
   Thread,
@@ -58,6 +59,8 @@ export const desktopQueryKeys = {
       request.chatGroupId ?? null,
     ] as const,
   projectGitState: (projectId: string) => ['desktop', 'projectGitState', projectId] as const,
+  projectUsageSummary: (projectId: string) =>
+    ['desktop', 'projectUsageSummary', projectId] as const,
   projectDiffPrefix: (projectId: string) => ['desktop', 'projectDiff', projectId] as const,
   projectDiff: (projectId: string, baseline: ProjectDiffBaseline | null = null) =>
     ['desktop', 'projectDiff', projectId, baseline?.kind ?? 'head', baseline ?? null] as const,
@@ -176,6 +179,12 @@ export async function getComposerSkillsQuery(request: ComposerStateRequest = {})
 
 export async function getProjectGitStateQuery(projectId: string): Promise<ProjectGitState | null> {
   return (await window.piDesktop?.getProjectGitState?.(projectId)) ?? null
+}
+
+export async function getProjectUsageSummaryQuery(
+  projectId: string,
+): Promise<ProjectUsageSummary | null> {
+  return (await window.piDesktop?.getProjectUsageSummary?.(projectId)) ?? null
 }
 
 export async function getProjectDiffQuery(

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -7,6 +7,7 @@ export type UtilityView = Extract<View, 'settings' | 'extensions' | 'skills'>
 type UtilityViewReturnState = {
   activeView: View
   selectedProjectId: string
+  hasSelectedProject: boolean
   selectedInboxSessionPath: string | null
   selectedThreadId: string | null
   selectedSessionPath: string | null
@@ -20,6 +21,7 @@ type UtilityViewReturnState = {
 export type WorkspaceState = {
   activeView: View
   selectedProjectId: string
+  hasSelectedProject: boolean
   selectedInboxSessionPath: string | null
   selectedThreadId: string | null
   selectedSessionPath: string | null
@@ -76,6 +78,7 @@ function createUtilityViewReturnState(state: WorkspaceState): UtilityViewReturnS
   return {
     activeView: state.activeView,
     selectedProjectId: state.selectedProjectId,
+    hasSelectedProject: state.hasSelectedProject,
     selectedInboxSessionPath: state.selectedInboxSessionPath,
     selectedThreadId: state.selectedThreadId,
     selectedSessionPath: state.selectedSessionPath,
@@ -175,11 +178,10 @@ function getTerminalStateForNextView(state: WorkspaceState, nextView: View) {
 // The collapsed map is derived once from project metadata so the tree interaction
 // stays deterministic even before we add persisted desktop state.
 export function createInitialWorkspaceState(projects: Project[]): WorkspaceState {
-  const [firstProject] = projects
-
   return {
     activeView: 'code',
-    selectedProjectId: firstProject?.id ?? '',
+    selectedProjectId: '',
+    hasSelectedProject: false,
     selectedInboxSessionPath: null,
     selectedThreadId: null,
     selectedSessionPath: null,
@@ -249,7 +251,9 @@ function syncProjectsState(
   )
   const selectedProjectId = hasSelectedProject
     ? state.selectedProjectId
-    : action.projects[0]?.id || ''
+    : state.hasSelectedProject
+      ? action.projects[0]?.id || ''
+      : ''
   const selectedThreadProject = findProjectContainingThread(action.projects, state)
   const shouldPreserveSelectedThread =
     (state.activeView === 'chat' || state.activeView === 'thread') && Boolean(selectedThreadProject)
@@ -276,6 +280,8 @@ function syncProjectsState(
       : shouldPreserveProjectSelection
         ? state.selectedProjectId
         : selectedProjectId,
+    hasSelectedProject:
+      state.hasSelectedProject || Boolean(selectedThreadProject) || shouldPreserveProjectSelection,
     selectedThreadId: getPreservedThreadValue(
       state,
       shouldPreserveProjectSelection,
@@ -350,6 +356,7 @@ function openThreadState(
     ...state,
     activeView: action.view ?? (state.activeView === 'chat' ? 'chat' : 'thread'),
     selectedProjectId: action.projectId,
+    hasSelectedProject: true,
     selectedThreadId: action.threadId,
     selectedSessionPath: action.sessionPath,
     terminalVisible: getTerminalVisibilityForSession(
@@ -466,6 +473,7 @@ const workspaceActionHandlers = {
     ...getTerminalStateForNextView(state, 'code'),
     activeView: 'code',
     selectedProjectId: action.projectId,
+    hasSelectedProject: true,
     selectedThreadId: null,
     selectedSessionPath: null,
     terminalVisible: false,
@@ -477,7 +485,7 @@ const workspaceActionHandlers = {
   'set-selected-project': (
     state: WorkspaceState,
     action: Extract<WorkspaceAction, { type: 'set-selected-project' }>,
-  ) => ({ ...state, selectedProjectId: action.projectId }),
+  ) => ({ ...state, selectedProjectId: action.projectId, hasSelectedProject: true }),
   'open-thread': openThreadState,
   'open-gitops': openGitOpsState,
   'close-gitops': closeGitOpsState,
@@ -535,7 +543,8 @@ export function workspaceReducer(state: WorkspaceState, action: WorkspaceAction)
 }
 
 export function selectProject(projects: Project[], selectedProjectId: string): Project | undefined {
-  return projects.find((project) => project.id === selectedProjectId) ?? projects[0]
+  if (!selectedProjectId) return undefined
+  return projects.find((project) => project.id === selectedProjectId)
 }
 
 export function selectThread(

--- a/src/app/views/landing-view.tsx
+++ b/src/app/views/landing-view.tsx
@@ -1,10 +1,25 @@
-import { Download, RotateCw } from 'lucide-react'
-import { type KeyboardEvent, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { CircleDot, Download, ExternalLink, GitBranch, Github, RotateCw } from 'lucide-react'
+import { type KeyboardEvent, useEffect, useState } from 'react'
+import { parseGitHubRepositoryUrl } from '../../../shared/github-repository-url'
 import { MarkdownContent } from '../components/common/markdown-content'
-import type { AppSettings, DesktopActionInvoker } from '../desktop/types'
+import { SkeletonBlock } from '../components/common/skeleton'
+import type {
+  AppSettings,
+  DesktopActionInvoker,
+  ProjectGitState,
+  ProjectUsageSessionSummary,
+  ProjectUsageSummary,
+} from '../desktop/types'
 import { useAppUpdateFlow } from '../hooks/useAppUpdateFlow'
+import {
+  desktopQueryKeys,
+  getProjectGitStateQuery,
+  getProjectUsageSummaryQuery,
+  openExternalQuery,
+} from '../query/desktop-query'
 import type { Project } from '../types'
-import { compactRoundIconButtonClass, toolbarButtonClass } from '../ui/classes'
+import { compactRoundIconButtonClass, ghostButtonClass, toolbarButtonClass } from '../ui/classes'
 import { cn } from '../utils/cn'
 import { getLandingOverviewContent } from './landing-overview-content'
 
@@ -14,9 +29,22 @@ type LandingViewProps = {
   projects: Project[]
   selectedProjectId: string
   className?: string
+  composerOverlayHeight: number
   onAction: DesktopActionInvoker
   onSelectProject: (projectId: string) => void
+  onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void
 }
+
+const tokenFormatter = new Intl.NumberFormat('en', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+const numberFormatter = new Intl.NumberFormat('en')
+const costFormatter = new Intl.NumberFormat('en', {
+  currency: 'USD',
+  maximumFractionDigits: 4,
+  style: 'currency',
+})
 
 function PixelHLogo() {
   const pixelRows = [
@@ -121,8 +149,306 @@ function LandingMockUpdateCard() {
   )
 }
 
-export function LandingView({ className }: LandingViewProps) {
+function formatTokens(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—'
+  return tokenFormatter.format(value)
+}
+
+function formatExactNumber(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—'
+  return numberFormatter.format(value)
+}
+
+function formatCost(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—'
+  return costFormatter.format(value)
+}
+
+function formatGitSummary(gitState: ProjectGitState | null | undefined) {
+  if (!gitState) return 'Checking repository…'
+  if (!gitState.isGitRepo) return 'Not a Git repository'
+  return null
+}
+
+function formatAverageCost(total: number | null | undefined, count: number) {
+  if (total === null || total === undefined || count <= 0) return '—'
+  return formatCost(total / count)
+}
+
+function getGitHubRepositoryLink(project: Project, gitState: ProjectGitState | null | undefined) {
+  const url = gitState === undefined ? (project.repoOriginUrl ?? null) : gitState?.originUrl
+  return url ? parseGitHubRepositoryUrl(url) : null
+}
+
+function TopSessionsSkeleton() {
+  return (
+    <div className="grid max-h-[9.75rem] w-full gap-1.5 overflow-hidden pr-8 [@media(max-height:760px)]:max-h-[3.25rem]">
+      {['top-session-a', 'top-session-b', 'top-session-c'].map((rowId) => (
+        <div
+          key={rowId}
+          className="grid min-h-11 w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 rounded-lg border border-[rgba(169,178,215,0.08)] bg-[rgba(255,255,255,0.02)] px-3 py-2"
+        >
+          <SkeletonBlock className="h-3.5 w-[min(18rem,72%)] rounded-md" />
+          <SkeletonBlock className="h-3 w-24 rounded-md opacity-60" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ProjectMetric({
+  detail,
+  label,
+  loading,
+  value,
+}: {
+  detail: string
+  label: string
+  loading: boolean
+  value: string
+}) {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <div className="text-[11px] font-medium tracking-[0.08em] text-[color:var(--muted)] uppercase">
+        {label}
+      </div>
+      {loading ? (
+        <>
+          <SkeletonBlock className="h-[17px] w-20 rounded-md" />
+          <SkeletonBlock className="h-3 w-[min(11rem,80%)] rounded-md opacity-60" />
+        </>
+      ) : (
+        <>
+          <div className="font-mono text-[17px] leading-none font-medium text-[color:var(--text)] tabular-nums">
+            {value}
+          </div>
+          <div className="truncate text-[12px] text-[color:var(--muted-2)]">{detail}</div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function TopSessionRow({
+  projectId,
+  session,
+  onOpenThread,
+}: {
+  projectId: string
+  session: ProjectUsageSessionSummary
+  onOpenThread: LandingViewProps['onOpenThread']
+}) {
+  return (
+    <button
+      type="button"
+      className="grid min-h-11 w-full min-w-0 grid-cols-[minmax(0,1fr)] items-center gap-1 rounded-lg border border-[rgba(169,178,215,0.08)] bg-[rgba(255,255,255,0.02)] px-3 py-2 text-left text-[12px] shadow-[var(--shadow)] transition-colors hover:bg-[rgba(255,255,255,0.04)] active:scale-[0.99] min-[560px]:grid-cols-[minmax(0,1fr)_auto] min-[560px]:gap-4"
+      onClick={() => onOpenThread(projectId, session.threadId, session.sessionPath)}
+    >
+      <span className="min-w-0 truncate text-[13px] font-medium text-[color:var(--text)]">
+        {session.title}
+      </span>
+      <span className="min-w-0 truncate font-mono text-[color:var(--muted)] tabular-nums max-[559px]:justify-self-start">
+        {formatCost(session.costTotal)} · {formatTokens(session.totalTokens)}
+      </span>
+    </button>
+  )
+}
+
+function TopSessionsSection({
+  loading,
+  projectId,
+  sessions,
+  onOpenThread,
+}: {
+  loading: boolean
+  projectId: string
+  sessions: ProjectUsageSessionSummary[]
+  onOpenThread: LandingViewProps['onOpenThread']
+}) {
+  return (
+    <section className="col-span-2 col-start-2 grid gap-2 [@media(max-height:560px)]:hidden">
+      <h2 className="m-0 w-[calc(100%-2.5rem)] px-1 text-[13px] font-medium text-[color:var(--text)]">
+        Top sessions by cost
+      </h2>
+      {loading ? (
+        <TopSessionsSkeleton />
+      ) : sessions.length > 0 ? (
+        <div className="grid max-h-[9.75rem] w-full gap-1.5 overflow-y-auto overflow-x-hidden pr-8 [scrollbar-gutter:stable] [@media(max-height:760px)]:max-h-[3.25rem]">
+          {sessions.map((session) => (
+            <TopSessionRow
+              key={session.sessionPath}
+              projectId={projectId}
+              session={session}
+              onOpenThread={onOpenThread}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-dashed border-[rgba(169,178,215,0.12)] px-3 py-4 text-[12px] text-[color:var(--muted)]">
+          No usage recorded yet. Start a session below and Pi usage will appear here after the first
+          assistant response.
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ProjectOverview({
+  composerOverlayHeight,
+  project,
+  gitState,
+  usageLoading,
+  usageSummary,
+  onOpenThread,
+}: {
+  composerOverlayHeight: number
+  project: Project
+  gitState: ProjectGitState | null | undefined
+  usageLoading: boolean
+  usageSummary: ProjectUsageSummary | null | undefined
+  onOpenThread: LandingViewProps['onOpenThread']
+}) {
+  const githubLink = getGitHubRepositoryLink(project, gitState)
+  const sessionCount = usageSummary?.sessionCount ?? project.threadCount ?? project.threads.length
+  const branchLabel = gitState?.isGitRepo ? (gitState.branch ?? 'Detached HEAD') : 'No branch'
+  const gitSummary = formatGitSummary(gitState)
+  const assistantTurnCount = usageSummary?.assistantTurnCount ?? 0
+  const measuredComposerHeight = Math.max(composerOverlayHeight, 132)
+  const overviewHeight = `calc(60% - ${measuredComposerHeight / 2}px - 0.5rem)`
+
+  return (
+    <div
+      className="mx-auto grid min-h-0 w-full max-w-[800px] grid-cols-[2rem_minmax(0,1fr)_2rem] content-end gap-x-2 gap-y-3 overflow-y-auto px-0 text-left [scrollbar-gutter:stable] min-[560px]:gap-y-4 [@media(max-height:660px)]:gap-y-2"
+      style={{ height: overviewHeight }}
+    >
+      <div className="col-start-2 grid w-full gap-1.5 [@media(max-height:660px)]:hidden">
+        <div className="text-[12px] font-medium tracking-[0.12em] text-[color:var(--muted)] uppercase">
+          Project overview
+        </div>
+        <h1 className="m-0 text-[24px] leading-tight font-medium text-[color:var(--text)] text-balance">
+          {project.name}
+        </h1>
+      </div>
+
+      <div className="col-start-2 grid w-full grid-cols-[repeat(auto-fit,minmax(118px,1fr))] gap-3 border-y border-[rgba(169,178,215,0.08)] py-3 min-[560px]:gap-4 [@media(max-height:660px)]:py-2">
+        <ProjectMetric
+          label="Sessions"
+          loading={usageLoading}
+          value={formatExactNumber(sessionCount)}
+          detail={`${formatExactNumber(assistantTurnCount)} turns`}
+        />
+        <ProjectMetric
+          label="Spend"
+          loading={usageLoading}
+          value={formatCost(usageSummary?.costTotal)}
+          detail={`${formatAverageCost(usageSummary?.costTotal, sessionCount)}/session`}
+        />
+        <ProjectMetric
+          label="Tokens"
+          loading={usageLoading}
+          value={formatTokens(usageSummary?.totalTokens)}
+          detail={`${formatTokens(usageSummary?.input)} in · ${formatTokens(usageSummary?.output)} out · ${formatTokens(usageSummary?.cacheRead)} read · ${formatTokens(usageSummary?.cacheWrite)} write`}
+        />
+      </div>
+
+      <section className="col-start-2 grid w-full gap-2">
+        <div className="flex min-h-10 flex-wrap items-center justify-between gap-2 rounded-xl border border-[rgba(169,178,215,0.08)] bg-[rgba(255,255,255,0.02)] px-3">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            {githubLink ? (
+              <Github size={14} className="text-[color:var(--muted)]" aria-hidden="true" />
+            ) : (
+              <GitBranch size={14} className="text-[color:var(--muted)]" aria-hidden="true" />
+            )}
+            <span className="min-w-0 truncate text-[13px] font-medium text-[color:var(--text)]">
+              {githubLink ? `${githubLink.owner}/${githubLink.repo}` : (gitSummary ?? branchLabel)}
+            </span>
+            {githubLink ? (
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)] active:scale-[0.96]"
+                onClick={() => void openExternalQuery(githubLink.canonicalUrl)}
+                aria-label={`Open ${githubLink.owner}/${githubLink.repo} on GitHub`}
+              >
+                <ExternalLink size={12} aria-hidden="true" />
+              </button>
+            ) : null}
+            {gitState?.isGitRepo ? (
+              <span className="max-w-full truncate rounded-full bg-[rgba(169,178,215,0.08)] px-2 py-0.5 text-[11px] text-[color:var(--muted)] max-[720px]:hidden">
+                {branchLabel}
+              </span>
+            ) : null}
+          </div>
+          {githubLink ? (
+            <div className="flex min-w-0 shrink-0 items-center gap-1 max-[520px]:w-full max-[520px]:justify-end">
+              <button
+                type="button"
+                className={cn(
+                  ghostButtonClass,
+                  'inline-flex h-7 items-center gap-1.5 px-2 active:scale-[0.96]',
+                )}
+                onClick={() => void openExternalQuery(`${githubLink.canonicalUrl}/issues`)}
+              >
+                <CircleDot size={12} aria-hidden="true" /> Issues
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  ghostButtonClass,
+                  'inline-flex h-7 items-center gap-1.5 px-2 active:scale-[0.96]',
+                )}
+                onClick={() => void openExternalQuery(`${githubLink.canonicalUrl}/pulls`)}
+              >
+                <CircleDot size={12} aria-hidden="true" /> PRs
+              </button>
+            </div>
+          ) : null}
+        </div>
+        {gitSummary ? (
+          <div className="px-1 text-[12px] text-[color:var(--muted)]">{gitSummary}</div>
+        ) : null}
+      </section>
+
+      <TopSessionsSection
+        loading={usageLoading}
+        projectId={project.id}
+        sessions={usageSummary?.topSessions ?? []}
+        onOpenThread={onOpenThread}
+      />
+    </div>
+  )
+}
+
+export function LandingView({
+  className,
+  projects,
+  selectedProjectId,
+  composerOverlayHeight,
+  onOpenThread,
+}: LandingViewProps) {
   const content = getLandingOverviewContent()
+  const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null
+  const projectUsageQuery = useQuery({
+    queryKey: selectedProject
+      ? desktopQueryKeys.projectUsageSummary(selectedProject.id)
+      : ['desktop', 'projectUsageSummary', null],
+    queryFn: () => getProjectUsageSummaryQuery(selectedProject?.id ?? ''),
+    enabled: Boolean(selectedProject),
+  })
+  const projectGitQuery = useQuery({
+    queryKey: selectedProject
+      ? desktopQueryKeys.projectGitState(selectedProject.id)
+      : ['desktop', 'projectGitState', null],
+    queryFn: () => getProjectGitStateQuery(selectedProject?.id ?? ''),
+    enabled: Boolean(selectedProject),
+  })
+
+  useEffect(() => {
+    if (!(selectedProject && projectUsageQuery.data?.archivedUsageRefreshing)) return
+    const timeout = window.setTimeout(() => {
+      void projectUsageQuery.refetch()
+    }, 750)
+    return () => window.clearTimeout(timeout)
+  }, [projectUsageQuery.data?.archivedUsageRefreshing, projectUsageQuery.refetch, selectedProject])
   const [activeSectionIndex, setActiveSectionIndex] = useState(0)
   const activeContent = content.sections[activeSectionIndex] ?? content.sections[0]
   const activePanelId = 'landing-overview-panel'
@@ -145,63 +471,75 @@ export function LandingView({ className }: LandingViewProps) {
   return (
     <section
       className={cn(
-        'relative mx-auto flex h-full min-h-0 w-full justify-center overflow-hidden px-6 pt-[clamp(4rem,20vh,14rem)] pb-0',
+        'relative mx-auto flex h-full min-h-0 w-full justify-center overflow-hidden pb-0',
+        selectedProject ? 'px-1 pt-0' : 'px-6 pt-[clamp(4rem,20vh,14rem)]',
         className,
       )}
     >
-      <div className="grid h-full min-h-0 w-full max-w-[760px] grid-rows-[auto_auto_minmax(0,1fr)] justify-items-center gap-3 text-center sm:gap-4">
-        <PixelHLogo />
-        <h1 className="sr-only">{content.title}</h1>
+      {selectedProject ? (
+        <ProjectOverview
+          composerOverlayHeight={composerOverlayHeight}
+          project={selectedProject}
+          gitState={projectGitQuery.data}
+          usageLoading={projectUsageQuery.isFetching}
+          usageSummary={projectUsageQuery.data}
+          onOpenThread={onOpenThread}
+        />
+      ) : (
+        <div className="grid h-full min-h-0 w-full max-w-[760px] grid-rows-[auto_auto_minmax(0,1fr)] justify-items-center gap-3 text-center sm:gap-4">
+          <PixelHLogo />
+          <h1 className="sr-only">{content.title}</h1>
 
-        <LandingMockUpdateCard />
+          <LandingMockUpdateCard />
 
-        <div className="grid min-h-0 w-full max-w-[680px] grid-rows-[auto_minmax(0,1fr)] gap-0">
-          <div
-            className="grid border-b border-[rgba(169,178,215,0.08)]"
-            style={{ gridTemplateColumns: `repeat(${content.sections.length}, minmax(0, 1fr))` }}
-            role="tablist"
-            aria-label={content.title}
-          >
-            {content.sections.map((section, index) => {
-              const selected = activeSectionIndex === index
+          <div className="grid min-h-0 w-full max-w-[680px] grid-rows-[auto_minmax(0,1fr)] gap-0">
+            <div
+              className="grid border-b border-[rgba(169,178,215,0.08)]"
+              style={{ gridTemplateColumns: `repeat(${content.sections.length}, minmax(0, 1fr))` }}
+              role="tablist"
+              aria-label={content.title}
+            >
+              {content.sections.map((section, index) => {
+                const selected = activeSectionIndex === index
 
-              return (
-                <button
-                  key={section.title}
-                  type="button"
-                  id={`landing-section-${index}-tab`}
-                  role="tab"
-                  className={cn(
-                    'border-b px-0 py-3 text-center text-[15px] font-medium transition-colors sm:py-4',
-                    selected
-                      ? 'border-[color:var(--accent)] text-[color:var(--text)]'
-                      : 'border-transparent text-[color:var(--muted)] hover:text-[color:var(--text)]',
-                  )}
-                  onClick={() => setActiveSectionIndex(index)}
-                  onKeyDown={handleTabKeyDown}
-                  aria-selected={selected}
-                  aria-controls={activePanelId}
-                  tabIndex={selected ? 0 : -1}
-                >
-                  {section.title}
-                </button>
-              )
-            })}
-          </div>
+                return (
+                  <button
+                    key={section.title}
+                    type="button"
+                    id={`landing-section-${index}-tab`}
+                    role="tab"
+                    className={cn(
+                      'border-b px-0 py-3 text-center text-[15px] font-medium transition-colors sm:py-4',
+                      selected
+                        ? 'border-[color:var(--accent)] text-[color:var(--text)]'
+                        : 'border-transparent text-[color:var(--muted)] hover:text-[color:var(--text)]',
+                    )}
+                    onClick={() => setActiveSectionIndex(index)}
+                    onKeyDown={handleTabKeyDown}
+                    aria-selected={selected}
+                    aria-controls={activePanelId}
+                    tabIndex={selected ? 0 : -1}
+                  >
+                    {section.title}
+                  </button>
+                )
+              })}
+            </div>
 
-          <div
-            id={activePanelId}
-            className="min-h-0 overflow-y-auto pt-4 pr-2 pb-6 text-left [scrollbar-gutter:stable]"
-            role="tabpanel"
-            aria-labelledby={`landing-section-${activeSectionIndex}-tab`}
-          >
-            <MarkdownContent
-              markdown={activeContent?.markdown ?? ''}
-              className="gap-2 text-[13px]"
-            />
+            <div
+              id={activePanelId}
+              className="min-h-0 overflow-y-auto pt-4 pr-2 pb-6 text-left [scrollbar-gutter:stable]"
+              role="tabpanel"
+              aria-labelledby={`landing-section-${activeSectionIndex}-tab`}
+            >
+              <MarkdownContent
+                markdown={activeContent?.markdown ?? ''}
+                className="gap-2 text-[13px]"
+              />
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </section>
   )
 }

--- a/src/electron/main/ipc/request-handlers/pi-threads.ts
+++ b/src/electron/main/ipc/request-handlers/pi-threads.ts
@@ -6,6 +6,7 @@ type PiThreadsRequestHandlers = Pick<
   DesktopRequestHandlerMap,
   | 'getShellState'
   | 'getProjectGitState'
+  | 'getProjectUsageSummary'
   | 'getProjectDiff'
   | 'getProjectDiffStats'
   | 'captureProjectDiffBaseline'
@@ -38,6 +39,7 @@ export function createPiThreadsHandlers(piThreads: PiThreadsModule): PiThreadsRe
   return {
     getShellState: async () => piThreads.loadShellState(getDesktopWorkingDirectory()),
     getProjectGitState: ({ projectId }) => piThreads.loadProjectGitState(projectId),
+    getProjectUsageSummary: ({ projectId }) => piThreads.loadProjectUsageSummary(projectId),
     getProjectDiff: ({ projectId, baseline }) =>
       piThreads.loadProjectDiff(projectId, baseline ?? null),
     getProjectDiffStats: ({ projectId, baseline }) =>

--- a/src/electron/main/runtime/desktop-runtime-contracts.ts
+++ b/src/electron/main/runtime/desktop-runtime-contracts.ts
@@ -30,6 +30,7 @@ import type {
   ProjectDiffResult,
   ProjectDiffStatsResult,
   ProjectGitState,
+  ProjectUsageSummary,
   ReactArtifactCompileResult,
   ShellState,
   SkillCreatorSessionState,
@@ -88,6 +89,7 @@ export type PiThreadsModule = {
     chat?: boolean | undefined
   }) => Promise<PiPackageMutationResult>
   loadProjectGitState: (projectId: string) => Promise<ProjectGitState | null>
+  loadProjectUsageSummary: (projectId: string) => Promise<ProjectUsageSummary>
   loadProjectDiff: (
     projectId: string,
     baseline?: ProjectDiffBaseline | null,

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -48,6 +48,8 @@ export function createDesktopApi() {
     clearClipboardImages: () => invokeRequest('clearClipboardImages', {}),
     getShellState: () => invokeRequest('getShellState', {}),
     getProjectGitState: (projectId: string) => invokeRequest('getProjectGitState', { projectId }),
+    getProjectUsageSummary: (projectId: string) =>
+      invokeRequest('getProjectUsageSummary', { projectId }),
     getProjectDiff: (projectId: string, baseline = null) =>
       invokeRequest('getProjectDiff', { projectId, baseline }),
     getProjectDiffStats: (projectId: string, baseline = null) =>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -38,6 +38,7 @@ import type {
   ProjectDiffResult,
   ProjectDiffStatsResult,
   ProjectGitState,
+  ProjectUsageSummary,
   ReactArtifactCompileResult,
   ShellState,
   SkillCreatorSessionState,
@@ -66,6 +67,7 @@ declare global {
       clearClipboardImages?: () => Promise<{ clearedCount: number; clearFailedCount: number }>
       getShellState: () => Promise<ShellState>
       getProjectGitState?: (projectId: string) => Promise<ProjectGitState | null>
+      getProjectUsageSummary?: (projectId: string) => Promise<ProjectUsageSummary>
       getProjectDiff?: (
         projectId: string,
         baseline?: ProjectDiffBaseline | null,


### PR DESCRIPTION
## Summary
- Add a project overview dashboard for selected code projects with usage totals, spend, token breakdowns, top-costing sessions, and minimal GitHub shortcuts.
- Keep the dashboard/composer aligned with the main composer geometry, including responsive height trimming and scrollbar placement.
- Preserve the generic no-project landing on fresh launch while keeping the project dashboard visible when starting a new code session.

## Implementation notes
- Adds project usage aggregation over Pi thread JSONL and wires it through desktop IPC/query/preload contracts.
- Invalidates project usage summaries on thread end/external updates so dashboard totals refresh after runs.
- Adds sidebar drag/click suppression and adjusts code-project new-session behavior so it selects the project dashboard without orphaning a persisted draft.
- Updates the current changelog with a one-line note for the feature.

## Validation
- `bun run ai:check`
- Addressed local review findings around draft creation, usage invalidation, stale GitHub links, and usage loading skeletons.

Closes #125
