### PR TITLE
Fix extension models in draft composer selection

### DIFF
--- a/desktop/runtime-host/live-runtime-service.ts
+++ b/desktop/runtime-host/live-runtime-service.ts
@@ -10,7 +10,6 @@ import type {
   ComposerThinkingLevel,
 } from '../../shared/desktop-contracts.ts'
 import { getDesktopWorkingDirectory } from '../../shared/desktop-working-directory.ts'
-import { normalizeModelRegistryContextWindows } from '../../shared/model-context-window-normalization.ts'
 import { createLocalThreadDraft, getPersistedSessionPath } from '../../shared/session-paths.ts'
 import { getPiModule } from '../pi-module.ts'
 import { discoverHeadlessAgentSessionResources } from '../runtime/agent-session-extensions.ts'
@@ -281,24 +280,35 @@ export async function setComposerModel(
 ) {
   const persistedSessionPath = getPersistedSessionPath(request.sessionPath)
   if (!persistedSessionPath) {
-    const { AuthStorage, ModelRegistry, SettingsManager, getAgentDir } = await getPiModule()
+    const { SettingsManager, getAgentDir } = await getPiModule()
     const cwd = request.projectId ?? getDesktopWorkingDirectory()
     const agentDir = getAgentDir()
-    const authStorage = AuthStorage.create()
-    const modelRegistry = normalizeModelRegistryContextWindows(
-      ModelRegistry.create(authStorage, `${agentDir}/models.json`),
-    )
-    const model = modelRegistry.find(provider, modelId)
-    if (!model) throw new Error(`Unknown Pi model: ${provider}/${modelId}`)
-    const currentComposer = await buildComposerStateSnapshot({ projectId: cwd, sessionPath: null })
-    const settingsManager = SettingsManager.create(cwd, agentDir)
-    settingsManager.setDefaultModelAndProvider(provider, modelId)
-    settingsManager.setDefaultThinkingLevel(
-      clampThinkingLevel(
-        currentComposer.currentThinkingLevel,
-        getAvailableThinkingLevelsForModel(model),
-      ),
-    )
+    const snapshot = await createComposerSnapshotSession({
+      ...request,
+      projectId: cwd,
+      sessionPath: null,
+    })
+
+    try {
+      const model = snapshot.session.modelRegistry.find(provider, modelId)
+      if (!model) throw new Error(`Unknown Pi model: ${provider}/${modelId}`)
+      const currentComposer = await buildComposerStateSnapshot({
+        ...request,
+        projectId: cwd,
+        sessionPath: null,
+      })
+      const settingsManager = SettingsManager.create(cwd, agentDir)
+      settingsManager.setDefaultModelAndProvider(provider, modelId)
+      settingsManager.setDefaultThinkingLevel(
+        clampThinkingLevel(
+          currentComposer.currentThinkingLevel,
+          getAvailableThinkingLevelsForModel(model),
+        ),
+      )
+    } finally {
+      snapshot.session.dispose()
+    }
+
     await emitComposerUpdate({ ...request, sessionPath: null })
     return { ok: true as const }
   }

--- a/desktop/runtime/composer-service.ts
+++ b/desktop/runtime/composer-service.ts
@@ -9,7 +9,6 @@ import type {
   ComposerThinkingLevel,
 } from '../../shared/desktop-contracts.ts'
 import { getDesktopWorkingDirectory } from '../../shared/desktop-working-directory.ts'
-import { normalizeModelRegistryContextWindows } from '../../shared/model-context-window-normalization.ts'
 import { createLocalThreadDraft, getPersistedSessionPath } from '../../shared/session-paths.ts'
 import { loadAppSettings } from '../app-settings/readers.ts'
 import { getPiModule } from '../pi-module.ts'
@@ -24,6 +23,7 @@ import {
   buildComposerState,
   buildComposerStateSnapshot,
   clampThinkingLevel,
+  createComposerSnapshotSession,
   getAvailableThinkingLevelsForModel,
 } from './composer-state.ts'
 import {
@@ -159,28 +159,43 @@ async function promptAndReturnAfterPreflight({
     })
 }
 
-async function setDraftComposerModel(cwd: string, provider: string, modelId: string) {
-  const { AuthStorage, ModelRegistry, SettingsManager, getAgentDir } = await getPiModule()
+async function setDraftComposerModel(
+  request: ComposerStateRequest,
+  cwd: string,
+  provider: string,
+  modelId: string,
+) {
+  const { SettingsManager, getAgentDir } = await getPiModule()
   const agentDir = getAgentDir()
-  const authStorage = AuthStorage.create()
-  const modelRegistry = normalizeModelRegistryContextWindows(
-    ModelRegistry.create(authStorage, `${agentDir}/models.json`),
-  )
-  const model = modelRegistry.find(provider, modelId)
+  const snapshot = await createComposerSnapshotSession({
+    ...request,
+    projectId: cwd,
+    sessionPath: null,
+  })
 
-  if (!model) {
-    throw new Error(`Unknown Pi model: ${provider}/${modelId}`)
+  try {
+    const model = snapshot.session.modelRegistry.find(provider, modelId)
+
+    if (!model) {
+      throw new Error(`Unknown Pi model: ${provider}/${modelId}`)
+    }
+
+    const currentComposer = await buildComposerStateSnapshot({
+      ...request,
+      projectId: cwd,
+      sessionPath: null,
+    })
+    const nextThinkingLevel = clampThinkingLevel(
+      currentComposer.currentThinkingLevel,
+      getAvailableThinkingLevelsForModel(model),
+    )
+    const settingsManager = SettingsManager.create(cwd, agentDir)
+
+    settingsManager.setDefaultModelAndProvider(provider, modelId)
+    settingsManager.setDefaultThinkingLevel(nextThinkingLevel)
+  } finally {
+    snapshot.session.dispose()
   }
-
-  const currentComposer = await buildComposerStateSnapshot({ projectId: cwd, sessionPath: null })
-  const nextThinkingLevel = clampThinkingLevel(
-    currentComposer.currentThinkingLevel,
-    getAvailableThinkingLevelsForModel(model),
-  )
-  const settingsManager = SettingsManager.create(cwd, agentDir)
-
-  settingsManager.setDefaultModelAndProvider(provider, modelId)
-  settingsManager.setDefaultThinkingLevel(nextThinkingLevel)
 }
 
 async function setDraftComposerThinkingLevel(cwd: string, level: ComposerThinkingLevel) {
@@ -223,6 +238,7 @@ export async function setComposerModel(
 
   if (!persistedSessionPath) {
     await setDraftComposerModel(
+      request,
       request.projectId ?? getDesktopWorkingDirectory(),
       provider,
       modelId,

--- a/src/app/views/settings-view.tsx
+++ b/src/app/views/settings-view.tsx
@@ -181,14 +181,12 @@ export function SettingsView({
 
     dirtyPiSettingsRef.current.clear()
     const snapshot = draftPiSettingsRef.current
-    await Promise.all(
-      dirtyKeys.map((key) =>
-        onAction('pi-settings.update', {
-          piSettingsKey: key,
-          value: snapshot[key],
-        }),
-      ),
-    )
+    for (const key of dirtyKeys) {
+      await onAction('pi-settings.update', {
+        piSettingsKey: key,
+        value: snapshot[key],
+      })
+    }
   }, [onAction])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Validate draft composer model selections against an extension-initialized Pi snapshot session instead of a bare `ModelRegistry`.
- Preserve extension-registered providers/models, such as dynamic LM Studio/backyard providers, when selecting a default model before a persisted session exists.
- Apply the same fix to both desktop runtime service paths.

## Validation
- `bun run ai:check`
- pre-push hook ran `bun run ai:check`

## Review notes
- Reviewed `/review` findings from the broader base diff; none applied to this PR's touched files or extension-model scope, so no unrelated updater/settings/thread cleanup was included.
