### PR TITLE
Add macOS top padding to sidebar to clear traffic light buttons

### DIFF
--- a/src/app/components/sidebar/sidebar.tsx
+++ b/src/app/components/sidebar/sidebar.tsx
@@ -297,10 +297,13 @@ export function Sidebar({
     ...(onCloseCompactSidebar ? { onCloseCompactSidebar } : {}),
   }
 
+  const isMacOS = typeof window !== 'undefined' && window.piDesktop?.platform === 'darwin'
+
   return (
     <aside
       aria-label="Workspace sidebar"
       data-pulse-active={projectScopeLockActive ? 'true' : 'false'}
+      data-macos={isMacOS ? 'true' : 'false'}
       className="sidebar-shell motion-surface-pulse motion-sidebar-selection-pulse relative"
     >
       {showModeSelection ? (

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -13,6 +13,7 @@ import type {
 import type { TerminalEvent, TerminalOpenRequest } from '../../shared/terminal-contracts'
 
 let bridgeTokenPromise: Promise<string> | null = null
+const MAC_PLATFORM_RE = /^Mac/
 
 function getBridgeToken() {
   bridgeTokenPromise ??= fetch('/__howcode/config')
@@ -112,6 +113,7 @@ export function installDevWebDesktopBridge() {
   window.howcodeDevWebBridge = true
 
   window.piDesktop = {
+    platform: MAC_PLATFORM_RE.test(navigator.platform) ? 'darwin' : 'linux',
     clearClipboardImages: () => invokeRequest('clearClipboardImages', {}),
     getShellState: () => invokeRequest('getShellState', {}),
     getProjectGitState: (projectId: string) => invokeRequest('getProjectGitState', { projectId }),

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -41,6 +41,7 @@ function subscribeToEvent<K extends DesktopEventChannel>(
 
 export function createDesktopApi() {
   return {
+    platform: process.platform,
     getAppUpdateState: () => invokeRequest('getAppUpdateState', {}),
     checkAppUpdate: () => invokeRequest('checkAppUpdate', {}),
     installAppUpdate: () => invokeRequest('installAppUpdate', {}),

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -11,6 +11,10 @@
   padding: 0.75rem 0.625rem 0.625rem;
 }
 
+.sidebar-shell[data-macos="true"] {
+  padding-top: 2.375rem;
+}
+
 .sidebar-mode-nav {
   display: grid;
   gap: 0.125rem;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -60,6 +60,7 @@ declare global {
   interface Window {
     howcodeDevWebBridge?: boolean
     piDesktop?: {
+      platform: 'darwin' | 'linux' | 'win32'
       getAppUpdateState?: () => Promise<AppUpdateState>
       checkAppUpdate?: () => Promise<AppUpdateState>
       installAppUpdate?: () => Promise<AppUpdateState>


### PR DESCRIPTION
## Summary

Fixes the macOS traffic light buttons (close, minimize, maximize) overlapping the top-left UI elements in the sidebar.

| Before | After |
|-|-|
| <img width="303" height="226" alt="image" src="https://github.com/user-attachments/assets/dd52377f-1453-4456-85fd-8e91ca069551" /> | <img width="303" height="226" alt="image" src="https://github.com/user-attachments/assets/1d3d4843-d35a-4a04-96e5-13ac7b575a99" /> |

## Problem

On macOS, the window uses `titleBarStyle: 'hiddenInset'` with traffic lights positioned at `{ x: 18, y: 17 }`. The sidebar had no awareness of this, so the navigation buttons (Claw, Work, Inbox, Chat, Code) were rendered directly underneath the traffic lights, making them partially obscured and hard to interact with.

## Solution

- Exposed `platform` through the desktop preload API and dev web bridge so the renderer knows which OS it is running on.
- Added a conditional `data-macos="true"` attribute to the sidebar `aside` element when on macOS.
- Added a CSS rule `.sidebar-shell[data-macos='true']` that increases `padding-top` from `0.75rem` to `2.375rem` (~38px), which clears the traffic light area while keeping the existing compact layout on Linux and Windows.

## Files Changed

- `src/electron/preload/create-desktop-api.ts` — added `platform: process.platform`
- `src/types.d.ts` — added `platform` to `Window.piDesktop` type definition
- `src/app/dev-web-bridge.ts` — added `platform` for dev mode (detects mac via `navigator.platform`)
- `src/app/components/sidebar/sidebar.tsx` — sets `data-macos` based on platform
- `src/styles/sidebar.css` — conditional top padding rule for macOS
