### PR TITLE
Fix new project sidebar ordering

### DIFF
--- a/desktop/project-create.test.ts
+++ b/desktop/project-create.test.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callOrder: string[] = []
+const startNewThreadMock = vi.fn(async (request: { projectId?: string }) => {
+  callOrder.push(`start:${request.projectId ?? ''}`)
+  return {
+    projectId: request.projectId,
+    sessionPath: `${request.projectId ?? 'missing'}/.pi/sessions/draft.jsonl`,
+    threadId: 'draft-thread',
+  }
+})
+const ensureProjectMock = vi.fn((projectId: string) => {
+  callOrder.push(`ensure:${projectId}`)
+})
+const moveProjectToTopMock = vi.fn((projectId: string) => {
+  callOrder.push(`top:${projectId}`)
+})
+const deleteProjectMock = vi.fn((projectId: string) => {
+  callOrder.push(`delete:${projectId}`)
+})
+const hasProjectMock = vi.fn(() => false)
+const setProjectRepoOriginMock = vi.fn()
+
+vi.mock('./pi-desktop-runtime.ts', () => ({
+  startNewThread: startNewThreadMock,
+}))
+
+vi.mock('./thread-state-db.ts', () => ({
+  deleteProject: deleteProjectMock,
+  ensureProject: ensureProjectMock,
+  hasProject: hasProjectMock,
+  listProjects: vi.fn(() => []),
+  moveProjectToTop: moveProjectToTopMock,
+  setProjectRepoOrigin: setProjectRepoOriginMock,
+}))
+
+describe('project creation', () => {
+  let workspacePath: string
+
+  beforeEach(async () => {
+    callOrder.length = 0
+    startNewThreadMock.mockClear()
+    deleteProjectMock.mockClear()
+    hasProjectMock.mockClear()
+    hasProjectMock.mockReturnValue(false)
+    ensureProjectMock.mockClear()
+    moveProjectToTopMock.mockClear()
+    setProjectRepoOriginMock.mockClear()
+    workspacePath = await mkdtemp(path.join(os.tmpdir(), 'howcode-project-create-workspace-'))
+  })
+
+  afterEach(async () => {
+    await rm(workspacePath, { recursive: true, force: true })
+  })
+
+  it('creates and orders a plain new project before starting its draft thread', async () => {
+    const { createProject } = await import('./project-create.ts')
+
+    const result = await createProject({
+      preferredProjectLocation: workspacePath,
+      projectName: 'Fresh Project',
+      initializeGit: false,
+    })
+
+    const projectPath = path.join(workspacePath, 'Fresh Project')
+    expect(result.projectId).toBe(projectPath)
+    expect(callOrder).toEqual([
+      `ensure:${projectPath}`,
+      `top:${projectPath}`,
+      `start:${projectPath}`,
+    ])
+  })
+
+  it('adds and orders a folder project before starting its draft thread', async () => {
+    const { addProjectFromPath } = await import('./project-create.ts')
+    const projectPath = path.join(workspacePath, 'existing-project')
+
+    const result = await addProjectFromPath({
+      projectPath,
+      createIfMissing: true,
+      initializeGit: false,
+    })
+
+    expect(result.projectId).toBe(projectPath)
+    expect(callOrder).toEqual([
+      `ensure:${projectPath}`,
+      `top:${projectPath}`,
+      `start:${projectPath}`,
+    ])
+  })
+
+  it('removes the newly-created project row if draft thread startup fails', async () => {
+    const { createProject } = await import('./project-create.ts')
+    const brokenProjectPath = path.join(workspacePath, 'Broken Project')
+    startNewThreadMock.mockImplementationOnce(async (request: { projectId?: string }) => {
+      callOrder.push(`start:${request.projectId ?? ''}`)
+      throw new Error('runtime failed')
+    })
+
+    await expect(
+      createProject({
+        preferredProjectLocation: workspacePath,
+        projectName: 'Broken Project',
+        initializeGit: false,
+      }),
+    ).rejects.toThrow('runtime failed')
+
+    expect(callOrder).toEqual([
+      `ensure:${brokenProjectPath}`,
+      `top:${brokenProjectPath}`,
+      `start:${brokenProjectPath}`,
+      `delete:${brokenProjectPath}`,
+    ])
+  })
+})

--- a/desktop/project-create.ts
+++ b/desktop/project-create.ts
@@ -12,13 +12,31 @@ import { formatGitCommandError, getNonInteractiveGitEnv } from './project-git/gi
 import { getOriginUrl, isGitRepository } from './project-git/project-state.ts'
 import { initializeProjectGit } from './project-git.ts'
 import {
+  deleteProject,
   ensureProject,
+  hasProject,
   listProjects,
   moveProjectToTop,
   setProjectRepoOrigin,
 } from './thread-state-db.ts'
 
 const execFile = promisify(execFileCallback)
+
+async function startThreadForNewlyVisibleProject(projectId: string) {
+  const hadVisibleProject = hasProject(projectId)
+  ensureProject(projectId)
+  moveProjectToTop(projectId)
+
+  try {
+    return await startNewThread({ projectId })
+  } catch (error) {
+    if (!hadVisibleProject) {
+      deleteProject(projectId)
+    }
+
+    throw error
+  }
+}
 
 function sanitizeProjectFolderName(projectName: string) {
   let nextName = projectName
@@ -59,8 +77,7 @@ export async function createProject(options: {
     await initializeProjectGit(projectPath)
   }
 
-  const result = await startNewThread({ projectId: projectPath })
-  moveProjectToTop(projectPath)
+  const result = await startThreadForNewlyVisibleProject(projectPath)
   return result
 }
 
@@ -90,8 +107,7 @@ export async function addProjectFromPath(options: {
     await initializeProjectGit(resolvedProjectPath)
   }
 
-  const result = await startNewThread({ projectId: resolvedProjectPath })
-  moveProjectToTop(resolvedProjectPath)
+  const result = await startThreadForNewlyVisibleProject(resolvedProjectPath)
   return result
 }
 
@@ -210,9 +226,7 @@ export async function createProjectFromGitHubUrl(options: {
     throw new Error(`Unable to clone ${repository.canonicalUrl}: ${formatGitCommandError(error)}`)
   }
 
-  const result = await startNewThread({ projectId: projectPath })
-  ensureProject(projectPath)
+  const result = await startThreadForNewlyVisibleProject(projectPath)
   setProjectRepoOrigin(projectPath, repository.canonicalUrl)
-  moveProjectToTop(projectPath)
   return result
 }


### PR DESCRIPTION
## Summary
- Ensure newly-created or added projects are inserted into the desktop project DB before starting the draft thread.
- Move new projects to the top only after the project row exists, preventing the order update from becoming a no-op.
- Add regression coverage for plain project creation and folder add ordering.

## Validation
- `bun run ai:check`
