### PR TITLE
Polish sidebar and artifact interactions

### DIFF
--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -11,7 +11,8 @@ Use GitHub issues as the working brief for this repo. This skill covers four rel
 1. pick the right issue to work on
 2. rewrite vague issues into proper issues, epics, and sub-issues
 3. implement issue-backed work on a fresh branch from `dev`
-4. open and maintain clean PRs with good GitHub hygiene
+4. choose single-PR vs stacked-PR shape
+5. open and maintain clean PRs with good GitHub hygiene
 
 Do not treat every issue as immediately buildable. First decide whether it is a good leaf issue, a parent issue, a research item, or something that should be rewritten before coding.
 
@@ -24,10 +25,12 @@ Do not treat every issue as immediately buildable. First decide whether it is a 
 - When rewriting an existing issue, preserve the user's original text at the bottom under `## Original issue text` as a blockquote.
 - New or rewritten issues should follow the writing rules in `references/issue-writing.md`.
 - If PR or release work touches GitHub Actions, artifact uploads, or release packaging, check `references/actions-artifact-retention.md` so workflow changes match the repo's storage policy.
-- Start new work from a fresh local branch based on `dev`.
-- Open the PR back into `dev`, not `main`, unless the user explicitly says otherwise.
+- Start new work from fresh `dev`. For single PRs, create a normal branch from `dev`; for stacked work, initialize the stack with `--base dev`.
+- Open PRs back into `dev`, not `main`, unless the user explicitly says otherwise. In stacked mode, the bottom PR ultimately targets `dev` and upper PRs target the layer below.
 - If the issue asks for discussion first or is clearly not actionable yet, stop and explain instead of forcing implementation.
-- Only use auto-closing keywords such as `Closes #123` for issues that are fully resolved by the PR. Use `Refs #123` for anything partial.
+- Choose the PR shape deliberately: small related changes should usually become layers in a stack; big unrelated features should be separate PRs or separate stacks; GitHub epics usually become a stacked PR series rather than one giant PR.
+- Use the `gh-stack` skill as the operating manual when stacked PR mode is selected; this skill owns the issue/PR policy and stack-vs-single decision.
+- Only use auto-closing keywords such as `Closes #123` for issues that are fully resolved by the PR. Use `Refs #123` for anything partial. In stacked mode, use `Refs` on intermediate layers and reserve `Closes` for the layer/PR whose merge completes the issue.
 - Before any build or release pass in this flow, refresh the landing changelog in `src/app/views/landing-overview-content.ts` from recent merged PRs / `origin/dev` commits so the shipped app does not carry stale release notes.
 
 ## When to use
@@ -99,13 +102,25 @@ Avoid the shorter `gh issue view <number> --comments` as the first read: it can 
    - `Backlog` means valid but not next
    - epics are usually containers, not active implementation cards
 
-### 4. Branch from `dev`
-1. Fetch remotes.
-2. Switch to `dev`.
-3. Fast-forward `dev` from `origin/dev`.
-4. Create a fresh branch from `dev` for the issue work.
+### 4. Choose PR shape, then branch from `dev`
+1. Fetch remotes, switch to `dev`, and fast-forward from `origin/dev`.
+2. Decide whether this work should be a single PR, a stacked PR series, or separate independent PRs/stacks.
+3. Use single PR mode only for tiny self-contained leaf work where a stack would be empty ceremony.
+4. Use stacked PR mode for small related changes that form one cohesive story with reviewable dependency layers. Treat most GitHub epics this way: split the epic into bottom-to-top PR layers instead of making one huge branch.
+5. Use separate PRs/stacks for big features that can merge independently or belong to different product stories.
 
-Useful commands:
+Decision tree:
+
+```text
+Is this local-only or not issue-backed? → leave this skill.
+Is the issue not actionable yet? → rewrite/split/research first.
+Is it one tiny self-contained leaf change? → one normal PR from dev.
+Is it small related changes or one cohesive feature/epic with dependent layers? → stacked PRs, base dev.
+Are the parts big, independent, or unrelated? → separate PRs or separate stacks.
+Would a stack only add ceremony? → one normal PR.
+```
+
+Useful commands for single PR mode:
 
 ```bash
 git fetch origin
@@ -114,7 +129,22 @@ git pull --ff-only origin dev
 git switch -c <branch-name>
 ```
 
-Branch naming should be issue-oriented and easy to trace, for example `issue-123-short-slug` or `issues-123-124-short-slug`.
+Useful commands for stacked PR mode:
+
+```bash
+git fetch origin
+git switch dev
+git pull --ff-only origin dev
+gh stack init --base dev -p issue-123 foundation
+# commit foundation layer
+gh stack add api
+# commit next layer
+gh stack add ui
+# commit top layer
+gh stack submit --auto
+```
+
+Branch naming should be issue-oriented and easy to trace. For stacks, prefer a shared prefix such as `issue-123` with short layer suffixes.
 
 ### 5. Implement the work
 1. Treat the issue as the brief.
@@ -134,10 +164,11 @@ Branch naming should be issue-oriented and easy to trace, for example `issue-123
 3. Keep it terse and user-facing; do not dump issue numbers or internal workflow noise into the app UI.
 4. If nothing user-visible changed since the last refresh, say so explicitly instead of inventing changelog churn.
 
-### 7. Open a clean PR with good hygiene
-1. Push the branch if needed.
-2. Create a PR targeting `dev`.
-3. Write a detailed PR body with:
+### 7. Open clean PRs with good hygiene
+1. Push the branch or submit the stack if needed.
+2. In single PR mode, create one PR targeting `dev`.
+3. In stacked mode, create/update the stack with `gh stack submit --auto`; verify with `gh stack view --json`.
+4. Write detailed PR bodies with:
    - a concise summary of the change
    - notable implementation details if they matter to reviewers
    - any validation or review loop summary worth preserving
@@ -149,16 +180,33 @@ Branch naming should be issue-oriented and easy to trace, for example `issue-123
 Useful commands:
 
 ```bash
+# single PR
 git push -u origin <branch-name>
 gh pr create --base dev --fill
 gh pr edit <pr-number> --body-file <file>
+
+# stacked PRs
+gh stack submit --auto
+gh stack view --json
+# edit individual PR bodies with gh pr edit as needed
 ```
 
+Stacked PR body guidance:
+- Intermediate layers usually use `Refs #n`.
+- The final/completing layer may use `Closes #n` if merging that layer resolves the issue.
+- For epic stacks, child issue PRs can close their child issues; parent epics should usually be referenced until the full epic is complete.
+
 ### 8. Ask Codex for review
-Post this exact PR comment after the PR is up:
+Post this exact PR comment after a normal PR is up:
 
 ```text
 @codex please review this PR and give me 10-20 issues if any. Categorize findings as required, recommended, or optional.
+```
+
+For stacked PRs, post this variant on each PR in the stack:
+
+```text
+@codex please review this PR as one layer in a stacked PR series. Focus on this layer's diff and call out cross-layer issues only when they affect correctness. Categorize findings as required, recommended, or optional.
 ```
 
 Useful command:
@@ -194,13 +242,13 @@ gh pr view <pr-number-or-url> --comments
 - If the user asked for issue selection, the chosen issue is a manageable leaf issue rather than an epic or mushy umbrella issue.
 - If the user asked for issue cleanup, the rewritten issues follow the house format and preserve original text.
 - The issue or PR was fully read before action.
-- New work started from a branch created off current `dev`.
-- The PR targets `dev` explicitly.
+- New single-PR work started from a branch created off current `dev`; stacked work was initialized with `--base dev`.
+- The PR targets `dev` explicitly, or the stack bottom ultimately targets `dev` with upper PRs targeting the layer below.
 - The PR body clearly distinguishes `Closes` from `Refs`.
 - The user's `/review` findings were addressed or explicitly called out.
 - If the flow included a build or release pass, `src/app/views/landing-overview-content.ts` was refreshed first from real merged PRs / `origin/dev` history.
 - If the flow touched GitHub Actions workflows, artifact retention and upload behavior still match `references/actions-artifact-retention.md`.
-- Codex was asked for review.
+- Codex was asked for review; in stacked mode, each layer received the stack-aware review request.
 - The PR link was returned to the user after posting the review request.
 - Codex feedback was triaged instead of accepted blindly when the user asked for feedback handling.
 
@@ -229,8 +277,8 @@ Action: do not churn on them. Fix the real ones, then note why the others were d
 ## Output contract
 The completed flow should leave:
 - a clearly chosen or clearly rewritten issue when the request was about backlog triage
-- an issue-backed implementation branch created from `dev`
-- a PR targeting `dev`
+- an issue-backed implementation branch from `dev`, or a stack initialized with `--base dev`
+- a PR targeting `dev`, or a stacked PR series whose bottom targets `dev`
 - a detailed PR description with correct closing references
 - a Codex review request comment on the PR
 - the PR link returned to the user

--- a/.pi/skills/gh-stack/SKILL.md
+++ b/.pi/skills/gh-stack/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: gh-stack
+description: Manage GitHub stacked pull requests with `gh stack`. Use when creating stacked diffs, splitting work into dependent PRs, pushing/submitting/syncing/rebasing a stack, checking stack status, or navigating branch layers. Do not use for ordinary single-branch PR work.
+---
+
+# gh-stack
+
+## Purpose
+
+Use `gh stack` to operate a linear chain of dependent branches and PRs. This is the CLI operating manual; higher-level repo policy decides whether work should be stacked. Each branch builds on the one below it; the bottom branch targets trunk, and each higher PR targets the branch below.
+
+```text
+main <- feat/base <- feat/api <- feat/ui
+       bottom                 top
+```
+
+## Critical rules
+
+- Run `gh stack` non-interactively. Avoid commands or flags that open prompts/TUIs.
+- Use `gh stack view --json`, never plain `gh stack view`.
+- Use `gh stack submit --auto`, never plain `gh stack submit`.
+- Pass branch names to `init`, `add`, and `checkout`; do not rely on prompts.
+- If a stack has a prefix, pass only suffixes to `add`: with prefix `feat`, use `gh stack add api`, not `gh stack add feat/api`.
+- Put changes in the right layer. If a higher layer needs a lower-layer change, move down, commit there, then `gh stack rebase --upstack`.
+- Prefer normal `git add` and `git commit` over `gh stack add -Am` unless the change is clearly a single-commit layer.
+
+## Setup
+
+If the extension is missing:
+
+```bash
+gh extension install github/gh-stack
+```
+
+Before stack work in a repo, reduce prompt risk:
+
+```bash
+git config rerere.enabled true
+git config remote.pushDefault origin
+```
+
+If multiple remotes exist and `remote.pushDefault` is not set, pass `--remote <name>` to `push`, `submit`, `sync`, `link`, and checkout/rebase flows that fetch or push.
+
+## Common workflows
+
+### Create a new stack
+
+```bash
+gh stack init -p feat base-layer
+# edit files
+git add <files>
+git commit -m "Add base layer"
+
+gh stack add api-layer
+# edit files
+git add <files>
+git commit -m "Add API layer"
+
+gh stack add ui-layer
+# edit files
+git add <files>
+git commit -m "Add UI layer"
+
+gh stack submit --auto
+gh stack view --json
+```
+
+Use dependency order: shared types/schema/core code at the bottom; callers, UI, tests, and integration work above.
+
+### Adopt existing branches
+
+```bash
+gh stack init --base main --adopt branch-a branch-b branch-c
+gh stack submit --auto
+```
+
+List branches bottom-to-top.
+
+### Check status
+
+```bash
+gh stack view --json
+```
+
+Inspect `branches[].name`, `branches[].isCurrent`, `branches[].needsRebase`, `branches[].isMerged`, and `branches[].pr`.
+
+### Push or submit
+
+```bash
+gh stack push              # push branches only
+gh stack submit --auto     # push and create/update PRs as draft by default
+gh stack submit --auto --open
+```
+
+### Sync routine updates
+
+```bash
+gh stack sync
+```
+
+This fetches, fast-forwards trunk when possible, rebases stack branches, pushes, and refreshes PR state.
+
+### Modify a lower layer
+
+```bash
+gh stack checkout feat/api-layer   # or: gh stack down / gh stack bottom
+# edit files
+git add <files>
+git commit -m "Fix API layer"
+gh stack rebase --upstack
+gh stack push
+```
+
+Do not commit lower-layer work on an upper branch just because that is where you noticed it.
+
+### Navigate
+
+```bash
+gh stack up [n]
+gh stack down [n]
+gh stack top
+gh stack bottom
+gh stack checkout <branch-or-pr-number>
+```
+
+Always provide an argument to `checkout`.
+
+### Rebase and conflicts
+
+```bash
+gh stack rebase
+gh stack rebase --upstack
+gh stack rebase --downstack
+```
+
+On conflict:
+
+1. Read stderr for conflicted paths.
+2. Resolve conflict markers in files.
+3. `git add <resolved-files>`.
+4. `gh stack rebase --continue`.
+5. If resolution is unsafe, `gh stack rebase --abort`.
+
+### Restructure a stack
+
+For reorder/rename/drop operations, prefer the interactive `gh stack modify` only when a human can operate the TUI. For agent-safe restructuring:
+
+```bash
+gh stack unstack --local       # use without --local only when intentionally changing GitHub stack state
+# rename/delete/reorder branches with git
+gh stack init --base main --adopt new-bottom new-middle new-top
+```
+
+Ask before destructive branch deletion or unstacking GitHub state.
+
+### Link PRs without local stack state
+
+Use this for branches managed by another tool, or when only GitHub stack linkage is needed:
+
+```bash
+gh stack link --base main branch-a branch-b branch-c
+gh stack link 101 102 103
+```
+
+Arguments are bottom-to-top.
+
+## Command reference
+
+| Task | Command |
+| --- | --- |
+| Create stack with prefix | `gh stack init -p feat base` |
+| Adopt branches | `gh stack init --base main --adopt branch-a branch-b` |
+| Add top branch | `gh stack add next-layer` |
+| View JSON | `gh stack view --json` |
+| Push branches | `gh stack push` |
+| Submit PRs | `gh stack submit --auto` |
+| Submit ready PRs | `gh stack submit --auto --open` |
+| Sync stack | `gh stack sync` |
+| Rebase whole stack | `gh stack rebase` |
+| Rebase above current branch | `gh stack rebase --upstack` |
+| Continue conflict resolution | `gh stack rebase --continue` |
+| Abort rebase | `gh stack rebase --abort` |
+| Move through layers | `gh stack up`, `gh stack down`, `gh stack top`, `gh stack bottom` |
+| Checkout stack/branch | `gh stack checkout <branch-or-pr>` |
+| Remove local tracking | `gh stack unstack --local` |
+| Link existing PRs/branches | `gh stack link <bottom> <middle> <top>` |
+
+## Failure handling
+
+- Extension missing: install `github/gh-stack` and retry.
+- Repository not enabled for GitHub Stacked PRs: `submit`/`link` can fail; report that the GitHub feature must be enabled for the repo.
+- Command hangs: assume an interactive prompt/TUI was triggered; cancel and rerun with explicit args/flags.
+- Multiple remotes: set `git config remote.pushDefault origin` or pass `--remote <name>`.
+- Branch belongs to multiple stacks: check out a specific non-shared stack branch before retrying.
+- Remote checkout conflict prompt risk: if local and remote stack composition differ, remove local tracking with `gh stack unstack --local` before `gh stack checkout <pr-number>`.
+
+## Output contract
+
+When using this skill, final responses should include:
+
+- stack branches changed or created, in bottom-to-top order
+- commands run that affected stack state
+- PR URLs/numbers when created or updated
+- any unresolved conflict, prompt, or repository feature blocker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,10 @@
 - `bun run ai:check` is the repo-wide verification command.
 
 ## Code Quality
-- MUST run `bun run ai:check` after concluding any changes.
-- Run `bun run ai:check` frequently while working and always before considering the task complete.
+- Run `bun run ai:check` after meaningful code, config, packaging, or behavior changes.
+- Run `bun run ai:check` frequently while working on code and before considering substantive implementation work complete.
 - If you touch a subsystem with its own fast deterministic tests, run those too.
-- Do not consider work complete while `ai:check` is failing.
+- Do not consider substantive implementation work complete while `ai:check` is failing.
 - Never weaken strict Biome or TypeScript rules just to silence warnings quickly. Fix the issue properly or add a narrow, justified override.
 
 ## Project Workflow

--- a/src/app/components/workspace/diff/diff-changed-files-tree.tsx
+++ b/src/app/components/workspace/diff/diff-changed-files-tree.tsx
@@ -81,19 +81,27 @@ export function DiffChangedFilesTree({
   focusedFileCount,
   onSelectedPathsChange,
 }: DiffChangedFilesTreeProps) {
-  const paths = useMemo(() => files.flatMap((file) => [resolveFileDiffPath(file)]), [files])
-  const gitStatus = useMemo<GitStatusEntry[]>(
-    () => files.map((file) => ({ path: resolveFileDiffPath(file), status: getGitStatus(file) })),
+  const filesWithPaths = useMemo(
+    () =>
+      files.flatMap((file) => {
+        const path = resolveFileDiffPath(file)
+        return path ? [{ file, path }] : []
+      }),
     [files],
+  )
+  const paths = useMemo(() => filesWithPaths.map(({ path }) => path), [filesWithPaths])
+  const gitStatus = useMemo<GitStatusEntry[]>(
+    () => filesWithPaths.map(({ file, path }) => ({ path, status: getGitStatus(file) })),
+    [filesWithPaths],
   )
   const fileStatsByPath = useMemo(() => {
     const stats = new Map<string, string>()
-    for (const file of files) {
+    for (const { file, path } of filesWithPaths) {
       const { additions, deletions } = getFileChangeCounts(file)
-      stats.set(resolveFileDiffPath(file), `+${additions} −${deletions}`)
+      stats.set(path, `+${additions} −${deletions}`)
     }
     return stats
-  }, [files])
+  }, [filesWithPaths])
 
   const fileStatsByPathRef = useRef(fileStatsByPath)
   fileStatsByPathRef.current = fileStatsByPath

--- a/src/app/dev-web-bridge.ts
+++ b/src/app/dev-web-bridge.ts
@@ -112,6 +112,7 @@ export function installDevWebDesktopBridge() {
   window.howcodeDevWebBridge = true
 
   window.piDesktop = {
+    platform: navigator.platform.toLowerCase().includes('mac') ? 'darwin' : 'browser',
     clearClipboardImages: () => invokeRequest('clearClipboardImages', {}),
     getShellState: () => invokeRequest('getShellState', {}),
     getProjectGitState: (projectId: string) => invokeRequest('getProjectGitState', { projectId }),

--- a/src/app/features/chat/artifacts/artifact-panel.tsx
+++ b/src/app/features/chat/artifacts/artifact-panel.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import {
   type CSSProperties,
+  type KeyboardEvent,
   lazy,
   type PointerEvent,
   Suspense,
@@ -265,6 +266,15 @@ function ArtifactVersionSelect({ panel }: { panel: ReturnType<typeof useArtifact
     event.stopPropagation()
     setOpen((current) => !current)
   }
+  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (!(event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown')) return
+    event.preventDefault()
+    setOpen(true)
+  }
+  const selectOption = (value: (typeof options)[number]['value']) => {
+    setSelectedVersion(value)
+    closeMenu()
+  }
   return (
     <>
       <button
@@ -272,6 +282,7 @@ function ArtifactVersionSelect({ panel }: { panel: ReturnType<typeof useArtifact
         type="button"
         className="artifact-version-trigger inline-flex h-7 max-w-28 shrink-0 items-center gap-1 rounded-lg border border-[color:var(--border)] bg-[color:var(--panel-2)] px-2 text-[color:var(--muted)] outline-none transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
         onPointerDown={handleTriggerPointerDown}
+        onKeyDown={handleTriggerKeyDown}
         aria-label="Artifact version"
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -306,9 +317,9 @@ function ArtifactVersionSelect({ panel }: { panel: ReturnType<typeof useArtifact
                   onPointerDown={(event) => {
                     event.preventDefault()
                     event.stopPropagation()
-                    setSelectedVersion(option.value)
-                    closeMenu()
+                    selectOption(option.value)
                   }}
+                  onClick={() => selectOption(option.value)}
                 >
                   {option.value === selectedVersion ? <Check size={12} /> : <span />}
                   <span className="truncate">{option.label}</span>

--- a/src/app/features/chat/artifacts/artifact-panel.tsx
+++ b/src/app/features/chat/artifacts/artifact-panel.tsx
@@ -1,4 +1,6 @@
 import {
+  Check,
+  ChevronDown,
   Download,
   FileCode2,
   List,
@@ -8,9 +10,22 @@ import {
   Play,
   Save,
 } from 'lucide-react'
-import { lazy, Suspense } from 'react'
+import {
+  type CSSProperties,
+  lazy,
+  type PointerEvent,
+  Suspense,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { SurfacePanel } from '../../../components/common/surface-panel'
 import { Tooltip } from '../../../components/common/tooltip'
-import { compactIconButtonClass } from '../../../ui/classes'
+import { useDismissibleLayer } from '../../../hooks/useDismissibleLayer'
+import { compactIconButtonClass, popoverPanelClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
 import { HistoricalMarkdownPreview } from './artifact-markdown-preview'
 import { formatArtifactSlug } from './artifactFormat'
@@ -33,6 +48,43 @@ type ArtifactPanelProps = {
   onClose: () => void
 }
 
+function ArtifactPreviewIframe({
+  previewHtml,
+  previewRevision,
+  selectedArtifactKey,
+  setPreviewSource,
+}: {
+  previewHtml: string
+  previewRevision: number
+  selectedArtifactKey: string
+  setPreviewSource: (source: MessageEventSource | null) => void
+}) {
+  const [previewUrl, setPreviewUrl] = useState('')
+
+  useEffect(() => {
+    if (!previewHtml) {
+      setPreviewUrl('')
+      return
+    }
+
+    const nextPreviewUrl = URL.createObjectURL(new Blob([previewHtml], { type: 'text/html' }))
+    setPreviewUrl(nextPreviewUrl)
+    return () => URL.revokeObjectURL(nextPreviewUrl)
+  }, [previewHtml])
+
+  if (!previewUrl) return null
+  return (
+    <iframe
+      ref={(node) => setPreviewSource(node?.contentWindow ?? null)}
+      key={`${selectedArtifactKey}:${previewRevision}:${previewUrl}`}
+      sandbox="allow-scripts allow-forms allow-modals allow-popups"
+      src={previewUrl}
+      className="h-full w-full border-0"
+      title="Artifact preview"
+    />
+  )
+}
+
 function ArtifactPanelBody({
   fullscreen,
   panel,
@@ -42,6 +94,7 @@ function ArtifactPanelBody({
 }) {
   const {
     artifacts,
+    artifactLoadError,
     displayedContent,
     draft,
     markdownPreviewEditable,
@@ -57,6 +110,18 @@ function ArtifactPanelBody({
     showingHistoricalVersion,
     view,
   } = panel
+  if (artifactLoadError)
+    return (
+      <div className="grid h-full place-items-center px-6 text-center text-[12px] text-[color:var(--danger)]">
+        {artifactLoadError}
+      </div>
+    )
+  if (panel.loadingArtifacts)
+    return (
+      <div className="grid h-full place-items-center px-6 text-center text-[12px] text-[color:var(--muted)]">
+        Loading artifacts…
+      </div>
+    )
   if (artifacts.length === 0)
     return (
       <div className="grid h-full place-items-center px-6 text-center text-[12px] text-[color:var(--muted)]">
@@ -132,13 +197,11 @@ function ArtifactPanelBody({
           </pre>
         ) : null}
         {previewHtml ? (
-          <iframe
-            ref={(node) => setPreviewSource(node?.contentWindow ?? null)}
-            key={`${selectedArtifact?.slug}:${selectedArtifact?.version}:${selectedArtifact?.updatedAt}:${previewRevision}`}
-            sandbox="allow-scripts allow-forms allow-modals allow-popups"
-            srcDoc={previewHtml}
-            className="h-full w-full border-0"
-            title="Artifact preview"
+          <ArtifactPreviewIframe
+            previewHtml={previewHtml}
+            previewRevision={previewRevision}
+            selectedArtifactKey={`${selectedArtifact?.slug}:${selectedArtifact?.version}:${selectedArtifact?.updatedAt}`}
+            setPreviewSource={setPreviewSource}
           />
         ) : null}
       </div>
@@ -149,28 +212,113 @@ function ArtifactPanelBody({
 
 function ArtifactVersionSelect({ panel }: { panel: ReturnType<typeof useArtifactPanelState> }) {
   const { selectedArtifact, selectedVersion, setSelectedVersion, versions } = panel
+  const [open, setOpen] = useState(false)
+  const [menuStyle, setMenuStyle] = useState<CSSProperties | undefined>(undefined)
+  const [positionReady, setPositionReady] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const closeMenu = useCallback(() => setOpen(false), [])
+
+  useDismissibleLayer({ open, onDismiss: closeMenu, refs: [buttonRef, menuRef] })
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPositionReady(false)
+      return
+    }
+
+    const updatePosition = () => {
+      const rect = buttonRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const width = Math.max(rect.width, 112)
+      setMenuStyle({
+        left: Math.min(Math.max(8, rect.left), window.innerWidth - width - 8),
+        top: rect.bottom + 6,
+        width,
+      })
+      setPositionReady(true)
+    }
+
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [open])
+
   if (!selectedArtifact) return null
+  const options = [
+    { label: `Latest v${selectedArtifact.version}`, value: 'latest' as const },
+    ...versions.flatMap((version) =>
+      version.version === selectedArtifact.version
+        ? []
+        : [{ label: `v${version.version}`, value: version.version }],
+    ),
+  ]
+  const selectedLabel =
+    options.find((option) => option.value === selectedVersion)?.label ??
+    (selectedVersion === 'latest' ? `Latest v${selectedArtifact.version}` : `v${selectedVersion}`)
+  const handleTriggerPointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setOpen((current) => !current)
+  }
   return (
-    <select
-      className="h-7 max-w-28 shrink-0 rounded-md border border-[color:var(--border)] bg-[color:var(--panel-2)] px-2 text-[11px] text-[color:var(--muted)] outline-none transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
-      value={selectedVersion}
-      onChange={(event) => {
-        const value = event.target.value
-        setSelectedVersion(value === 'latest' ? 'latest' : Number(value))
-      }}
-      aria-label="Artifact version"
-    >
-      <option value="latest">Latest v{selectedArtifact.version}</option>
-      {versions.flatMap((version) =>
-        version.version === selectedArtifact.version
-          ? []
-          : [
-              <option key={version.version} value={version.version}>
-                v{version.version}
-              </option>,
-            ],
-      )}
-    </select>
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className="artifact-version-trigger inline-flex h-7 max-w-28 shrink-0 items-center gap-1 rounded-lg border border-[color:var(--border)] bg-[color:var(--panel-2)] px-2 text-[color:var(--muted)] outline-none transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]"
+        onPointerDown={handleTriggerPointerDown}
+        aria-label="Artifact version"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="truncate">{selectedLabel}</span>
+        <ChevronDown size={12} className="shrink-0" />
+      </button>
+      {open && typeof document !== 'undefined'
+        ? createPortal(
+            <SurfacePanel
+              ref={menuRef}
+              data-open={positionReady ? 'true' : 'false'}
+              className={cn(
+                popoverPanelClass,
+                'motion-popover fixed z-[120] grid gap-0.5 rounded-xl p-1',
+              )}
+              style={menuStyle}
+              role="listbox"
+              aria-label="Artifact version"
+            >
+              {options.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={option.value === selectedVersion}
+                  className={cn(
+                    'artifact-version-option grid grid-cols-[14px_minmax(0,1fr)] items-center gap-1.5 rounded-lg px-2 py-1.5 text-left text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-[color:var(--text)]',
+                    option.value === selectedVersion &&
+                      'bg-[color:var(--surface-hover)] text-[color:var(--text)]',
+                  )}
+                  onPointerDown={(event) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    setSelectedVersion(option.value)
+                    closeMenu()
+                  }}
+                >
+                  {option.value === selectedVersion ? <Check size={12} /> : <span />}
+                  <span className="truncate">{option.label}</span>
+                </button>
+              ))}
+            </SurfacePanel>,
+            document.body,
+          )
+        : null}
+    </>
   )
 }
 

--- a/src/app/features/chat/artifacts/useArtifactPanelState.ts
+++ b/src/app/features/chat/artifacts/useArtifactPanelState.ts
@@ -73,7 +73,10 @@ export function useArtifactPanelState(conversationId: string | null) {
     setSelectedVersion('latest')
     setVersions([])
     setArtifactLoadError(null)
-    if (!conversationId) return
+    if (!conversationId) {
+      setLoadingArtifacts(false)
+      return
+    }
     setLoadingArtifacts(true)
     void listArtifactsQuery(conversationId)
       .then((nextArtifacts) => {

--- a/src/app/features/chat/artifacts/useArtifactPanelState.ts
+++ b/src/app/features/chat/artifacts/useArtifactPanelState.ts
@@ -26,6 +26,8 @@ export function useArtifactPanelState(conversationId: string | null) {
   const [versions, setVersions] = useState<ArtifactVersion[]>([])
   const [selectedVersion, setSelectedVersion] = useState<number | 'latest'>('latest')
   const [saving, setSaving] = useState(false)
+  const [loadingArtifacts, setLoadingArtifacts] = useState(false)
+  const [artifactLoadError, setArtifactLoadError] = useState<string | null>(null)
   const [downloadStatus, setDownloadStatus] = useState<string | null>(null)
   const [previewHtml, setPreviewHtml] = useState('')
   const [previewError, setPreviewError] = useState<string | null>(null)
@@ -70,16 +72,29 @@ export function useArtifactPanelState(conversationId: string | null) {
     setSelectedArtifactId(null)
     setSelectedVersion('latest')
     setVersions([])
+    setArtifactLoadError(null)
     if (!conversationId) return
-    void listArtifactsQuery(conversationId).then((nextArtifacts) => {
-      if (cancelled) return
-      setArtifacts(nextArtifacts)
-      setSelectedArtifactId((current) =>
-        current && nextArtifacts.some((artifact) => artifact.slug === current)
-          ? current
-          : (nextArtifacts[0]?.slug ?? null),
-      )
-    })
+    setLoadingArtifacts(true)
+    void listArtifactsQuery(conversationId)
+      .then((nextArtifacts) => {
+        if (cancelled) return
+        setArtifacts(nextArtifacts)
+        setSelectedArtifactId((current) =>
+          current && nextArtifacts.some((artifact) => artifact.slug === current)
+            ? current
+            : (nextArtifacts[0]?.slug ?? null),
+        )
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setArtifactLoadError(
+            error instanceof Error ? error.message : 'Could not load artifacts.',
+          )
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingArtifacts(false)
+      })
     return () => {
       cancelled = true
     }
@@ -129,9 +144,13 @@ export function useArtifactPanelState(conversationId: string | null) {
       return
     }
     void selectedArtifactVersion
-    void listArtifactVersionsQuery(selectedArtifactSlug).then((nextVersions) => {
-      if (!cancelled) setVersions(nextVersions)
-    })
+    void listArtifactVersionsQuery(selectedArtifactSlug)
+      .then((nextVersions) => {
+        if (!cancelled) setVersions(nextVersions)
+      })
+      .catch(() => {
+        if (!cancelled) setVersions([])
+      })
     return () => {
       cancelled = true
     }
@@ -227,6 +246,8 @@ export function useArtifactPanelState(conversationId: string | null) {
 
   return {
     artifacts,
+    artifactLoadError,
+    loadingArtifacts,
     selectedArtifact,
     selectedVersion,
     versions,

--- a/src/app/features/code/code-workspace-view.tsx
+++ b/src/app/features/code/code-workspace-view.tsx
@@ -342,7 +342,9 @@ function CodeGitOpsComposer(props: CodeWorkspaceContentProps) {
         onSetDiffBaseline={onSetDiffBaseline}
         onSetDiffRenderMode={onSetDiffRenderMode}
         onSendDiffComments={(message) => {
-          void handleSendDiffComments(message)
+          void handleSendDiffComments(message).then((sent) => {
+            if (sent) handleCloseGitOpsView()
+          })
         }}
         onSelectDiffComment={handleSelectDiffComment}
         onLayoutChange={() => setComposerLayoutVersion((current: number) => current + 1)}

--- a/src/app/features/code/useDiffCommentController.ts
+++ b/src/app/features/code/useDiffCommentController.ts
@@ -24,7 +24,7 @@ async function sendDiffCommentsToComposer(input: {
   handleAction: AppShellController['handleAction']
   message?: string | null | undefined
   shellState: AppShellController['shellState']
-}) {
+}): Promise<{ ok: boolean; error: string | null }> {
   const streamingBehaviorPreference =
     input.shellState?.appSettings.composerStreamingBehavior ?? 'followUp'
   const result = await input.handleAction('composer.send', {
@@ -33,11 +33,11 @@ async function sendDiffCommentsToComposer(input: {
   })
 
   const actionErrorMessage = getDiffCommentSendError(result)
-  if (actionErrorMessage) return actionErrorMessage
-  if (result?.result?.composerSendOutcome !== 'stopped') {
-    diffCommentStore.clearContext(input.diffCommentContextId)
-  }
-  return null
+  if (actionErrorMessage) return { ok: false, error: actionErrorMessage }
+  if (result?.result?.composerSendOutcome === 'stopped') return { ok: false, error: null }
+
+  diffCommentStore.clearContext(input.diffCommentContextId)
+  return { ok: true, error: null }
 }
 
 export function useDiffCommentController({
@@ -84,9 +84,9 @@ export function useDiffCommentController({
   }, [diffCommentContextId])
 
   const handleSendDiffComments = async (message?: string | null) => {
-    if (!diffCommentContextId || diffCommentsSending) return
+    if (!diffCommentContextId || diffCommentsSending) return false
     const context = diffCommentStore.getContext(diffCommentContextId)
-    if (!hasDiffCommentsContext(context)) return
+    if (!hasDiffCommentsContext(context)) return false
 
     setDiffCommentsSending(true)
     setDiffCommentError(null)
@@ -94,19 +94,20 @@ export function useDiffCommentController({
     setComposerPromptResetKey((current) => current + 1)
 
     try {
-      setDiffCommentError(
-        await sendDiffCommentsToComposer({
-          context,
-          diffCommentContextId,
-          handleAction,
-          message,
-          shellState,
-        }),
-      )
+      const result = await sendDiffCommentsToComposer({
+        context,
+        diffCommentContextId,
+        handleAction,
+        message,
+        shellState,
+      })
+      setDiffCommentError(result.error)
+      return result.ok
     } catch (error) {
       setDiffCommentError(
         error instanceof Error ? error.message : 'Could not send comments to the agent.',
       )
+      return false
     } finally {
       setDiffCommentsSending(false)
     }

--- a/src/electron/preload/create-desktop-api.ts
+++ b/src/electron/preload/create-desktop-api.ts
@@ -41,6 +41,7 @@ function subscribeToEvent<K extends DesktopEventChannel>(
 
 export function createDesktopApi() {
   return {
+    platform: process.platform,
     getAppUpdateState: () => invokeRequest('getAppUpdateState', {}),
     checkAppUpdate: () => invokeRequest('checkAppUpdate', {}),
     installAppUpdate: () => invokeRequest('installAppUpdate', {}),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,12 +9,18 @@ import { applyStoredPiGuiTheme } from './app/app-shell/usePiGuiTheme'
 import { installDevWebDesktopBridge } from './app/dev-web-bridge'
 import { queryClient } from './app/query/query-client'
 
+function applyDesktopPlatformAttribute() {
+  const platform = window.piDesktop?.platform ?? 'browser'
+  document.documentElement.setAttribute('data-desktop-platform', platform)
+}
+
 if (import.meta.env.DEV) {
   void import('react-grab')
   installDevWebDesktopBridge()
 }
 
 try {
+  applyDesktopPlatformAttribute()
   applyStoredPiGuiTheme()
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -494,6 +494,12 @@ button[data-tooltip][data-tooltip-size="wide"]::after {
   display: none;
 }
 
+.artifact-version-trigger,
+.artifact-version-option {
+  font-size: 13px;
+  font-weight: 500;
+}
+
 .artifact-markdown-editor .artifact-mdx-toolbar [class*="diffSourceToggleWrapper"] {
   height: 24px;
   display: inline-flex;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -11,6 +11,10 @@
   padding: 0.75rem 0.625rem 0.625rem;
 }
 
+:root[data-desktop-platform="darwin"] .sidebar-shell {
+  padding-top: 2.375rem;
+}
+
 .sidebar-mode-nav {
   display: grid;
   gap: 0.125rem;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -60,6 +60,7 @@ declare global {
   interface Window {
     howcodeDevWebBridge?: boolean
     piDesktop?: {
+      platform?: string
       getAppUpdateState?: () => Promise<AppUpdateState>
       checkAppUpdate?: () => Promise<AppUpdateState>
       installAppUpdate?: () => Promise<AppUpdateState>


### PR DESCRIPTION
## Summary
- Apply macOS-only sidebar top padding using a platform attribute from the desktop bridge.
- Fix artifact previews by loading generated HTML through sandboxed blob URLs instead of `srcDoc`.
- Add artifact loading/error states and a rounded, themed artifact version popover.
- Return from GitOps to the session after successfully sending diff comments.
- Include stacked PR workflow guidance updates.

## Validation
- `bun run ai:check`
- pre-commit and pre-push hooks ran `bun run ai:check`
