### PR TITLE
Fix updater migration and review follow-ups

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,4 @@
+- Pages deploys from `main` only. Do not suggest adding `dev` unless the release flow changes.
+- PRs to `dev` should validate release artifacts, but only `push`/tag/manual runs publish or upload release assets.
+- `package.json` and `packages/howcode/package.json` do not have to match. Root tracks app artifacts; `packages/howcode` tracks the npm launcher only.
+- The launcher should keep picking up current `main`/`dev` channel assets without an npm publish unless launcher code changes.

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -4,6 +4,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
+  pull_request:
+    branches:
+      - dev
   push:
     branches:
       - dev

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ artifacts/
 coverage/
 
 .pi/semantic-grep.sqlite
+.pi/semantic-grep.json
+.pi/semantic-grep.sync-conflict-*.sqlite
 
 .pi/semantic-grep.sqlite-shm
 .pi/semantic-grep.sqlite-wal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 
 ## Code Quality
 - Run `bun run ai:check` after meaningful code, config, packaging, or behavior changes.
+- Do not run `bun run ai:check` for docs-only or AGENTS.md-only edits unless they change commands, configuration, packaging, workflow behavior, or explicit validation instructions.
 - Run `bun run ai:check` frequently while working on code and before considering substantive implementation work complete.
 - If you touch a subsystem with its own fast deterministic tests, run those too.
 - Do not consider substantive implementation work complete while `ai:check` is failing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
 ## Stack
 - Use Bun for installs and scripts; keep the app runtime on Node.js/Electron.
-- Biome for formatting, linting, and import organization.
-- `tsgo --noEmit` via `@typescript/native-preview` for type checking.
-- `bun run ai:check` is the repo-wide verification command.
+- `bun run ai:check` is the repo-wide verification command; do not run standalone formatting or typechecking commands.
 
 ## Code Quality
 - Run `bun run ai:check` after meaningful code, config, packaging, or behavior changes.

--- a/desktop/pi-threads/thread-actions.ts
+++ b/desktop/pi-threads/thread-actions.ts
@@ -141,7 +141,8 @@ const threadActionHandlers = {
   },
   'inbox.clear-read': (payload) => {
     const olderThanDays = typeof payload.olderThanDays === 'number' ? payload.olderThanDays : null
-    const olderThanMs = olderThanDays ? Date.now() - olderThanDays * 24 * 60 * 60 * 1000 : null
+    const olderThanMs =
+      olderThanDays === null ? null : Date.now() - olderThanDays * 24 * 60 * 60 * 1000
     return handledAction({ clearedCount: clearReadInboxThreads(olderThanMs) })
   },
 } satisfies Partial<Record<DesktopAction, ThreadActionHandler>>

--- a/desktop/pi-threads/thread-actions.ts
+++ b/desktop/pi-threads/thread-actions.ts
@@ -140,7 +140,10 @@ const threadActionHandlers = {
     return handledAction()
   },
   'inbox.clear-read': (payload) => {
-    const olderThanDays = typeof payload.olderThanDays === 'number' ? payload.olderThanDays : null
+    const olderThanDays =
+      typeof payload.olderThanDays === 'number' && Number.isFinite(payload.olderThanDays)
+        ? Math.max(0, payload.olderThanDays)
+        : null
     const olderThanMs =
       olderThanDays === null ? null : Date.now() - olderThanDays * 24 * 60 * 60 * 1000
     return handledAction({ clearedCount: clearReadInboxThreads(olderThanMs) })

--- a/desktop/project-create.test.ts
+++ b/desktop/project-create.test.ts
@@ -18,10 +18,6 @@ const ensureProjectMock = vi.fn((projectId: string) => {
 const moveProjectToTopMock = vi.fn((projectId: string) => {
   callOrder.push(`top:${projectId}`)
 })
-const deleteProjectMock = vi.fn((projectId: string) => {
-  callOrder.push(`delete:${projectId}`)
-})
-const hasProjectMock = vi.fn(() => false)
 const setProjectRepoOriginMock = vi.fn()
 
 vi.mock('./pi-desktop-runtime.ts', () => ({
@@ -29,9 +25,7 @@ vi.mock('./pi-desktop-runtime.ts', () => ({
 }))
 
 vi.mock('./thread-state-db.ts', () => ({
-  deleteProject: deleteProjectMock,
   ensureProject: ensureProjectMock,
-  hasProject: hasProjectMock,
   listProjects: vi.fn(() => []),
   moveProjectToTop: moveProjectToTopMock,
   setProjectRepoOrigin: setProjectRepoOriginMock,
@@ -43,9 +37,6 @@ describe('project creation', () => {
   beforeEach(async () => {
     callOrder.length = 0
     startNewThreadMock.mockClear()
-    deleteProjectMock.mockClear()
-    hasProjectMock.mockClear()
-    hasProjectMock.mockReturnValue(false)
     ensureProjectMock.mockClear()
     moveProjectToTopMock.mockClear()
     setProjectRepoOriginMock.mockClear()
@@ -56,7 +47,7 @@ describe('project creation', () => {
     await rm(workspacePath, { recursive: true, force: true })
   })
 
-  it('creates and orders a plain new project before starting its draft thread', async () => {
+  it('creates and orders a plain new project after starting its draft thread', async () => {
     const { createProject } = await import('./project-create.ts')
 
     const result = await createProject({
@@ -68,13 +59,13 @@ describe('project creation', () => {
     const projectPath = path.join(workspacePath, 'Fresh Project')
     expect(result.projectId).toBe(projectPath)
     expect(callOrder).toEqual([
+      `start:${projectPath}`,
       `ensure:${projectPath}`,
       `top:${projectPath}`,
-      `start:${projectPath}`,
     ])
   })
 
-  it('adds and orders a folder project before starting its draft thread', async () => {
+  it('adds and orders a folder project after starting its draft thread', async () => {
     const { addProjectFromPath } = await import('./project-create.ts')
     const projectPath = path.join(workspacePath, 'existing-project')
 
@@ -86,13 +77,13 @@ describe('project creation', () => {
 
     expect(result.projectId).toBe(projectPath)
     expect(callOrder).toEqual([
+      `start:${projectPath}`,
       `ensure:${projectPath}`,
       `top:${projectPath}`,
-      `start:${projectPath}`,
     ])
   })
 
-  it('removes the newly-created project row if draft thread startup fails', async () => {
+  it('does not insert the project row if draft thread startup fails', async () => {
     const { createProject } = await import('./project-create.ts')
     const brokenProjectPath = path.join(workspacePath, 'Broken Project')
     startNewThreadMock.mockImplementationOnce(async (request: { projectId?: string }) => {
@@ -108,11 +99,6 @@ describe('project creation', () => {
       }),
     ).rejects.toThrow('runtime failed')
 
-    expect(callOrder).toEqual([
-      `ensure:${brokenProjectPath}`,
-      `top:${brokenProjectPath}`,
-      `start:${brokenProjectPath}`,
-      `delete:${brokenProjectPath}`,
-    ])
+    expect(callOrder).toEqual([`start:${brokenProjectPath}`])
   })
 })

--- a/desktop/project-create.ts
+++ b/desktop/project-create.ts
@@ -12,9 +12,7 @@ import { formatGitCommandError, getNonInteractiveGitEnv } from './project-git/gi
 import { getOriginUrl, isGitRepository } from './project-git/project-state.ts'
 import { initializeProjectGit } from './project-git.ts'
 import {
-  deleteProject,
   ensureProject,
-  hasProject,
   listProjects,
   moveProjectToTop,
   setProjectRepoOrigin,
@@ -23,19 +21,10 @@ import {
 const execFile = promisify(execFileCallback)
 
 async function startThreadForNewlyVisibleProject(projectId: string) {
-  const hadVisibleProject = hasProject(projectId)
+  const result = await startNewThread({ projectId })
   ensureProject(projectId)
   moveProjectToTop(projectId)
-
-  try {
-    return await startNewThread({ projectId })
-  } catch (error) {
-    if (!hadVisibleProject) {
-      deleteProject(projectId)
-    }
-
-    throw error
-  }
+  return result
 }
 
 function sanitizeProjectFolderName(projectName: string) {

--- a/desktop/thread-state-db/inbox-writes.ts
+++ b/desktop/thread-state-db/inbox-writes.ts
@@ -79,8 +79,16 @@ export function dismissInboxThread(sessionPath: string) {
 export function clearReadInboxThreads(olderThanMs: number | null = null) {
   const db = getThreadStateDatabase()
   const result = (
-    olderThanMs
+    olderThanMs === null
       ? db
+          .prepare(
+            `
+            DELETE FROM inbox_items
+            WHERE unread = 0
+          `,
+          )
+          .run()
+      : db
           .prepare(
             `
             DELETE FROM inbox_items
@@ -94,14 +102,6 @@ export function clearReadInboxThreads(olderThanMs: number | null = null) {
           `,
           )
           .run(olderThanMs)
-      : db
-          .prepare(
-            `
-            DELETE FROM inbox_items
-            WHERE unread = 0
-          `,
-          )
-          .run()
   ) as { changes: number }
 
   return result.changes

--- a/src/app/app-shell/useDesktopActionHandlers.ts
+++ b/src/app/app-shell/useDesktopActionHandlers.ts
@@ -168,7 +168,8 @@ export function useDesktopActionHandlers({
 
       if (
         action === 'settings.update' &&
-        contextualPayload.key === 'devUpdateBranch' &&
+        (contextualPayload.key === 'devUpdateBranch' ||
+          contextualPayload.key === 'betaUpdateBranch') &&
         !actionErrorMessage
       ) {
         void checkAppUpdateQuery()

--- a/src/electron/main/updater/app-updater.ts
+++ b/src/electron/main/updater/app-updater.ts
@@ -28,6 +28,7 @@ const channelReleaseKeyPattern = /^(main|dev)-(\d+\.\d+\.\d+)-([a-f0-9]{64})$/i
 const legacyReleaseKeyPattern = /^(\d+\.\d+\.\d+)-([a-f0-9]{64})$/i
 const trailingSlashesPattern = /\/+$/
 const trailingChannelPattern = /\/(?:main|dev)$/i
+const channelPlaceholderPattern = /\{channel\}/g
 
 type UpdateTarget = {
   os: 'macos' | 'linux' | 'win'
@@ -94,8 +95,10 @@ function getReleaseBaseUrl(channel: UpdateChannel) {
   if (!RELEASE_BASE_URL) return `${DEFAULT_RELEASE_BASE_URL}/${channel}`
 
   const baseUrl = RELEASE_BASE_URL.replace(trailingSlashesPattern, '')
+  if (baseUrl.includes('{channel}')) return baseUrl.replace(channelPlaceholderPattern, channel)
+
   const channelBaseUrl = baseUrl.replace(trailingChannelPattern, `/${channel}`)
-  return channelBaseUrl === baseUrl ? `${baseUrl}/${channel}` : channelBaseUrl
+  return channelBaseUrl
 }
 
 function getReleaseKey(release: Pick<ReleaseInfo, 'channel' | 'version' | 'hash'>) {
@@ -619,7 +622,7 @@ export class AppUpdater {
       return false
     }
 
-    return release.channel === 'dev'
+    return true
   }
 
   private async getPruneKeepDirs(installDir: string) {

--- a/src/electron/main/updater/app-updater.ts
+++ b/src/electron/main/updater/app-updater.ts
@@ -26,6 +26,8 @@ const semverPattern = /^\d+\.\d+\.\d+$/
 const sha256Pattern = /^[a-f0-9]{64}$/i
 const channelReleaseKeyPattern = /^(main|dev)-(\d+\.\d+\.\d+)-([a-f0-9]{64})$/i
 const legacyReleaseKeyPattern = /^(\d+\.\d+\.\d+)-([a-f0-9]{64})$/i
+const trailingSlashesPattern = /\/+$/
+const trailingChannelPattern = /\/(?:main|dev)$/i
 
 type UpdateTarget = {
   os: 'macos' | 'linux' | 'win'
@@ -89,7 +91,11 @@ function getCacheRoot() {
 }
 
 function getReleaseBaseUrl(channel: UpdateChannel) {
-  return RELEASE_BASE_URL ?? `${DEFAULT_RELEASE_BASE_URL}/${channel}`
+  if (!RELEASE_BASE_URL) return `${DEFAULT_RELEASE_BASE_URL}/${channel}`
+
+  const baseUrl = RELEASE_BASE_URL.replace(trailingSlashesPattern, '')
+  const channelBaseUrl = baseUrl.replace(trailingChannelPattern, `/${channel}`)
+  return channelBaseUrl === baseUrl ? `${baseUrl}/${channel}` : channelBaseUrl
 }
 
 function getReleaseKey(release: Pick<ReleaseInfo, 'channel' | 'version' | 'hash'>) {
@@ -103,6 +109,22 @@ function getInstallPaths(target: UpdateTarget, release: ReleaseInfo) {
   return {
     cacheRoot,
     currentFile: path.join(cacheRoot, `current-${release.channel}.json`),
+    installDir,
+    executablePath: path.join(installDir, target.executable),
+  }
+}
+
+function getLegacyCurrentFile() {
+  return path.join(getCacheRoot(), 'current.json')
+}
+
+function getLegacyInstallPaths(target: UpdateTarget, release: ReleaseInfo) {
+  const cacheRoot = getCacheRoot()
+  const releaseKey = `${release.version}-${release.hash}`
+  const installDir = path.join(cacheRoot, 'versions', releaseKey)
+  return {
+    cacheRoot,
+    currentFile: getLegacyCurrentFile(),
     installDir,
     executablePath: path.join(installDir, target.executable),
   }
@@ -235,9 +257,12 @@ async function sha256File(filePath: string) {
   return hash.digest('hex')
 }
 
-function parseInstalledUpdateRecord(record: unknown): InstalledUpdate | null {
+function parseInstalledUpdateRecord(
+  record: unknown,
+  fallbackChannel: UpdateChannel | null = null,
+): InstalledUpdate | null {
   if (!record || typeof record !== 'object') return null
-  const channel = 'channel' in record ? record.channel : null
+  const channel = 'channel' in record ? record.channel : fallbackChannel
   const version = 'version' in record ? record.version : null
   const hash = 'hash' in record ? record.hash : null
   const installDir = 'installDir' in record ? record.installDir : null
@@ -254,6 +279,23 @@ function parseInstalledUpdateRecord(record: unknown): InstalledUpdate | null {
     return null
   }
   return { channel, version, hash: hash.toLowerCase(), installDir, executablePath, assetUrl: '' }
+}
+
+function writeInstalledUpdateRecord(currentFile: string, record: InstalledUpdate) {
+  return writeFile(
+    currentFile,
+    JSON.stringify(
+      {
+        version: record.version,
+        channel: record.channel,
+        hash: record.hash,
+        installDir: record.installDir,
+        executablePath: record.executablePath,
+      },
+      null,
+      2,
+    ),
+  )
 }
 
 async function isExecutableFile(filePath: string) {
@@ -486,25 +528,12 @@ export class AppUpdater {
         tempRoot = null
       }
 
-      await writeFile(
-        paths.currentFile,
-        JSON.stringify(
-          {
-            version: release.version,
-            channel: release.channel,
-            hash: release.hash,
-            installDir: paths.installDir,
-            executablePath: paths.executablePath,
-          },
-          null,
-          2,
-        ),
-      )
       this.installedUpdate = {
         ...release,
         executablePath: paths.executablePath,
         installDir: paths.installDir,
       }
+      await writeInstalledUpdateRecord(paths.currentFile, this.installedUpdate)
       await pruneOldVersions(paths.cacheRoot, await this.getPruneKeepDirs(paths.installDir))
       this.setState({
         status: 'ready',
@@ -544,21 +573,34 @@ export class AppUpdater {
   private async readInstalledUpdate() {
     if (!isUpdateEnabled()) return
     this.installedUpdate = null
-    const record = await this.readCurrentFile(
-      path.join(getCacheRoot(), `current-${await this.getUpdateChannel()}.json`),
-    )
+    const channel = await this.getUpdateChannel()
+    const currentFile = path.join(getCacheRoot(), `current-${channel}.json`)
+    const record =
+      (await this.readCurrentFile(currentFile)) ??
+      (await this.readCurrentFile(getLegacyCurrentFile(), channel))
     if (!(record && this.isUpdateCandidate(record))) return
     const target = getTarget()
     const expectedPaths = getInstallPaths(target, record)
+    const legacyPaths = getLegacyInstallPaths(target, record)
     if (
-      record.installDir !== expectedPaths.installDir ||
-      record.executablePath !== expectedPaths.executablePath
+      !(
+        (record.installDir === expectedPaths.installDir &&
+          record.executablePath === expectedPaths.executablePath) ||
+        (record.installDir === legacyPaths.installDir &&
+          record.executablePath === legacyPaths.executablePath)
+      )
     ) {
       return
     }
-    if (!(await isValidInstall(expectedPaths, target))) return
+    const paths = record.installDir === legacyPaths.installDir ? legacyPaths : expectedPaths
+    if (!(await isValidInstall(paths, target))) return
     this.installedUpdate = record
     this.latestRelease = record
+    if (paths.currentFile === getLegacyCurrentFile()) {
+      await writeInstalledUpdateRecord(currentFile, record).catch(() => {
+        // Preserve restart capability even if best-effort migration fails.
+      })
+    }
     this.setState({
       status: 'ready',
       latestVersion: record.version,
@@ -593,9 +635,12 @@ export class AppUpdater {
     return keepDirs
   }
 
-  private async readCurrentFile(currentFile: string) {
+  private async readCurrentFile(currentFile: string, fallbackChannel: UpdateChannel | null = null) {
     try {
-      return parseInstalledUpdateRecord(JSON.parse(await readFile(currentFile, 'utf8')))
+      return parseInstalledUpdateRecord(
+        JSON.parse(await readFile(currentFile, 'utf8')),
+        fallbackChannel,
+      )
     } catch {
       return null
     }


### PR DESCRIPTION
## Summary
- Preserve legacy cached app-update records while migrating to channel-specific cache files.
- Make custom updater base URLs respect `main`/`dev` channel selection.
- Avoid inserting/reordering project rows until draft thread creation succeeds.
- Fix small legacy edge cases for inbox clearing and update-branch refresh.
- Document workflow/release conventions and ignore semantic-grep cache files.

## Validation
- `bun run ai:check`
- `bun test desktop/project-create.test.ts`

## Notes
- Pages deploys from `main` only by design.
- Root `package.json` and `packages/howcode/package.json` intentionally do not have to match: root tracks app artifacts, `packages/howcode` tracks the npm launcher.
