### PR TITLE
Fix composer controls and release channel tags

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,4 +1,4 @@
 - Pages deploys from `main` only. Do not suggest adding `dev` unless the release flow changes.
-- PRs to `dev` should validate release artifacts, but only `push`/tag/manual runs publish or upload release assets.
+- PRs to `dev` must not build release artifacts. Only `push`/tag/manual runs build, publish, or upload release assets.
 - `package.json` and `packages/howcode/package.json` do not have to match. Root tracks app artifacts; `packages/howcode` tracks the npm launcher only.
 - The launcher should keep picking up current `main`/`dev` channel assets without an npm publish unless launcher code changes.

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -4,9 +4,6 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
-  pull_request:
-    branches:
-      - dev
   push:
     branches:
       - dev

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -249,6 +249,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CHANNEL: ${{ github.ref_name }}
         run: |
+          RELEASE_TAG="channel-$CHANNEL"
           mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
@@ -264,15 +265,15 @@ jobs:
 
           release_title=$(cat channel-release-title.txt)
 
-          if gh release view "$CHANNEL" >/dev/null 2>&1; then
-            mapfile -t old_assets < <(gh release view "$CHANNEL" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-.*\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-.*\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
             for old_asset in "${old_assets[@]}"; do
-              gh release delete-asset "$CHANNEL" "$old_asset" --yes
+              gh release delete-asset "$RELEASE_TAG" "$old_asset" --yes
             done
-            gh release upload "$CHANNEL" "${assets[@]}" --clobber
-            gh release edit "$CHANNEL" --title "$release_title" --notes-file channel-release-notes.md --target "$GITHUB_SHA" "${release_flags[@]}"
+            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+            gh release edit "$RELEASE_TAG" --title "$release_title" --notes-file channel-release-notes.md --target "$GITHUB_SHA" "${release_flags[@]}"
           else
-            gh release create "$CHANNEL" "${assets[@]}" --title "$release_title" --target "$GITHUB_SHA" --notes-file channel-release-notes.md "${release_flags[@]}"
+            gh release create "$RELEASE_TAG" "${assets[@]}" --title "$release_title" --target "$GITHUB_SHA" --notes-file channel-release-notes.md "${release_flags[@]}"
           fi
 
   publish-release:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -265,7 +265,7 @@ jobs:
           release_title=$(cat channel-release-title.txt)
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
+            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|archive-howcode-[^-]+-[^-]+-[a-f0-9]{64}\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
             for old_asset in "${old_assets[@]}"; do
               gh release delete-asset "$RELEASE_TAG" "$old_asset" --yes
             done

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -97,6 +97,8 @@ jobs:
           bun run build:release
 
       - name: Build launcher archives
+        env:
+          HOWCODE_RELEASE_ASSET_BASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_type == 'tag' && github.ref_name || format('channel-{0}', github.ref_name) }}
         run: bun run build:launcher-artifacts
 
       - name: Upload dev artifacts
@@ -263,7 +265,7 @@ jobs:
           release_title=$(cat channel-release-title.txt)
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-.*\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
+            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
             for old_asset in "${old_assets[@]}"; do
               gh release delete-asset "$RELEASE_TAG" "$old_asset" --yes
             done

--- a/desktop/terminal/manager.ts
+++ b/desktop/terminal/manager.ts
@@ -1,4 +1,4 @@
-import { rmSync } from 'node:fs'
+import { renameSync, rmSync } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { getPersistedSessionPath } from '../../shared/session-paths.ts'
 import type {
@@ -108,6 +108,67 @@ function ensureProcessStarted(record: TerminalSessionRecord, reason: 'started' |
   return record.restartPromise
 }
 
+function findUnboundProjectShellTerminal(request: TerminalOpenRequest) {
+  if (!request.sessionPath) {
+    return null
+  }
+
+  const cwd = request.cwd ?? request.projectId
+  return (
+    listTerminalSessions().find(
+      (record) =>
+        record.snapshot.projectId === request.projectId &&
+        record.snapshot.sessionPath === null &&
+        record.snapshot.cwd === cwd &&
+        record.snapshot.launchMode === (request.launchMode ?? 'shell'),
+    ) ?? null
+  )
+}
+
+function moveTranscript(fromPath: string, toPath: string) {
+  if (fromPath === toPath) {
+    return
+  }
+
+  try {
+    renameSync(fromPath, toPath)
+  } catch {
+    // The transcript may not have been flushed yet, or the target can already exist from a
+    // previous bound terminal. Keeping the live in-memory history is more important than failing
+    // the bind operation for best-effort persistence.
+  }
+}
+
+function bindProjectTerminalToSession(input: {
+  record: TerminalSessionRecord
+  request: TerminalOpenRequest
+  sessionId: string
+}) {
+  const previousSessionId = input.record.snapshot.sessionId
+  const nextTranscriptPath = getTranscriptPath(input.sessionId)
+
+  deleteTerminalSession(previousSessionId)
+  moveTranscript(input.record.transcriptPath, nextTranscriptPath)
+  input.record.transcriptPath = nextTranscriptPath
+  input.record.snapshot = {
+    ...input.record.snapshot,
+    sessionId: input.sessionId,
+    sessionPath: input.request.sessionPath ?? null,
+    cols: input.request.cols,
+    rows: input.request.rows,
+    updatedAt: nowIso(),
+  }
+  setTerminalSession(input.sessionId, input.record)
+  input.record.process?.resize(input.request.cols, input.request.rows)
+  emitTerminalEvent({
+    type: 'updated',
+    sessionId: input.sessionId,
+    snapshot: input.record.snapshot,
+    createdAt: nowIso(),
+  })
+  return input.record.snapshot
+}
+
 export async function openTerminal(request: TerminalOpenRequest): Promise<TerminalSessionSnapshot> {
   const cwd = request.cwd ?? request.projectId
   const sessionId = makeSessionId(request)
@@ -135,6 +196,15 @@ export async function openTerminal(request: TerminalOpenRequest): Promise<Termin
     }
 
     return existing.snapshot
+  }
+
+  const unboundProjectTerminal = findUnboundProjectShellTerminal(request)
+  if (unboundProjectTerminal) {
+    return bindProjectTerminalToSession({
+      record: unboundProjectTerminal,
+      request,
+      sessionId,
+    })
   }
 
   const history = readTranscript(getTranscriptPath(sessionId))

--- a/desktop/terminal/manager.ts
+++ b/desktop/terminal/manager.ts
@@ -200,11 +200,23 @@ export async function openTerminal(request: TerminalOpenRequest): Promise<Termin
 
   const unboundProjectTerminal = findUnboundProjectShellTerminal(request)
   if (unboundProjectTerminal) {
-    return bindProjectTerminalToSession({
+    const snapshot = bindProjectTerminalToSession({
       record: unboundProjectTerminal,
       request,
       sessionId,
     })
+    if (isRestartableTerminalStatus(unboundProjectTerminal.snapshot.status)) {
+      unboundProjectTerminal.snapshot = {
+        ...unboundProjectTerminal.snapshot,
+        status: 'starting',
+        exitCode: null,
+        exitSignal: null,
+        updatedAt: nowIso(),
+      }
+      void ensureProcessStarted(unboundProjectTerminal, 'restarted')
+      return unboundProjectTerminal.snapshot
+    }
+    return snapshot
   }
 
   const history = readTranscript(getTranscriptPath(sessionId))

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -12,6 +12,13 @@ const packageJson = require('../package.json')
 
 const APP_NAME = packageJson.howcode.appName
 const RELEASE_BASE_URL = process.env.HOWCODE_BASE_URL || packageJson.howcode.releaseBaseUrl
+const RELEASE_CHANNEL =
+  process.env.HOWCODE_RELEASE_CHANNEL || packageJson.howcode.releaseChannel || 'main'
+const CHANNEL_RELEASE_TAGS = { main: 'channel-main', dev: 'channel-dev' }
+const trailingSlashesPattern = /\/+$/
+const trailingChannelPattern = /\/(?:main|dev|channel-main|channel-dev)$/i
+const releaseTagPlaceholderPattern = /\{releaseTag\}/g
+const channelPlaceholderPattern = /\{channel\}/g
 const FETCH_METADATA_TIMEOUT_MS = 30_000
 const DOWNLOAD_IDLE_TIMEOUT_MS = 60_000
 
@@ -84,15 +91,35 @@ function getCacheRoot() {
   return path.join(process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'), APP_NAME)
 }
 
+function getReleaseChannel() {
+  if (RELEASE_CHANNEL === 'main' || RELEASE_CHANNEL === 'dev') return RELEASE_CHANNEL
+  throw new Error(`Unsupported release channel: ${RELEASE_CHANNEL}`)
+}
+
+function getChannelReleaseTag(channel) {
+  return CHANNEL_RELEASE_TAGS[channel]
+}
+
+function getReleaseBaseUrl(channel = getReleaseChannel()) {
+  const releaseTag = getChannelReleaseTag(channel)
+  const baseUrl = RELEASE_BASE_URL.replace(trailingSlashesPattern, '')
+
+  if (baseUrl.includes('{releaseTag}'))
+    return baseUrl.replace(releaseTagPlaceholderPattern, releaseTag)
+  if (baseUrl.includes('{channel}')) return baseUrl.replace(channelPlaceholderPattern, releaseTag)
+
+  return baseUrl.replace(trailingChannelPattern, `/${releaseTag}`)
+}
+
 function getPaths(target, releaseInfo) {
   const cacheRoot = getCacheRoot()
   const versionsRoot = path.join(cacheRoot, 'versions')
-  const releaseKey = `${releaseInfo.version}-${releaseInfo.hash}`
+  const releaseKey = `${releaseInfo.channel}-${releaseInfo.version}-${releaseInfo.hash}`
   const installDir = path.join(versionsRoot, releaseKey)
   const launcherWorkingDirectory = path.dirname(path.join(installDir, target.executable))
   return {
     cacheRoot,
-    currentFile: path.join(cacheRoot, 'current.json'),
+    currentFile: path.join(cacheRoot, `current-${releaseInfo.channel}.json`),
     windowsCommandFile: path.join(cacheRoot, `${APP_NAME}.cmd`),
     launcherWorkingDirectory,
     installDir,
@@ -344,16 +371,19 @@ async function sha256File(filePath) {
 }
 
 async function resolveLatestRelease(target) {
-  const updateUrl = `${RELEASE_BASE_URL}/stable-${target.os}-${target.arch}-update.json`
+  const channel = getReleaseChannel()
+  const releaseBaseUrl = getReleaseBaseUrl(channel)
+  const updateUrl = `${releaseBaseUrl}/stable-${target.os}-${target.arch}-update.json`
   const metadata = await fetchJson(updateUrl)
   if (!metadata || typeof metadata.version !== 'string' || typeof metadata.hash !== 'string') {
     throw new Error(`Invalid release metadata from ${updateUrl}`)
   }
 
   return {
+    channel,
     version: metadata.version,
     hash: metadata.hash,
-    assetUrl: `${RELEASE_BASE_URL}/${APP_NAME}-${target.os}-${target.arch}.tar.gz`,
+    assetUrl: `${releaseBaseUrl}/${APP_NAME}-${target.os}-${target.arch}.tar.gz`,
   }
 }
 
@@ -399,6 +429,7 @@ async function installRelease(target, releaseInfo, paths) {
     JSON.stringify(
       {
         version: releaseInfo.version,
+        channel: releaseInfo.channel,
         hash: releaseInfo.hash,
         installDir: paths.installDir,
         executablePath: paths.executablePath,
@@ -409,8 +440,22 @@ async function installRelease(target, releaseInfo, paths) {
   )
 }
 
+async function getPruneKeepDirs(cacheRoot, keepDir) {
+  const keepDirs = new Set([keepDir])
+
+  for (const channel of Object.keys(CHANNEL_RELEASE_TAGS)) {
+    const record = readJsonIfPresent(path.join(cacheRoot, `current-${channel}.json`))
+    if (record?.installDir) {
+      keepDirs.add(record.installDir)
+    }
+  }
+
+  return keepDirs
+}
+
 async function pruneOldVersions(cacheRoot, keepDir) {
   const versionsRoot = path.join(cacheRoot, 'versions')
+  const keepDirs = await getPruneKeepDirs(cacheRoot, keepDir)
   let entries = []
 
   try {
@@ -423,7 +468,7 @@ async function pruneOldVersions(cacheRoot, keepDir) {
     entries
       .filter((entry) => entry.isDirectory())
       .map((entry) => path.join(versionsRoot, entry.name))
-      .filter((dirPath) => dirPath !== keepDir)
+      .filter((dirPath) => !keepDirs.has(dirPath))
       .map((dirPath) => fsp.rm(dirPath, { recursive: true, force: true })),
   )
 }
@@ -456,7 +501,8 @@ async function main() {
   const cacheRoot = getCacheRoot()
   await fsp.mkdir(cacheRoot, { recursive: true })
 
-  const current = readJsonIfPresent(path.join(cacheRoot, 'current.json'))
+  const channel = getReleaseChannel()
+  const current = readJsonIfPresent(path.join(cacheRoot, `current-${channel}.json`))
 
   let releaseInfo = null
   try {
@@ -465,7 +511,7 @@ async function main() {
     if (current?.executablePath) {
       const currentPaths = {
         cacheRoot,
-        currentFile: path.join(cacheRoot, 'current.json'),
+        currentFile: path.join(cacheRoot, `current-${channel}.json`),
         windowsCommandFile: path.join(cacheRoot, `${APP_NAME}.cmd`),
         installDir: current.installDir || path.dirname(path.dirname(current.executablePath)),
         launcherWorkingDirectory: path.dirname(current.executablePath),

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -383,7 +383,10 @@ async function resolveLatestRelease(target) {
     channel,
     version: metadata.version,
     hash: metadata.hash,
-    assetUrl: `${releaseBaseUrl}/${APP_NAME}-${target.os}-${target.arch}.tar.gz`,
+    assetUrl:
+      typeof metadata.assetUrl === 'string' && metadata.assetUrl.length > 0
+        ? metadata.assetUrl
+        : `${releaseBaseUrl}/${APP_NAME}-${target.os}-${target.arch}.tar.gz`,
   }
 }
 

--- a/packages/howcode/package.json
+++ b/packages/howcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "howcode",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Desktop coding app for Pi with projects, terminal, git, and diff workflows.",
   "license": "MIT",
   "author": "Igor Warzocha",

--- a/packages/howcode/package.json
+++ b/packages/howcode/package.json
@@ -38,6 +38,7 @@
   ],
   "howcode": {
     "appName": "howcode",
-    "releaseBaseUrl": "https://github.com/IgorWarzocha/howcode/releases/download/main"
+    "releaseChannel": "main",
+    "releaseBaseUrl": "https://github.com/IgorWarzocha/howcode/releases/download/channel-main"
   }
 }

--- a/packages/howcode/package.json
+++ b/packages/howcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "howcode",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Desktop coding app for Pi with projects, terminal, git, and diff workflows.",
   "license": "MIT",
   "author": "Igor Warzocha",

--- a/scripts/package-launcher-artifacts.ts
+++ b/scripts/package-launcher-artifacts.ts
@@ -4,7 +4,7 @@ const linuxUnpackedDirectoryPattern = /linux.*unpacked$/i
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { existsSync, mkdirSync } from 'node:fs'
-import { cp, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { copyFile, cp, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -164,6 +164,12 @@ async function createUpdateMetadata(archivePath: string, target: Target, version
   const archiveBuffer = await readFile(archivePath)
   const hash = createHash('sha256').update(archiveBuffer).digest('hex')
   const metadataPath = path.join(artifactRoot, `stable-${target.os}-${target.arch}-update.json`)
+  const immutableArchivePath = path.join(
+    path.dirname(archivePath),
+    `archive-${appName}-${target.os}-${target.arch}-${hash}.tar.gz`,
+  )
+  await copyFile(archivePath, immutableArchivePath)
+  const assetBaseUrl = process.env['HOWCODE_RELEASE_ASSET_BASE_URL']
 
   await writeFile(
     metadataPath,
@@ -171,11 +177,16 @@ async function createUpdateMetadata(archivePath: string, target: Target, version
       {
         version,
         hash,
+        assetUrl: assetBaseUrl
+          ? `${assetBaseUrl}/${path.basename(immutableArchivePath)}`
+          : undefined,
       },
       null,
       2,
     ),
   )
+
+  return immutableArchivePath
 }
 
 async function main() {
@@ -186,8 +197,8 @@ async function main() {
   const target = getCurrentTarget()
   const bundlePath = await resolveBundlePath(target)
   const archivePath = await createNormalizedArchive(bundlePath, target)
-  await createUpdateMetadata(archivePath, target, packageJson.version)
-  console.log(`created ${path.relative(process.cwd(), archivePath)}`)
+  const immutableArchivePath = await createUpdateMetadata(archivePath, target, packageJson.version)
+  console.log(`created ${path.relative(process.cwd(), immutableArchivePath)}`)
 }
 
 void main().catch((error) => {

--- a/src/app/components/sidebar/project-tree.tsx
+++ b/src/app/components/sidebar/project-tree.tsx
@@ -217,6 +217,7 @@ export function ProjectTree({
                         isDragging={isDragging}
                         isEditing={editingProjectId === project.id}
                         isExpanded={effectiveIsExpanded}
+                        pinned={Boolean(project.pinned)}
                         hasRepoOrigin={Boolean(project.repoOriginUrl)}
                         canEdit={!selectionModeActive}
                         canToggleExpanded={!selectionModeActive}

--- a/src/app/components/sidebar/project-tree/project-row.tsx
+++ b/src/app/components/sidebar/project-tree/project-row.tsx
@@ -1,5 +1,5 @@
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core'
-import { ChevronDown, ChevronRight, Folder, Github, MoreHorizontal, Plus } from 'lucide-react'
+import { ChevronDown, ChevronRight, Folder, Github, MoreHorizontal, Plus, Star } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { compactIconButtonClass } from '../../../ui/classes'
 import { cn } from '../../../utils/cn'
@@ -19,6 +19,7 @@ type ProjectRowProps = {
   isActive: boolean
   isDragging: boolean
   isExpanded: boolean
+  pinned: boolean
   hasRepoOrigin: boolean
   name: string
   renameDraft: string
@@ -53,6 +54,7 @@ function ProjectRowName({
   onCancelEdit,
   onChangeRenameDraft,
   onSubmitEdit,
+  pinned,
   renameDraft,
 }: Pick<
   ProjectRowProps,
@@ -60,6 +62,7 @@ function ProjectRowName({
   | 'isActive'
   | 'isEditing'
   | 'name'
+  | 'pinned'
   | 'onCancelEdit'
   | 'onChangeRenameDraft'
   | 'onSubmitEdit'
@@ -110,6 +113,9 @@ function ProjectRowName({
       aria-current={isActive ? 'page' : undefined}
     >
       <span className="sidebar-project-title">{name}</span>
+      {pinned ? (
+        <Star size={12} className="sidebar-row-inline-icon sidebar-project-favourite-icon" />
+      ) : null}
     </button>
   )
 }
@@ -181,6 +187,7 @@ export function ProjectRow({
   isActive,
   isDragging,
   isExpanded,
+  pinned,
   hasRepoOrigin,
   name,
   renameDraft,
@@ -273,6 +280,7 @@ export function ProjectRow({
         isActive={isActive}
         isEditing={isEditing}
         name={name}
+        pinned={pinned}
         onCancelEdit={onCancelEdit}
         onChangeRenameDraft={onChangeRenameDraft}
         onSubmitEdit={onSubmitEdit}

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -79,7 +79,7 @@ function ComposerResponsivePlaceholder({
       aria-hidden="true"
       className={cn(
         'pointer-events-none absolute inset-x-0 top-0 min-w-0 truncate text-[14px] leading-[1.45]',
-        leadingAdornmentVisible && 'pl-7',
+        leadingAdornmentVisible && 'pl-6',
         tone === 'error' ? 'text-[color:var(--danger)]' : 'text-[color:var(--muted-2)]',
       )}
     >
@@ -573,7 +573,7 @@ export function ComposerTextField({
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
             'overflow-x-hidden [hyphens:auto] [overflow-wrap:break-word] [word-break:normal]',
-            trailingAdornmentVisible && value.length === 0 && 'pl-7',
+            trailingAdornmentVisible && value.length === 0 && 'pl-6',
             canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',
             'placeholder:text-transparent',

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -414,8 +414,11 @@ export function ComposerTextField({
         const nextTop = 0
         const nextContainerHeight = textarea.offsetHeight
 
+        const nextLeft = -2
         setTrailingAdornmentPosition((current) =>
-          current?.left === 0 && current.top === nextTop ? current : { left: 0, top: nextTop },
+          current?.left === nextLeft && current.top === nextTop
+            ? current
+            : { left: nextLeft, top: nextTop },
         )
         setTrailingContainerHeight((current) =>
           current === nextContainerHeight ? current : nextContainerHeight,

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -272,6 +272,10 @@ function measureTextareaMarkerPosition(input: {
   }
 }
 
+function isTextareaScrolledToBottom(textarea: HTMLTextAreaElement) {
+  return textarea.scrollHeight - textarea.scrollTop - textarea.clientHeight <= 1
+}
+
 export function ComposerTextField({
   value,
   placeholder,
@@ -389,6 +393,8 @@ export function ComposerTextField({
   }, [])
 
   useLayoutEffect(() => {
+    void textareaLayoutVersion
+
     if (!trailingAdornmentVisible) {
       setTrailingAdornmentPosition(null)
       setTrailingContainerHeight(null)
@@ -417,7 +423,9 @@ export function ComposerTextField({
       const shouldWrapAdornment =
         markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth && value.length > 0
       const nextLeft = shouldWrapAdornment ? 0 : markerLeft + adornmentGap
-      const nextTop = Math.max(0, markerTop + (shouldWrapAdornment ? lineHeight : 0) - 1.5)
+      const rawTop = markerTop + (shouldWrapAdornment ? lineHeight : 0) - textarea.scrollTop - 1.5
+      const maxVisibleTop = Math.max(0, textarea.clientHeight - lineHeight)
+      const nextTop = Math.max(0, Math.min(rawTop, maxVisibleTop))
       const canGrowForAdornment = textarea.scrollHeight <= textarea.offsetHeight + 1
       const maxContainerHeight = textarea.offsetHeight + (canGrowForAdornment ? lineHeight : 0)
       const nextContainerHeight = Math.min(
@@ -437,8 +445,12 @@ export function ComposerTextField({
 
     measureTrailingAdornmentPosition()
     window.addEventListener('resize', measureTrailingAdornmentPosition)
-    return () => window.removeEventListener('resize', measureTrailingAdornmentPosition)
-  }, [placeholder, trailingAdornmentVisible, value])
+    textarea.addEventListener('scroll', measureTrailingAdornmentPosition, { passive: true })
+    return () => {
+      window.removeEventListener('resize', measureTrailingAdornmentPosition)
+      textarea.removeEventListener('scroll', measureTrailingAdornmentPosition)
+    }
+  }, [placeholder, textareaLayoutVersion, trailingAdornmentVisible, value])
 
   useLayoutEffect(() => {
     if (!inlinePopover) {
@@ -549,7 +561,12 @@ export function ComposerTextField({
           onChange={(event) => {
             if (!readOnly) onChange(event.target.value)
           }}
-          onInput={onInput}
+          onInput={() => {
+            if (textareaRef.current && isTextareaScrolledToBottom(textareaRef.current)) {
+              setTextareaLayoutVersion((current) => current + 1)
+            }
+            onInput?.()
+          }}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
           onFocus={onFocus}

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -219,7 +219,7 @@ function TrailingAdornment({
   return (
     <span
       className={cn(
-        'absolute z-10 inline-flex items-center justify-center',
+        'absolute z-10 inline-flex items-center',
         !visible && 'pointer-events-none invisible',
       )}
       style={{ left: `${position.left}px`, top: `${position.top}px`, height: `${lineHeight}px` }}
@@ -410,12 +410,47 @@ export function ComposerTextField({
     }
 
     const measureTrailingAdornmentPosition = () => {
-      const lineHeight = lineHeightRef.current
-      const nextTop = Math.max(0, (textarea.clientHeight - lineHeight) / 2)
-      const nextContainerHeight = textarea.offsetHeight
+      if (value.length === 0) {
+        const lineHeight = lineHeightRef.current
+        const nextTop = Math.max(0, (textarea.clientHeight - lineHeight) / 2)
+        const nextContainerHeight = textarea.offsetHeight
+
+        setTrailingAdornmentPosition((current) =>
+          current?.left === 0 && current.top === nextTop ? current : { left: 0, top: nextTop },
+        )
+        setTrailingContainerHeight((current) =>
+          current === nextContainerHeight ? current : nextContainerHeight,
+        )
+        return
+      }
+
+      const markerPosition = measureTextareaMarkerPosition({
+        adornmentWidth: 0,
+        markerText: value,
+        placeholder,
+        textarea,
+      })
+      const markerLeft = markerPosition.left
+      const markerTop = markerPosition.top
+      const lineHeight = markerPosition.lineHeight || lineHeightRef.current
+      const adornmentWidth = 24
+      const adornmentGap = 6
+      const shouldWrapAdornment = markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth
+      const nextLeft = shouldWrapAdornment ? 0 : markerLeft + adornmentGap
+      const rawTop = markerTop + (shouldWrapAdornment ? lineHeight : 0) - textarea.scrollTop - 1.5
+      const maxVisibleTop = Math.max(0, textarea.clientHeight - lineHeight)
+      const nextTop = Math.max(0, Math.min(rawTop, maxVisibleTop))
+      const canGrowForAdornment = textarea.scrollHeight <= textarea.offsetHeight + 1
+      const maxContainerHeight = textarea.offsetHeight + (canGrowForAdornment ? lineHeight : 0)
+      const nextContainerHeight = Math.min(
+        maxContainerHeight,
+        Math.max(textarea.offsetHeight, nextTop + lineHeight),
+      )
 
       setTrailingAdornmentPosition((current) =>
-        current?.left === 0 && current.top === nextTop ? current : { left: 0, top: nextTop },
+        current?.left === nextLeft && current.top === nextTop
+          ? current
+          : { left: nextLeft, top: nextTop },
       )
       setTrailingContainerHeight((current) =>
         current === nextContainerHeight ? current : nextContainerHeight,
@@ -429,7 +464,7 @@ export function ComposerTextField({
       window.removeEventListener('resize', measureTrailingAdornmentPosition)
       textarea.removeEventListener('scroll', measureTrailingAdornmentPosition)
     }
-  }, [textareaLayoutVersion, trailingAdornmentVisible])
+  }, [placeholder, textareaLayoutVersion, trailingAdornmentVisible, value])
 
   useLayoutEffect(() => {
     if (!inlinePopover) {
@@ -536,7 +571,7 @@ export function ComposerTextField({
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
             'overflow-x-hidden [hyphens:auto] [overflow-wrap:break-word] [word-break:normal]',
-            trailingAdornmentVisible && 'pl-7',
+            trailingAdornmentVisible && value.length === 0 && 'pl-7',
             canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',
             'placeholder:text-transparent',

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -414,7 +414,7 @@ export function ComposerTextField({
         const nextTop = 0
         const nextContainerHeight = textarea.offsetHeight
 
-        const nextLeft = -2
+        const nextLeft = -8
         setTrailingAdornmentPosition((current) =>
           current?.left === nextLeft && current.top === nextTop
             ? current

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -66,9 +66,11 @@ function splitPlaceholderText(placeholder: string) {
 function ComposerResponsivePlaceholder({
   placeholder,
   tone,
+  leadingAdornmentVisible = false,
 }: {
   placeholder: string
   tone: NonNullable<ComposerTextFieldProps['placeholderTone']>
+  leadingAdornmentVisible?: boolean
 }) {
   if (!placeholder) return null
   const { leading, tailParts } = splitPlaceholderText(placeholder)
@@ -77,6 +79,7 @@ function ComposerResponsivePlaceholder({
       aria-hidden="true"
       className={cn(
         'pointer-events-none absolute inset-x-0 top-0 min-w-0 truncate text-[14px] leading-[1.45]',
+        leadingAdornmentVisible && 'pl-7',
         tone === 'error' ? 'text-[color:var(--danger)]' : 'text-[color:var(--muted-2)]',
       )}
     >
@@ -216,7 +219,7 @@ function TrailingAdornment({
   return (
     <span
       className={cn(
-        'absolute z-10 inline-flex items-center',
+        'absolute z-10 inline-flex items-center justify-center',
         !visible && 'pointer-events-none invisible',
       )}
       style={{ left: `${position.left}px`, top: `${position.top}px`, height: `${lineHeight}px` }}
@@ -407,36 +410,12 @@ export function ComposerTextField({
     }
 
     const measureTrailingAdornmentPosition = () => {
-      const measuredPlaceholder =
-        value.length === 0 ? splitPlaceholderText(placeholder).leading : placeholder
-      const markerPosition = measureTextareaMarkerPosition({
-        adornmentWidth: 0,
-        markerText: value,
-        placeholder: measuredPlaceholder,
-        textarea,
-      })
-      const markerLeft = markerPosition.left
-      const markerTop = markerPosition.top
-      const lineHeight = markerPosition.lineHeight || lineHeightRef.current
-      const adornmentWidth = 24
-      const adornmentGap = 6
-      const shouldWrapAdornment =
-        markerLeft + adornmentGap + adornmentWidth > textarea.clientWidth && value.length > 0
-      const nextLeft = shouldWrapAdornment ? 0 : markerLeft + adornmentGap
-      const rawTop = markerTop + (shouldWrapAdornment ? lineHeight : 0) - textarea.scrollTop - 1.5
-      const maxVisibleTop = Math.max(0, textarea.clientHeight - lineHeight)
-      const nextTop = Math.max(0, Math.min(rawTop, maxVisibleTop))
-      const canGrowForAdornment = textarea.scrollHeight <= textarea.offsetHeight + 1
-      const maxContainerHeight = textarea.offsetHeight + (canGrowForAdornment ? lineHeight : 0)
-      const nextContainerHeight = Math.min(
-        maxContainerHeight,
-        Math.max(textarea.offsetHeight, nextTop + lineHeight),
-      )
+      const lineHeight = lineHeightRef.current
+      const nextTop = Math.max(0, (textarea.clientHeight - lineHeight) / 2)
+      const nextContainerHeight = textarea.offsetHeight
 
       setTrailingAdornmentPosition((current) =>
-        current?.left === nextLeft && current.top === nextTop
-          ? current
-          : { left: nextLeft, top: nextTop },
+        current?.left === 0 && current.top === nextTop ? current : { left: 0, top: nextTop },
       )
       setTrailingContainerHeight((current) =>
         current === nextContainerHeight ? current : nextContainerHeight,
@@ -450,7 +429,7 @@ export function ComposerTextField({
       window.removeEventListener('resize', measureTrailingAdornmentPosition)
       textarea.removeEventListener('scroll', measureTrailingAdornmentPosition)
     }
-  }, [placeholder, textareaLayoutVersion, trailingAdornmentVisible, value])
+  }, [textareaLayoutVersion, trailingAdornmentVisible])
 
   useLayoutEffect(() => {
     if (!inlinePopover) {
@@ -545,7 +524,11 @@ export function ComposerTextField({
         style={trailingContainerHeight ? { minHeight: `${trailingContainerHeight}px` } : undefined}
       >
         {value.length === 0 ? (
-          <ComposerResponsivePlaceholder placeholder={placeholder} tone={placeholderTone} />
+          <ComposerResponsivePlaceholder
+            placeholder={placeholder}
+            tone={placeholderTone}
+            leadingAdornmentVisible={trailingAdornmentVisible}
+          />
         ) : null}
         <textarea
           ref={textareaRef}
@@ -553,6 +536,7 @@ export function ComposerTextField({
           className={cn(
             'm-0 w-full min-h-6 resize-none bg-transparent p-0 text-[14px] leading-[1.45] text-[color:var(--text)] outline-none transition-opacity duration-150 [scrollbar-gutter:stable]',
             'overflow-x-hidden [hyphens:auto] [overflow-wrap:break-word] [word-break:normal]',
+            trailingAdornmentVisible && 'pl-7',
             canExpandField && 'composer-textarea-scroll-above-button',
             readOnly && 'cursor-wait opacity-45',
             'placeholder:text-transparent',

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -414,7 +414,7 @@ export function ComposerTextField({
         const nextTop = 0
         const nextContainerHeight = textarea.offsetHeight
 
-        const nextLeft = -8
+        const nextLeft = -5
         setTrailingAdornmentPosition((current) =>
           current?.left === nextLeft && current.top === nextTop
             ? current

--- a/src/app/components/workspace/composer/composer-text-field.tsx
+++ b/src/app/components/workspace/composer/composer-text-field.tsx
@@ -411,8 +411,7 @@ export function ComposerTextField({
 
     const measureTrailingAdornmentPosition = () => {
       if (value.length === 0) {
-        const lineHeight = lineHeightRef.current
-        const nextTop = Math.max(0, (textarea.clientHeight - lineHeight) / 2)
+        const nextTop = 0
         const nextContainerHeight = textarea.offsetHeight
 
         setTrailingAdornmentPosition((current) =>

--- a/src/app/features/chat/chat-workspace-view.tsx
+++ b/src/app/features/chat/chat-workspace-view.tsx
@@ -10,7 +10,7 @@ import type { AppSettings, ProjectDiffBaseline, ProjectDiffRenderMode } from '..
 import { useAnimatedPresence } from '../../hooks/useAnimatedPresence'
 import type { Message } from '../../types'
 import { cn } from '../../utils/cn'
-import { DesktopComposerStatus } from '../code/desktop-composer-status'
+import { DesktopComposerStatusModelPicker } from '../code/desktop-composer-status'
 import { useQueuedPromptRestore } from '../code/useQueuedPromptRestore'
 import { useWorkspaceFooterHeight } from '../code/useWorkspaceFooterHeight'
 import { ChatView } from './chat-view'
@@ -303,8 +303,15 @@ function ChatComposerCenter(props: ChatWorkspaceContentProps) {
 }
 
 function ChatComposerDock(props: ChatWorkspaceContentProps) {
-  const { sidebarAutoHidden, sidebarCompactMode, showDesktopArtifactDrawer, activeComposerState } =
-    props
+  const {
+    sidebarAutoHidden,
+    sidebarCompactMode,
+    showDesktopArtifactDrawer,
+    activeComposerState,
+    composerProjectId,
+    terminalSessionPath,
+    handleAction,
+  } = props
   return (
     <WorkspaceComposerDock
       compactControls={sidebarAutoHidden}
@@ -315,10 +322,16 @@ function ChatComposerDock(props: ChatWorkspaceContentProps) {
         showDesktopArtifactDrawer && 'invisible',
       )}
       right={
-        <DesktopComposerStatus
+        <DesktopComposerStatusModelPicker
+          availableModels={activeComposerState?.availableModels ?? []}
+          availableThinkingLevels={activeComposerState?.availableThinkingLevels ?? ['off']}
+          composerMode="chat"
           contextUsage={activeComposerState?.contextUsage ?? null}
           model={activeComposerState?.currentModel ?? null}
+          projectId={composerProjectId}
+          sessionPath={terminalSessionPath}
           thinkingLevel={activeComposerState?.currentThinkingLevel ?? 'off'}
+          onAction={handleAction}
         />
       }
     />

--- a/src/app/features/code/code-workspace-view.tsx
+++ b/src/app/features/code/code-workspace-view.tsx
@@ -14,7 +14,7 @@ import type { Message } from '../../types'
 import { mainPanelClass } from '../../ui/classes'
 import { cn } from '../../utils/cn'
 import { CodeWorkspaceMainView } from './code-workspace-main-view'
-import { DesktopComposerStatus } from './desktop-composer-status'
+import { DesktopComposerStatusModelPicker } from './desktop-composer-status'
 import { useDiffCommentController } from './useDiffCommentController'
 import { useQueuedPromptRestore } from './useQueuedPromptRestore'
 import { useWorkspaceFooterHeight } from './useWorkspaceFooterHeight'
@@ -485,6 +485,9 @@ function CodeFooterRight(props: CodeWorkspaceContentProps) {
     gitOpsFileTreeVisible,
     showDesktopTerminalDrawer,
     activeComposerState,
+    composerProjectId,
+    terminalSessionPath,
+    handleAction,
   } = props
   if (state.activeView === 'gitops' && !state.takeoverVisible)
     return (
@@ -500,10 +503,16 @@ function CodeFooterRight(props: CodeWorkspaceContentProps) {
     )
   if (state.activeView === 'thread' && !state.takeoverVisible && !showDesktopTerminalDrawer)
     return (
-      <DesktopComposerStatus
+      <DesktopComposerStatusModelPicker
+        availableModels={activeComposerState?.availableModels ?? []}
+        availableThinkingLevels={activeComposerState?.availableThinkingLevels ?? ['off']}
+        composerMode="code"
         contextUsage={activeComposerState?.contextUsage ?? null}
         model={activeComposerState?.currentModel ?? null}
+        projectId={composerProjectId}
+        sessionPath={terminalSessionPath}
         thinkingLevel={activeComposerState?.currentThinkingLevel ?? 'off'}
+        onAction={handleAction}
       />
     )
   return null

--- a/src/app/features/code/desktop-composer-status.tsx
+++ b/src/app/features/code/desktop-composer-status.tsx
@@ -148,6 +148,7 @@ export function DesktopComposerStatusModelPicker({
 
   const selectModel = useCallback(
     (availableModel: ComposerModel) => {
+      setOpen(false)
       if (!persistedSessionPath) {
         void onAction('settings.update', {
           key: composerMode === 'chat' ? 'chatModel' : 'codeModel',
@@ -169,6 +170,7 @@ export function DesktopComposerStatusModelPicker({
 
   const selectThinkingLevel = useCallback(
     (level: ComposerThinkingLevel) => {
+      setOpen(false)
       if (!persistedSessionPath) {
         void onAction('settings.update', {
           key: composerMode === 'chat' ? 'chatThinkingLevel' : 'codeThinkingLevel',

--- a/src/app/features/code/desktop-composer-status.tsx
+++ b/src/app/features/code/desktop-composer-status.tsx
@@ -1,16 +1,38 @@
 import { Bot, Brain, Gauge, Server } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import { getPersistedSessionPath } from '../../../../shared/session-paths'
+import { ComposerModelPopover } from '../../components/workspace/composer/composer-model-popover'
 import type {
   ComposerContextUsage,
   ComposerModel,
   ComposerThinkingLevel,
+  DesktopActionInvoker,
 } from '../../desktop/types'
+import { useDismissibleLayer } from '../../hooks/useDismissibleLayer'
 import { cn } from '../../utils/cn'
 
 type DesktopComposerStatusProps = {
-  className?: string
+  className?: string | undefined
   contextUsage: ComposerContextUsage | null
   model: ComposerModel | null
   thinkingLevel: ComposerThinkingLevel
+  interactive?: boolean
+  menuOpen?: boolean
+  triggerRef?: React.RefObject<HTMLButtonElement | null>
+  onToggleMenu?: () => void
+}
+
+type DesktopComposerStatusModelPickerProps = {
+  composerMode: 'chat' | 'code'
+  availableModels: ComposerModel[]
+  availableThinkingLevels: ComposerThinkingLevel[]
+  className?: string | undefined
+  contextUsage: ComposerContextUsage | null
+  model: ComposerModel | null
+  projectId: string
+  sessionPath: string | null
+  thinkingLevel: ComposerThinkingLevel
+  onAction: DesktopActionInvoker
 }
 
 const statusLineClass =
@@ -38,8 +60,12 @@ function formatContextPercent(contextUsage: ComposerContextUsage | null) {
 export function DesktopComposerStatus({
   className,
   contextUsage,
+  interactive = false,
+  menuOpen = false,
   model,
+  onToggleMenu,
   thinkingLevel,
+  triggerRef,
 }: DesktopComposerStatusProps) {
   const rows = [
     { id: 'context', icon: Gauge, label: formatContextPercent(contextUsage) },
@@ -47,6 +73,45 @@ export function DesktopComposerStatus({
     { id: 'model', icon: Bot, label: model?.name ?? 'No model', highlight: true },
     { id: 'provider', icon: Server, label: model?.provider ?? 'No provider' },
   ]
+
+  const content = rows.map((row) => {
+    const Icon = row.icon
+    return (
+      <div key={row.id} className={statusLineClass}>
+        <Icon size={11} className={iconClass} />
+        <span
+          className={cn('min-w-0 flex-1 truncate', row.highlight && 'text-[color:var(--text)]')}
+        >
+          {row.label}
+        </span>
+      </div>
+    )
+  })
+
+  const statusClassName = cn(
+    'pointer-events-auto ml-auto grid w-36 select-none gap-0.5 rounded-xl px-1.5 py-1 text-right opacity-70 transition-opacity hover:opacity-100',
+    interactive &&
+      'cursor-pointer hover:bg-[color:var(--surface-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]',
+    menuOpen && 'bg-[color:var(--surface-hover)] opacity-100',
+    className,
+  )
+
+  if (interactive) {
+    return (
+      <button
+        ref={triggerRef}
+        type="button"
+        className={statusClassName}
+        onClick={onToggleMenu}
+        aria-label="Model settings"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        aria-controls="composer-model-menu"
+      >
+        {content}
+      </button>
+    )
+  }
 
   return (
     <section
@@ -56,19 +121,97 @@ export function DesktopComposerStatus({
       )}
       aria-label="Composer status"
     >
-      {rows.map((row) => {
-        const Icon = row.icon
-        return (
-          <div key={row.id} className={statusLineClass}>
-            <Icon size={11} className={iconClass} />
-            <span
-              className={cn('min-w-0 flex-1 truncate', row.highlight && 'text-[color:var(--text)]')}
-            >
-              {row.label}
-            </span>
-          </div>
-        )
-      })}
+      {content}
     </section>
+  )
+}
+
+export function DesktopComposerStatusModelPicker({
+  availableModels,
+  availableThinkingLevels,
+  className,
+  composerMode,
+  contextUsage,
+  model,
+  projectId,
+  sessionPath,
+  thinkingLevel,
+  onAction,
+}: DesktopComposerStatusModelPickerProps) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const closeMenu = useCallback(() => setOpen(false), [])
+  const persistedSessionPath = getPersistedSessionPath(sessionPath)
+
+  useDismissibleLayer({ open, onDismiss: closeMenu, refs: [triggerRef, panelRef] })
+
+  const selectModel = useCallback(
+    (availableModel: ComposerModel) => {
+      if (!persistedSessionPath) {
+        void onAction('settings.update', {
+          key: composerMode === 'chat' ? 'chatModel' : 'codeModel',
+          provider: availableModel.provider,
+          modelId: availableModel.id,
+        })
+        return
+      }
+
+      void onAction('composer.model', {
+        provider: availableModel.provider,
+        modelId: availableModel.id,
+        projectId,
+        sessionPath,
+      })
+    },
+    [composerMode, onAction, persistedSessionPath, projectId, sessionPath],
+  )
+
+  const selectThinkingLevel = useCallback(
+    (level: ComposerThinkingLevel) => {
+      if (!persistedSessionPath) {
+        void onAction('settings.update', {
+          key: composerMode === 'chat' ? 'chatThinkingLevel' : 'codeThinkingLevel',
+          value: level,
+        })
+        return
+      }
+
+      void onAction('composer.thinking', {
+        level,
+        projectId,
+        sessionPath,
+      })
+    },
+    [composerMode, onAction, persistedSessionPath, projectId, sessionPath],
+  )
+
+  return (
+    <div className="relative ml-auto">
+      <DesktopComposerStatus
+        className={className}
+        contextUsage={contextUsage}
+        interactive
+        menuOpen={open}
+        model={model}
+        thinkingLevel={thinkingLevel}
+        triggerRef={triggerRef}
+        onToggleMenu={() => setOpen((current) => !current)}
+      />
+      {open ? (
+        <ComposerModelPopover
+          anchorRef={triggerRef}
+          availableModels={availableModels}
+          availableThinkingLevels={availableThinkingLevels}
+          currentModel={model}
+          currentThinkingLevel={thinkingLevel}
+          panelRef={panelRef}
+          preferSidePlacement
+          thinkingLevelLabels={thinkingLevelLabels}
+          onSelectModel={selectModel}
+          onSelectThinkingLevel={selectThinkingLevel}
+        />
+      ) : null}
+    </div>
   )
 }

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -12,6 +12,7 @@ type UtilityViewReturnState = {
   selectedThreadId: string | null
   selectedSessionPath: string | null
   terminalVisible: boolean
+  projectTerminalVisibleByProject: Record<string, boolean>
   restoreTerminalVisibleOnGitOpsClose: boolean
   takeoverVisible: boolean
   gitOpsReturnView: NonGitOpsView
@@ -26,6 +27,7 @@ export type WorkspaceState = {
   selectedThreadId: string | null
   selectedSessionPath: string | null
   terminalVisible: boolean
+  projectTerminalVisibleByProject: Record<string, boolean>
   terminalVisibleBySession: Record<string, boolean>
   restoreTerminalVisibleOnGitOpsClose: boolean
   takeoverVisible: boolean
@@ -84,6 +86,7 @@ function createUtilityViewReturnState(state: WorkspaceState): UtilityViewReturnS
     selectedThreadId: state.selectedThreadId,
     selectedSessionPath: state.selectedSessionPath,
     terminalVisible: state.terminalVisible,
+    projectTerminalVisibleByProject: state.projectTerminalVisibleByProject,
     restoreTerminalVisibleOnGitOpsClose: state.restoreTerminalVisibleOnGitOpsClose,
     takeoverVisible: state.takeoverVisible,
     gitOpsReturnView: state.gitOpsReturnView,
@@ -135,6 +138,14 @@ function shouldMigrateTerminalVisibilityForOpenedThread(
   action: Extract<WorkspaceAction, { type: 'open-thread' }>,
 ) {
   if (
+    state.activeView === 'code' &&
+    state.selectedProjectId === action.projectId &&
+    (state.projectTerminalVisibleByProject[action.projectId] ?? false)
+  ) {
+    return true
+  }
+
+  if (
     state.activeView !== 'thread' ||
     !state.selectedSessionPath ||
     state.selectedSessionPath === action.sessionPath
@@ -150,6 +161,11 @@ function shouldMigrateTerminalVisibilityForOpenedThread(
 }
 
 function getTerminalStateForNextView(state: WorkspaceState, nextView: View) {
+  const getProjectTerminalVisible = () =>
+    state.selectedProjectId
+      ? (state.projectTerminalVisibleByProject[state.selectedProjectId] ?? false)
+      : false
+
   if (state.activeView !== 'gitops') {
     return {
       terminalVisible:
@@ -158,7 +174,9 @@ function getTerminalStateForNextView(state: WorkspaceState, nextView: View) {
               state.terminalVisibleBySession,
               state.selectedSessionPath,
             )
-          : state.terminalVisible,
+          : nextView === 'code'
+            ? getProjectTerminalVisible()
+            : state.terminalVisible,
       restoreTerminalVisibleOnGitOpsClose: state.restoreTerminalVisibleOnGitOpsClose,
     }
   }
@@ -187,6 +205,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     selectedThreadId: null,
     selectedSessionPath: null,
     terminalVisible: false,
+    projectTerminalVisibleByProject: {},
     terminalVisibleBySession: {},
     restoreTerminalVisibleOnGitOpsClose: false,
     takeoverVisible: false,
@@ -347,10 +366,12 @@ function openThreadState(
     ? {
         ...state.terminalVisibleBySession,
         [action.sessionPath]:
-          getTerminalVisibilityForSession(
-            state.terminalVisibleBySession,
-            state.selectedSessionPath,
-          ) ?? false,
+          state.activeView === 'code'
+            ? (state.projectTerminalVisibleByProject[action.projectId] ?? false)
+            : getTerminalVisibilityForSession(
+                state.terminalVisibleBySession,
+                state.selectedSessionPath,
+              ),
       }
     : state.terminalVisibleBySession
   return {
@@ -416,7 +437,17 @@ function closeGitOpsState(state: WorkspaceState): WorkspaceState {
 }
 
 function setTerminalVisibleState(state: WorkspaceState, visible: boolean): WorkspaceState {
-  if (!state.selectedSessionPath) return { ...state, terminalVisible: visible }
+  if (!state.selectedSessionPath) {
+    if (!state.selectedProjectId) return { ...state, terminalVisible: visible }
+    return {
+      ...state,
+      terminalVisible: visible,
+      projectTerminalVisibleByProject: {
+        ...state.projectTerminalVisibleByProject,
+        [state.selectedProjectId]: visible,
+      },
+    }
+  }
   return {
     ...state,
     terminalVisible: visible,
@@ -493,7 +524,7 @@ const workspaceActionHandlers = {
     hasSelectedProject: true,
     selectedThreadId: null,
     selectedSessionPath: null,
-    terminalVisible: false,
+    terminalVisible: state.projectTerminalVisibleByProject[action.projectId] ?? false,
     selectedDiffFilePath: null,
     takeoverVisible: false,
     gitOpsReturnView: 'code',

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -133,6 +133,10 @@ function getTerminalVisibilityForSession(
   return sessionPath ? (terminalVisibleBySession[sessionPath] ?? false) : false
 }
 
+function shouldRestoreTerminalOnGitOpsClose(state: WorkspaceState) {
+  return state.terminalVisible && (state.activeView === 'thread' || state.activeView === 'code')
+}
+
 function shouldMigrateTerminalVisibilityForOpenedThread(
   state: WorkspaceState,
   action: Extract<WorkspaceAction, { type: 'open-thread' }>,
@@ -189,7 +193,8 @@ function getTerminalStateForNextView(state: WorkspaceState, nextView: View) {
   }
 
   return {
-    terminalVisible: nextView === 'thread' && state.restoreTerminalVisibleOnGitOpsClose,
+    terminalVisible:
+      (nextView === 'thread' || nextView === 'code') && state.restoreTerminalVisibleOnGitOpsClose,
     restoreTerminalVisibleOnGitOpsClose: false,
   }
 }
@@ -409,7 +414,7 @@ function openGitOpsState(
     restoreTerminalVisibleOnGitOpsClose:
       state.activeView === 'gitops'
         ? state.restoreTerminalVisibleOnGitOpsClose
-        : state.activeView === 'thread' && state.terminalVisible,
+        : shouldRestoreTerminalOnGitOpsClose(state),
     takeoverVisible: false,
     gitOpsReturnView:
       action.returnView ?? getGitOpsReturnView(state.activeView, state.gitOpsReturnView),

--- a/src/electron/main/updater/app-updater.ts
+++ b/src/electron/main/updater/app-updater.ts
@@ -25,9 +25,8 @@ const updateAllowedInDev = getProcessEnvironmentVariable('HOWCODE_ENABLE_DEV_APP
 const semverPattern = /^\d+\.\d+\.\d+$/
 const sha256Pattern = /^[a-f0-9]{64}$/i
 const channelReleaseKeyPattern = /^(main|dev)-(\d+\.\d+\.\d+)-([a-f0-9]{64})$/i
-const legacyReleaseKeyPattern = /^(\d+\.\d+\.\d+)-([a-f0-9]{64})$/i
 const trailingSlashesPattern = /\/+$/
-const trailingChannelPattern = /\/(?:main|dev)$/i
+const trailingChannelPattern = /\/(?:main|dev|channel-main|channel-dev)$/i
 const channelPlaceholderPattern = /\{channel\}/g
 
 type UpdateTarget = {
@@ -91,14 +90,19 @@ function getCacheRoot() {
   )
 }
 
+function getChannelReleaseTag(channel: UpdateChannel) {
+  return `channel-${channel}`
+}
+
 function getReleaseBaseUrl(channel: UpdateChannel) {
-  if (!RELEASE_BASE_URL) return `${DEFAULT_RELEASE_BASE_URL}/${channel}`
+  const releaseTag = getChannelReleaseTag(channel)
+  if (!RELEASE_BASE_URL) return `${DEFAULT_RELEASE_BASE_URL}/${releaseTag}`
 
   const baseUrl = RELEASE_BASE_URL.replace(trailingSlashesPattern, '')
-  if (baseUrl.includes('{channel}')) return baseUrl.replace(channelPlaceholderPattern, channel)
+  if (baseUrl.includes('{releaseTag}')) return baseUrl.replace(/\{releaseTag\}/g, releaseTag)
+  if (baseUrl.includes('{channel}')) return baseUrl.replace(channelPlaceholderPattern, releaseTag)
 
-  const channelBaseUrl = baseUrl.replace(trailingChannelPattern, `/${channel}`)
-  return channelBaseUrl
+  return baseUrl.replace(trailingChannelPattern, `/${releaseTag}`)
 }
 
 function getReleaseKey(release: Pick<ReleaseInfo, 'channel' | 'version' | 'hash'>) {
@@ -112,22 +116,6 @@ function getInstallPaths(target: UpdateTarget, release: ReleaseInfo) {
   return {
     cacheRoot,
     currentFile: path.join(cacheRoot, `current-${release.channel}.json`),
-    installDir,
-    executablePath: path.join(installDir, target.executable),
-  }
-}
-
-function getLegacyCurrentFile() {
-  return path.join(getCacheRoot(), 'current.json')
-}
-
-function getLegacyInstallPaths(target: UpdateTarget, release: ReleaseInfo) {
-  const cacheRoot = getCacheRoot()
-  const releaseKey = `${release.version}-${release.hash}`
-  const installDir = path.join(cacheRoot, 'versions', releaseKey)
-  return {
-    cacheRoot,
-    currentFile: getLegacyCurrentFile(),
     installDir,
     executablePath: path.join(installDir, target.executable),
   }
@@ -345,11 +333,6 @@ function getRunningReleaseFingerprint() {
     }
   }
 
-  const legacyMatch = legacyReleaseKeyPattern.exec(runningReleaseKey)
-  if (legacyMatch?.[1] && legacyMatch[2]) {
-    return { version: legacyMatch[1], hash: legacyMatch[2].toLowerCase() }
-  }
-
   return null
 }
 
@@ -490,7 +473,12 @@ export class AppUpdater {
         this.latestRelease = null
         throw new Error('Update channel changed. Check for updates again before installing.')
       }
-      this.setState({ status: 'downloading', latestVersion: release.version, error: null })
+      this.setState({
+        status: 'downloading',
+        latestVersion: release.version,
+        channel: release.channel,
+        error: null,
+      })
       const target = getTarget()
       assertInstallSupported(target)
       const paths = getInstallPaths(target, release)
@@ -514,7 +502,12 @@ export class AppUpdater {
           throw new Error(
             `Downloaded archive hash mismatch. Expected ${release.hash}, got ${hash}.`,
           )
-        this.setState({ status: 'installing', latestVersion: release.version, error: null })
+        this.setState({
+          status: 'installing',
+          latestVersion: release.version,
+          channel: release.channel,
+          error: null,
+        })
         await mkdir(tempInstallDir, { recursive: true })
         await extractTar({ file: archivePath, cwd: tempInstallDir })
         if (!existsSync(path.join(tempInstallDir, target.executable))) {
@@ -578,32 +571,19 @@ export class AppUpdater {
     this.installedUpdate = null
     const channel = await this.getUpdateChannel()
     const currentFile = path.join(getCacheRoot(), `current-${channel}.json`)
-    const record =
-      (await this.readCurrentFile(currentFile)) ??
-      (await this.readCurrentFile(getLegacyCurrentFile(), channel))
+    const record = await this.readCurrentFile(currentFile)
     if (!(record && this.isUpdateCandidate(record))) return
     const target = getTarget()
     const expectedPaths = getInstallPaths(target, record)
-    const legacyPaths = getLegacyInstallPaths(target, record)
     if (
-      !(
-        (record.installDir === expectedPaths.installDir &&
-          record.executablePath === expectedPaths.executablePath) ||
-        (record.installDir === legacyPaths.installDir &&
-          record.executablePath === legacyPaths.executablePath)
-      )
+      record.installDir !== expectedPaths.installDir ||
+      record.executablePath !== expectedPaths.executablePath
     ) {
       return
     }
-    const paths = record.installDir === legacyPaths.installDir ? legacyPaths : expectedPaths
-    if (!(await isValidInstall(paths, target))) return
+    if (!(await isValidInstall(expectedPaths, target))) return
     this.installedUpdate = record
     this.latestRelease = record
-    if (paths.currentFile === getLegacyCurrentFile()) {
-      await writeInstalledUpdateRecord(currentFile, record).catch(() => {
-        // Preserve restart capability even if best-effort migration fails.
-      })
-    }
     this.setState({
       status: 'ready',
       latestVersion: record.version,

--- a/src/electron/main/updater/app-updater.ts
+++ b/src/electron/main/updater/app-updater.ts
@@ -28,6 +28,7 @@ const channelReleaseKeyPattern = /^(main|dev)-(\d+\.\d+\.\d+)-([a-f0-9]{64})$/i
 const trailingSlashesPattern = /\/+$/
 const trailingChannelPattern = /\/(?:main|dev|channel-main|channel-dev)$/i
 const channelPlaceholderPattern = /\{channel\}/g
+const releaseTagPlaceholderPattern = /\{releaseTag\}/g
 
 type UpdateTarget = {
   os: 'macos' | 'linux' | 'win'
@@ -99,7 +100,8 @@ function getReleaseBaseUrl(channel: UpdateChannel) {
   if (!RELEASE_BASE_URL) return `${DEFAULT_RELEASE_BASE_URL}/${releaseTag}`
 
   const baseUrl = RELEASE_BASE_URL.replace(trailingSlashesPattern, '')
-  if (baseUrl.includes('{releaseTag}')) return baseUrl.replace(/\{releaseTag\}/g, releaseTag)
+  if (baseUrl.includes('{releaseTag}'))
+    return baseUrl.replace(releaseTagPlaceholderPattern, releaseTag)
   if (baseUrl.includes('{channel}')) return baseUrl.replace(channelPlaceholderPattern, releaseTag)
 
   return baseUrl.replace(trailingChannelPattern, `/${releaseTag}`)
@@ -180,13 +182,14 @@ function assertInstallSupported(target: UpdateTarget) {
 function normalizeReleaseMetadata(
   metadata: unknown,
   updateUrl: string,
-): Pick<ReleaseInfo, 'version' | 'hash'> {
+): Pick<ReleaseInfo, 'version' | 'hash' | 'assetUrl'> {
   if (!metadata || typeof metadata !== 'object') {
     throw new Error(`Invalid metadata from ${updateUrl}`)
   }
 
   const version = 'version' in metadata ? metadata.version : null
   const hash = 'hash' in metadata ? metadata.hash : null
+  const assetUrl = 'assetUrl' in metadata ? metadata.assetUrl : null
 
   if (typeof version !== 'string' || !semverPattern.test(version)) {
     throw new Error(`Invalid release version from ${updateUrl}`)
@@ -196,7 +199,11 @@ function normalizeReleaseMetadata(
     throw new Error(`Invalid release hash from ${updateUrl}`)
   }
 
-  return { version, hash: hash.toLowerCase() }
+  return {
+    version,
+    hash: hash.toLowerCase(),
+    assetUrl: typeof assetUrl === 'string' && assetUrl.length > 0 ? assetUrl : '',
+  }
 }
 
 async function fetchJson(url: string, timeoutMs = 15_000) {
@@ -211,12 +218,15 @@ async function resolveLatestRelease(
 ): Promise<ReleaseInfo> {
   const releaseBaseUrl = getReleaseBaseUrl(channel)
   const updateUrl = `${releaseBaseUrl}/stable-${target.os}-${target.arch}-update.json`
-  const { version, hash } = normalizeReleaseMetadata(await fetchJson(updateUrl), updateUrl)
+  const { version, hash, assetUrl } = normalizeReleaseMetadata(
+    await fetchJson(updateUrl),
+    updateUrl,
+  )
   return {
     channel,
     version,
     hash,
-    assetUrl: `${releaseBaseUrl}/${APP_NAME}-${target.os}-${target.arch}.tar.gz`,
+    assetUrl: assetUrl || `${releaseBaseUrl}/${APP_NAME}-${target.os}-${target.arch}.tar.gz`,
   }
 }
 
@@ -598,6 +608,8 @@ export class AppUpdater {
     if (versionDiff < 0) return false
 
     const runningRelease = getRunningReleaseFingerprint()
+    if (release.channel === 'main') return false
+
     if (runningRelease?.version === release.version && runningRelease.hash === release.hash) {
       return false
     }

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -730,6 +730,7 @@
   color: var(--text);
   fill: currentColor;
   opacity: 0.72;
+  transform: none;
 }
 
 .sidebar-project-actions {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -619,7 +619,7 @@
 .sidebar-project-toggle {
   position: relative;
   display: inline-flex;
-  height: 1rem;
+  height: 1.25rem;
   width: 1rem;
   flex-shrink: 0;
   align-items: center;
@@ -641,6 +641,7 @@
   position: absolute;
   inset: 0;
   margin: auto;
+  transform: translateY(0.5px);
   transition: opacity 150ms ease-out;
 }
 
@@ -695,6 +696,7 @@
   min-height: 1.75rem;
   min-width: 0;
   align-items: center;
+  gap: 0.375rem;
   border-radius: 0.75rem;
   padding-block: 0.25rem;
   color: var(--muted);
@@ -717,6 +719,17 @@
   font-size: 13.5px;
   font-weight: 500;
   opacity: 0.92;
+}
+
+.sidebar-row-inline-icon {
+  flex-shrink: 0;
+  transform: translateY(0.5px);
+}
+
+.sidebar-project-favourite-icon {
+  color: var(--text);
+  fill: currentColor;
+  opacity: 0.72;
 }
 
 .sidebar-project-actions {
@@ -769,7 +782,7 @@
 
 .sidebar-old-sessions-toggle {
   display: inline-flex;
-  height: 1rem;
+  height: 1.25rem;
   width: 1rem;
   align-items: center;
   justify-content: center;
@@ -803,7 +816,7 @@
 
 .sidebar-thread-leading-icon {
   display: inline-flex;
-  height: 1rem;
+  height: 1.25rem;
   width: 1rem;
   align-items: center;
   justify-content: center;
@@ -813,7 +826,7 @@
 .sidebar-thread-pin {
   position: relative;
   display: inline-flex;
-  height: 1rem;
+  height: 1.25rem;
   width: 1rem;
   flex-shrink: 0;
   align-items: center;
@@ -824,6 +837,10 @@
   transition:
     color 150ms ease-out,
     opacity 150ms ease-out;
+}
+
+.sidebar-thread-pin svg {
+  transform: translateY(0.5px);
 }
 
 .sidebar-thread-pin:hover {
@@ -841,13 +858,11 @@
 
 .sidebar-thread-row:hover .sidebar-thread-pin,
 .sidebar-thread-row:focus-within .sidebar-thread-pin,
-.sidebar-thread-pin[data-pinned="true"],
-.sidebar-thread-pin[data-selected="true"] {
+.sidebar-thread-pin[data-pinned="true"] {
   opacity: 1;
 }
 
-.sidebar-thread-pin[data-pinned="true"],
-.sidebar-thread-pin[data-selected="true"] {
+.sidebar-thread-pin[data-pinned="true"] {
   color: var(--text);
 }
 

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -641,7 +641,7 @@
   position: absolute;
   inset: 0;
   margin: auto;
-  transform: translateY(0.5px);
+  transform: translateY(2px);
   transition: opacity 150ms ease-out;
 }
 
@@ -723,7 +723,7 @@
 
 .sidebar-row-inline-icon {
   flex-shrink: 0;
-  transform: translateY(0.5px);
+  transform: translateY(2px);
 }
 
 .sidebar-project-favourite-icon {
@@ -840,7 +840,7 @@
 }
 
 .sidebar-thread-pin svg {
-  transform: translateY(0.5px);
+  transform: translateY(2px);
 }
 
 .sidebar-thread-pin:hover {


### PR DESCRIPTION
## Summary
- Fix composer/control polish: empty-composer mic placement, sidebar favorite/icon alignment, model picker close behavior, and project terminal launch/session binding.
- Move moving release channels off ambiguous `main`/`dev` tags and onto `channel-main` / `channel-dev` GitHub release tags.
- Update both the in-app updater and npm launcher to consume the prefixed channel releases, and bump the npm launcher to `0.1.66`.

## Release/update details
- Branches remain `main` and `dev`; moving release tags become `channel-main` and `channel-dev`.
- The release workflow now creates/updates `channel-$CHANNEL` instead of tags that collide with branch names.
- The app updater and npm launcher support `{releaseTag}` and map `{channel}` to the prefixed release tag.
- Legacy unprefixed updater install/current-file compatibility was removed as part of the clean cut.

## Validation
- `bun run ai:check`
