### PR TITLE
Polish sidebar search and inbox actions

### DIFF
--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -1,5 +1,4 @@
 - `desktop/` is backend runtime code for threads, skills, and terminal lanes.
 - Keep entrypoints stable: `pi-threads.ts`, `pi-skills.ts`, `skill-creator-session.ts`, and `terminal/manager.ts`.
 - Update `shared/*` contracts and the matching action router/handlers together.
-- After `desktop/**/*.ts` edits, rebuild with `bun ./scripts/build-electron-runtime.ts` or `bun run dev:runtime`.
 - Keep event/state flow on the existing publisher and `thread-state-db.ts` paths.

--- a/desktop/pi-threads/thread-actions.ts
+++ b/desktop/pi-threads/thread-actions.ts
@@ -13,6 +13,7 @@ import { openThreadRuntime, startNewThread } from '../pi-desktop-runtime.ts'
 import {
   archiveThread,
   archiveThreads,
+  clearReadInboxThreads,
   deleteThreadRecord,
   dismissInboxThread,
   getThreadSessionPath,
@@ -137,6 +138,11 @@ const threadActionHandlers = {
     const sessionPath = getSessionPath(payload)
     if (sessionPath) dismissInboxThread(sessionPath)
     return handledAction()
+  },
+  'inbox.clear-read': (payload) => {
+    const olderThanDays = typeof payload.olderThanDays === 'number' ? payload.olderThanDays : null
+    const olderThanMs = olderThanDays ? Date.now() - olderThanDays * 24 * 60 * 60 * 1000 : null
+    return handledAction({ clearedCount: clearReadInboxThreads(olderThanMs) })
   },
 } satisfies Partial<Record<DesktopAction, ThreadActionHandler>>
 

--- a/desktop/thread-state-db.ts
+++ b/desktop/thread-state-db.ts
@@ -20,6 +20,7 @@ export {
   archiveThread,
   archiveThreads,
   beginInboxThreadTurn,
+  clearReadInboxThreads,
   collapseAllProjects,
   deleteProject,
   deleteThreadRecord,

--- a/desktop/thread-state-db/inbox-writes.ts
+++ b/desktop/thread-state-db/inbox-writes.ts
@@ -76,6 +76,37 @@ export function dismissInboxThread(sessionPath: string) {
   ).run(sessionPath)
 }
 
+export function clearReadInboxThreads(olderThanMs: number | null = null) {
+  const db = getThreadStateDatabase()
+  const result = (
+    olderThanMs
+      ? db
+          .prepare(
+            `
+            DELETE FROM inbox_items
+            WHERE unread = 0
+              AND COALESCE(
+                last_assistant_at_ms,
+                unixepoch(updated_at) * 1000,
+                unixepoch(created_at) * 1000,
+                0
+              ) < ?
+          `,
+          )
+          .run(olderThanMs)
+      : db
+          .prepare(
+            `
+            DELETE FROM inbox_items
+            WHERE unread = 0
+          `,
+          )
+          .run()
+  ) as { changes: number }
+
+  return result.changes
+}
+
 export function upsertInboxThreadMessage(record: ThreadInboxMessageRecord) {
   const db = getThreadStateDatabase()
   const serializedContent = JSON.stringify(record.content)

--- a/desktop/thread-state-db/writes.ts
+++ b/desktop/thread-state-db/writes.ts
@@ -1,5 +1,6 @@
 export {
   beginInboxThreadTurn,
+  clearReadInboxThreads,
   dismissInboxThread,
   markInboxThreadRead,
   upsertInboxThreadMessage,

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -33,6 +33,7 @@ export type DesktopActionPayloadFields = {
   level?: ComposerThinkingLevel
   message?: string | undefined | null | undefined
   modelId?: string | undefined
+  olderThanDays?: number | undefined | null | undefined
   preview?: boolean | undefined
   projectId?: string | undefined | null | undefined
   projectIds?: string[] | undefined
@@ -213,6 +214,7 @@ export type DesktopActionPayloadMap = {
   }
   'inbox.mark-read': { sessionPath: string; projectId?: string | undefined | null | undefined }
   'inbox.dismiss': { sessionPath: string; projectId?: string | undefined | null | undefined }
+  'inbox.clear-read': { olderThanDays?: number | undefined | null | undefined }
   'settings.update': DesktopSettingsUpdatePayload
   'settings.clear-clipboard-images': EmptyActionPayload
   'pi-settings.update': { piSettingsKey: keyof PiSettings; value: string | number | boolean }

--- a/shared/desktop-action-coverage.ts
+++ b/shared/desktop-action-coverage.ts
@@ -31,6 +31,7 @@ export const implementedDesktopActions = [
   'composer.answer-native-questions',
   'inbox.mark-read',
   'inbox.dismiss',
+  'inbox.clear-read',
   'workspace.commit',
   'workspace.commit-options',
   'workspace.diff-preferences',

--- a/shared/desktop-actions.ts
+++ b/shared/desktop-actions.ts
@@ -37,6 +37,7 @@ export const desktopActions = [
   'composer.answer-native-questions',
   'inbox.mark-read',
   'inbox.dismiss',
+  'inbox.clear-read',
   'settings.update',
   'settings.clear-clipboard-images',
   'pi-settings.update',

--- a/src/app/app-shell/controller-post-action-effects.ts
+++ b/src/app/app-shell/controller-post-action-effects.ts
@@ -385,7 +385,8 @@ const postEffectHandlers: PostEffectHandler[] = [
     matches: (ctx) =>
       ctx.action === 'thread.open' ||
       ctx.action === 'inbox.mark-read' ||
-      ctx.action === 'inbox.dismiss',
+      ctx.action === 'inbox.dismiss' ||
+      ctx.action === 'inbox.clear-read',
     run: handleThreadOpenOrInboxEffects,
   },
   {

--- a/src/app/components/sidebar/inbox/sidebar-inbox-section.tsx
+++ b/src/app/components/sidebar/inbox/sidebar-inbox-section.tsx
@@ -1,27 +1,37 @@
-import { Clock3, ListFilter, Search, SquareTerminal } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import type { InboxThread } from '../../../desktop/types'
+import {
+  BrushCleaning,
+  Check,
+  Clock3,
+  Inbox,
+  ListFilter,
+  Mail,
+  Search,
+  SquareTerminal,
+  X,
+} from 'lucide-react'
+import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react'
+import type { DesktopActionInvoker, InboxThread } from '../../../desktop/types'
+import { useDismissibleLayer } from '../../../hooks/useDismissibleLayer'
 import { EmptyStateCard } from '../../common/empty-state-card'
 import { IconButton } from '../../common/icon-button'
+import { SurfacePanel } from '../../common/surface-panel'
 import { InboxThreadRow } from './inbox-thread-row'
+
+type InboxFilterMode = 'all' | 'terminal' | 'recent'
 
 type SidebarInboxSectionProps = {
   appLaunchedAtMs: number
   terminalRunningSessionPaths: ReadonlySet<string>
   threads: InboxThread[]
   selectedSessionPath: string | null
+  onAction: DesktopActionInvoker
   onDismissThread: (thread: InboxThread) => void
   onSelectThread: (thread: InboxThread) => void
 }
 
-function getNextInboxFilterMode(current: 'all' | 'terminal' | 'recent') {
-  if (current === 'all') return 'terminal'
-  return current === 'terminal' ? 'recent' : 'all'
-}
-
 function matchesInboxFilter(
   thread: InboxThread,
-  filterMode: 'all' | 'terminal' | 'recent',
+  filterMode: InboxFilterMode,
   terminalRunningSessionPaths: ReadonlySet<string>,
   appLaunchedAtMs: number,
 ) {
@@ -37,17 +47,17 @@ function matchesInboxSearch(thread: InboxThread, normalizedQuery: string) {
     .includes(normalizedQuery)
 }
 
-function getInboxFilterIcon(filterMode: 'all' | 'terminal' | 'recent') {
+function getInboxFilterIcon(filterMode: InboxFilterMode) {
   if (filterMode === 'terminal') return <SquareTerminal size={15} />
   return filterMode === 'recent' ? <Clock3 size={15} /> : <ListFilter size={15} />
 }
 
-function getInboxFilterLabel(filterMode: 'all' | 'terminal' | 'recent') {
+function getInboxFilterLabel(filterMode: InboxFilterMode) {
   if (filterMode === 'terminal') return 'Show inbox threads with terminals'
   return filterMode === 'recent' ? 'Show inbox threads active since launch' : 'Filter inbox threads'
 }
 
-function getEmptyInboxMessage(showUnreadOnly: boolean, filterMode: 'all' | 'terminal' | 'recent') {
+function getEmptyInboxMessage(showUnreadOnly: boolean, filterMode: InboxFilterMode) {
   if (showUnreadOnly) return 'No unread threads right now.'
   if (filterMode === 'terminal') return 'No inbox threads have a running terminal.'
   return filterMode === 'recent'
@@ -55,19 +65,135 @@ function getEmptyInboxMessage(showUnreadOnly: boolean, filterMode: 'all' | 'term
     : 'Nothing to catch up on yet.'
 }
 
+const inboxFilterItems: Array<{ id: InboxFilterMode; label: string; icon: ReactNode }> = [
+  { id: 'all', label: 'All', icon: <Inbox size={14} /> },
+  { id: 'terminal', label: 'Terminals', icon: <SquareTerminal size={14} /> },
+  { id: 'recent', label: 'Since launch', icon: <Clock3 size={14} /> },
+]
+
+const inboxClearItems: Array<{ label: string; olderThanDays: number | null }> = [
+  { label: 'Older than 1 day', olderThanDays: 1 },
+  { label: 'Older than 7 days', olderThanDays: 7 },
+  { label: 'Older than 30 days', olderThanDays: 30 },
+  { label: 'All read items', olderThanDays: null },
+]
+
+function SidebarInboxFilterMenu({
+  menuId,
+  filterMode,
+  panelRef,
+  onSelect,
+}: {
+  menuId: string
+  filterMode: InboxFilterMode
+  panelRef: React.RefObject<HTMLDivElement | null>
+  onSelect: (filterMode: InboxFilterMode) => void
+}) {
+  return (
+    <SurfacePanel
+      ref={panelRef}
+      id={menuId}
+      role="menu"
+      aria-label="Inbox filters"
+      data-open="true"
+      className="sidebar-popover-panel sidebar-filter-menu motion-popover"
+    >
+      {inboxFilterItems.map((item) => {
+        const selected = item.id === filterMode
+
+        return (
+          <button
+            key={item.id}
+            type="button"
+            role="menuitemradio"
+            aria-checked={selected}
+            className="sidebar-filter-option"
+            data-selected={selected ? 'true' : 'false'}
+            onClick={() => onSelect(item.id)}
+          >
+            <span className="sidebar-filter-option__check">
+              {selected ? <Check size={14} /> : null}
+            </span>
+            <span className="sidebar-filter-option__icon">{item.icon}</span>
+            <span className="truncate text-left">{item.label}</span>
+          </button>
+        )
+      })}
+    </SurfacePanel>
+  )
+}
+
+function SidebarInboxClearMenu({
+  menuId,
+  panelRef,
+  onSelect,
+}: {
+  menuId: string
+  panelRef: React.RefObject<HTMLDivElement | null>
+  onSelect: (olderThanDays: number | null) => void
+}) {
+  return (
+    <SurfacePanel
+      ref={panelRef}
+      id={menuId}
+      role="menu"
+      aria-label="Clear read inbox items"
+      data-open="true"
+      className="sidebar-popover-panel sidebar-filter-menu motion-popover"
+    >
+      {inboxClearItems.map((item) => (
+        <button
+          key={item.label}
+          type="button"
+          role="menuitem"
+          className="sidebar-filter-option sidebar-filter-option--compact"
+          onClick={() => onSelect(item.olderThanDays)}
+        >
+          <span className="truncate text-left">{item.label}</span>
+        </button>
+      ))}
+    </SurfacePanel>
+  )
+}
+
 export function SidebarInboxSection({
   appLaunchedAtMs,
   terminalRunningSessionPaths,
   threads,
   selectedSessionPath,
+  onAction,
   onDismissThread,
   onSelectThread,
 }: SidebarInboxSectionProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [showUnreadOnly, setShowUnreadOnly] = useState(false)
-  const [filterMode, setFilterMode] = useState<'all' | 'terminal' | 'recent'>('all')
+  const [clearOpen, setClearOpen] = useState(false)
+  const [filterMode, setFilterMode] = useState<InboxFilterMode>('all')
+  const [filterOpen, setFilterOpen] = useState(false)
+  const clearButtonRef = useRef<HTMLButtonElement>(null)
+  const clearPanelRef = useRef<HTMLDivElement>(null)
+  const filterButtonRef = useRef<HTMLButtonElement>(null)
+  const filterPanelRef = useRef<HTMLDivElement>(null)
 
-  const cycleFilterMode = () => setFilterMode(getNextInboxFilterMode)
+  const dismissClear = useCallback(() => {
+    setClearOpen(false)
+  }, [])
+
+  const dismissFilter = useCallback(() => {
+    setFilterOpen(false)
+  }, [])
+
+  useDismissibleLayer({
+    open: clearOpen,
+    onDismiss: dismissClear,
+    refs: [clearButtonRef, clearPanelRef],
+  })
+
+  useDismissibleLayer({
+    open: filterOpen,
+    onDismiss: dismissFilter,
+    refs: [filterButtonRef, filterPanelRef],
+  })
 
   const visibleThreads = useMemo(() => {
     const normalizedQuery = searchQuery.trim().toLowerCase()
@@ -92,7 +218,7 @@ export function SidebarInboxSection({
   return (
     <section className="sidebar-section">
       <div className="sidebar-toolbar">
-        <label
+        <div
           className="sidebar-search-field"
           data-active={searchQuery.trim().length > 0 ? 'true' : 'false'}
         >
@@ -100,28 +226,87 @@ export function SidebarInboxSection({
           <input
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape' || searchQuery.length === 0) return
+              event.preventDefault()
+              event.stopPropagation()
+              setSearchQuery('')
+            }}
             placeholder="Search inbox"
             className="sidebar-search-input"
             aria-label="Search inbox"
           />
-        </label>
+          {searchQuery.length > 0 ? (
+            <button
+              type="button"
+              className="sidebar-search-clear"
+              aria-label="Clear inbox search"
+              onClick={() => setSearchQuery('')}
+            >
+              <X size={13} />
+            </button>
+          ) : null}
+        </div>
 
         <div className="sidebar-action-group">
           <IconButton
+            ref={clearButtonRef}
+            label="Clear read items"
+            tooltipPlacement="right"
+            icon={<BrushCleaning size={15} />}
+            onClick={() => {
+              setFilterOpen(false)
+              setClearOpen((open) => !open)
+            }}
+            aria-haspopup="menu"
+            aria-expanded={clearOpen}
+            aria-controls="sidebar-inbox-clear-menu"
+          />
+          <IconButton
+            ref={filterButtonRef}
             label={filterLabel}
             tooltipPlacement="right"
             icon={filterIcon}
             active={filterMode !== 'all'}
-            onClick={cycleFilterMode}
+            onClick={() => {
+              setClearOpen(false)
+              setFilterOpen((open) => !open)
+            }}
+            aria-haspopup="menu"
+            aria-expanded={filterOpen}
+            aria-controls="sidebar-inbox-filter-menu"
           />
           <IconButton
             label="Show unread only"
             tooltipPlacement="right"
-            icon={<ListFilter size={15} />}
+            icon={<Mail size={15} />}
             active={showUnreadOnly}
             onClick={() => setShowUnreadOnly((current) => !current)}
           />
         </div>
+
+        {clearOpen ? (
+          <SidebarInboxClearMenu
+            menuId="sidebar-inbox-clear-menu"
+            panelRef={clearPanelRef}
+            onSelect={(olderThanDays) => {
+              setClearOpen(false)
+              void onAction('inbox.clear-read', { olderThanDays })
+            }}
+          />
+        ) : null}
+
+        {filterOpen ? (
+          <SidebarInboxFilterMenu
+            menuId="sidebar-inbox-filter-menu"
+            filterMode={filterMode}
+            panelRef={filterPanelRef}
+            onSelect={(nextFilterMode) => {
+              setFilterMode(nextFilterMode)
+              setFilterOpen(false)
+            }}
+          />
+        ) : null}
       </div>
 
       {visibleThreads.length > 0 ? (

--- a/src/app/components/sidebar/projects/sidebar-projects-section.tsx
+++ b/src/app/components/sidebar/projects/sidebar-projects-section.tsx
@@ -1,4 +1,13 @@
-import { Clock3, FolderPlus, Github, ListFilter, Search, SquareTerminal, Star } from 'lucide-react'
+import {
+  Clock3,
+  FolderPlus,
+  Github,
+  ListFilter,
+  Search,
+  SquareTerminal,
+  Star,
+  X,
+} from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { parseGitHubRepositoryUrl } from '../../../../../shared/github-repository-url'
 import type { AppSettings, DesktopActionInvoker } from '../../../desktop/types'
@@ -15,6 +24,7 @@ import {
   type SidebarProjectsFilterMode,
 } from './sidebar-projects.helpers'
 import { SidebarProjectsCreatePopover } from './sidebar-projects-create-popover'
+import { SidebarProjectsFilterMenu } from './sidebar-projects-filter-menu'
 import { getSidebarFolderProjectName } from './sidebar-projects-folder-browser'
 
 type PendingProject = {
@@ -252,6 +262,7 @@ export function SidebarProjectsSection({
   const showProjectCreate = activeView !== 'extensions' && activeView !== 'skills'
   const [searchQuery, setSearchQuery] = useState('')
   const [filterMode, setFilterMode] = useState<SidebarProjectsFilterMode>('all')
+  const [filterOpen, setFilterOpen] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
   const [projectNameDraft, setProjectNameDraft] = useState('')
   const [createBusy, setCreateBusy] = useState(false)
@@ -259,6 +270,8 @@ export function SidebarProjectsSection({
   const [createdProjectIds, setCreatedProjectIds] = useState<string[]>([])
   const [pendingProject, setPendingProject] = useState<PendingProject | null>(null)
   const desktopBridgeAvailable = useDesktopBridgeAvailable()
+  const filterButtonRef = useRef<HTMLButtonElement>(null)
+  const filterPanelRef = useRef<HTMLDivElement>(null)
   const createButtonRef = useRef<HTMLButtonElement>(null)
   const createPanelRef = useRef<HTMLDialogElement>(null)
 
@@ -319,33 +332,21 @@ export function SidebarProjectsSection({
     }
   }, [autoExpandedProjectIds, collapsedProjectIds, searchQuery])
 
-  const cycleFilterMode = () => {
-    setFilterMode((current) => {
-      if (current === 'all') {
-        return 'favourites'
-      }
-
-      if (current === 'favourites') {
-        return 'github'
-      }
-
-      if (current === 'github') {
-        return 'terminal'
-      }
-
-      if (current === 'terminal') {
-        return 'recent'
-      }
-
-      return 'all'
-    })
-  }
-
   const filterLabel = getSidebarProjectFilterLabel(filterMode)
+
+  const dismissFilter = useCallback(() => {
+    setFilterOpen(false)
+  }, [])
 
   const dismissCreate = useCallback(() => {
     setCreateOpen(false)
   }, [])
+
+  useDismissibleLayer({
+    open: filterOpen,
+    onDismiss: dismissFilter,
+    refs: [filterButtonRef, filterPanelRef],
+  })
 
   useDismissibleLayer({
     open: createOpen,
@@ -432,7 +433,7 @@ export function SidebarProjectsSection({
   return (
     <section className="sidebar-section">
       <div className="sidebar-toolbar">
-        <label
+        <div
           className="sidebar-search-field"
           data-active={searchQuery.trim().length > 0 ? 'true' : 'false'}
         >
@@ -440,19 +441,42 @@ export function SidebarProjectsSection({
           <input
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape' || searchQuery.length === 0) return
+              event.preventDefault()
+              event.stopPropagation()
+              setSearchQuery('')
+            }}
             placeholder="Search"
             className="sidebar-search-input"
             aria-label="Search projects"
           />
-        </label>
+          {searchQuery.length > 0 ? (
+            <button
+              type="button"
+              className="sidebar-search-clear"
+              aria-label="Clear project search"
+              onClick={() => setSearchQuery('')}
+            >
+              <X size={13} />
+            </button>
+          ) : null}
+        </div>
         {showProjects ? (
           <div className="sidebar-action-group">
             <IconButton
+              ref={filterButtonRef}
               label={filterLabel}
               tooltipPlacement="right"
-              onClick={cycleFilterMode}
+              onClick={() => {
+                setCreateOpen(false)
+                setFilterOpen((open) => !open)
+              }}
               icon={getSidebarProjectFilterIcon(filterMode)}
               active={filterMode !== 'all'}
+              aria-haspopup="menu"
+              aria-expanded={filterOpen}
+              aria-controls="sidebar-project-filter-menu"
             />
             {showProjectCreate ? (
               <IconButton
@@ -461,12 +485,26 @@ export function SidebarProjectsSection({
                 tooltipPlacement="right"
                 onClick={() => {
                   setCreateErrorMessage(null)
+                  setFilterOpen(false)
                   setCreateOpen(true)
                 }}
                 icon={<FolderPlus size={15} />}
               />
             ) : null}
           </div>
+        ) : null}
+
+        {filterOpen ? (
+          <SidebarProjectsFilterMenu
+            menuId="sidebar-project-filter-menu"
+            open={filterOpen}
+            filterMode={filterMode}
+            panelRef={filterPanelRef}
+            onSelect={(nextFilterMode) => {
+              setFilterMode(nextFilterMode)
+              setFilterOpen(false)
+            }}
+          />
         ) : null}
 
         {createOpen ? (

--- a/src/app/components/sidebar/sidebar.tsx
+++ b/src/app/components/sidebar/sidebar.tsx
@@ -144,6 +144,7 @@ function SidebarContent(props: SidebarProps) {
         terminalRunningSessionPaths={props.terminalRunningSessionPaths}
         threads={props.inboxThreads}
         selectedSessionPath={props.selectedInboxSessionPath}
+        onAction={props.onAction}
         onDismissThread={props.onDismissInboxThread}
         onSelectThread={props.onSelectInboxThread}
       />

--- a/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
+++ b/src/app/components/workspace/composer/composer-prompt-input-panel.tsx
@@ -21,7 +21,16 @@ import {
   getComposerSlashCommandOptionId,
 } from './useComposerSlashCommands'
 
-const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+let graphemeSegmenter: Intl.Segmenter | null = null
+
+function getTextSegments(value: string) {
+  if (!('Segmenter' in Intl)) {
+    return Array.from(value, (segment, index) => ({ index, segment }))
+  }
+
+  graphemeSegmenter ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+  return [...graphemeSegmenter.segment(value)]
+}
 
 function SlashCommandOption({
   command,
@@ -157,7 +166,7 @@ function handleDeleteTextKey(
   const textarea = event.currentTarget
   const selectionStart = textarea.selectionStart
   const selectionEnd = textarea.selectionEnd
-  const segments = [...graphemeSegmenter.segment(textarea.value)]
+  const segments = getTextSegments(textarea.value)
   const previousSegment = [...segments].reverse().find((segment) => segment.index < selectionStart)
   const nextSegment = segments.find((segment) => segment.index > selectionEnd)
   const deleteStart =

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -450,6 +450,7 @@ const workspaceActionHandlers = {
     activeView: 'code',
     terminalVisible: false,
     selectedProjectId: '',
+    selectedInboxSessionPath: null,
     selectedThreadId: null,
     selectedSessionPath: null,
     selectedDiffFilePath: null,

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -468,6 +468,10 @@
   background: rgba(255, 255, 255, 0.06);
 }
 
+.sidebar-filter-option--compact {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .sidebar-section {
   display: flex;
   min-height: 0;
@@ -537,6 +541,25 @@
 
 .sidebar-search-input::placeholder {
   color: var(--muted);
+}
+
+.sidebar-search-clear {
+  display: inline-flex;
+  height: 1.25rem;
+  width: 1.25rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: var(--muted);
+  transition:
+    background-color 150ms ease-out,
+    color 150ms ease-out;
+}
+
+.sidebar-search-clear:hover {
+  background: var(--surface-hover);
+  color: var(--text);
 }
 
 .sidebar-scroll-region {


### PR DESCRIPTION
## Summary
- add clear buttons and Escape-to-clear for sidebar project and inbox searches
- replace sidebar project/inbox filter cycling with dropdown menus
- add an inbox sweep menu for clearing read items older than 1/7/30 days or all read items

## Validation
- bun run ai:check
