### PR TITLE
Guard release asset metadata before publishing

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -224,6 +224,9 @@ jobs:
       - name: List channel release assets
         run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
 
+      - name: Verify channel release assets
+        run: bun run release:verify-assets release-assets
+
       - name: Prepare channel release notes
         env:
           CHANNEL: ${{ github.ref_name }}
@@ -293,6 +296,9 @@ jobs:
 
       - name: List release assets
         run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
+
+      - name: Verify release assets
+        run: bun run release:verify-assets release-assets
 
       - name: Create or update GitHub release
         env:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "pages:build": "vite build --config pages/vite.config.ts",
     "pages:preview": "vite preview --config pages/vite.config.ts",
     "deadcode": "react-doctor . --offline --project howcode --dead-code --fail-on warning",
-    "react-doctor": "react-doctor . --offline --project howcode --dead-code"
+    "react-doctor": "react-doctor . --offline --project howcode --dead-code",
+    "release:verify-assets": "bun ./scripts/verify-release-assets.ts"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,cts,mts,cjs,mjs,json,css,md}": [

--- a/scripts/verify-release-assets.ts
+++ b/scripts/verify-release-assets.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+
+type ReleaseTarget = {
+  os: 'linux' | 'macos' | 'win'
+  arch: 'arm64' | 'x64'
+}
+
+type StableUpdateMetadata = {
+  version?: unknown
+  hash?: unknown
+  assetUrl?: unknown
+}
+
+const expectedTargets: ReleaseTarget[] = [
+  { os: 'linux', arch: 'arm64' },
+  { os: 'linux', arch: 'x64' },
+  { os: 'macos', arch: 'arm64' },
+  { os: 'macos', arch: 'x64' },
+  { os: 'win', arch: 'arm64' },
+  { os: 'win', arch: 'x64' },
+]
+
+const sha256Pattern = /^[a-f0-9]{64}$/
+const semverPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+
+async function sha256File(filePath: string) {
+  const buffer = await readFile(filePath)
+  return createHash('sha256').update(buffer).digest('hex')
+}
+
+async function findFile(rootPath: string, fileName: string) {
+  const stack = [rootPath]
+  while (stack.length > 0) {
+    const currentPath = stack.pop()
+    if (!currentPath) continue
+
+    for (const entry of await readdir(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(entryPath)
+      } else if (entry.name === fileName) {
+        return entryPath
+      }
+    }
+  }
+  return null
+}
+
+function parseMetadata(rawMetadata: string, metadataPath: string) {
+  let metadata: StableUpdateMetadata
+  try {
+    metadata = JSON.parse(rawMetadata) as StableUpdateMetadata
+  } catch (error) {
+    throw new Error(
+      `${metadataPath} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  if (typeof metadata.version !== 'string' || !semverPattern.test(metadata.version)) {
+    throw new Error(`${metadataPath} has invalid version ${String(metadata.version)}`)
+  }
+  if (typeof metadata.hash !== 'string' || !sha256Pattern.test(metadata.hash)) {
+    throw new Error(`${metadataPath} has invalid sha256 hash ${String(metadata.hash)}`)
+  }
+  if (metadata.assetUrl !== undefined && typeof metadata.assetUrl !== 'string') {
+    throw new Error(`${metadataPath} has non-string assetUrl`)
+  }
+
+  return {
+    version: metadata.version,
+    hash: metadata.hash,
+    assetUrl: metadata.assetUrl,
+  }
+}
+
+async function assertReleaseAssetsRootExists(releaseAssetsRoot: string) {
+  if (!(existsSync(releaseAssetsRoot) && (await stat(releaseAssetsRoot)).isDirectory())) {
+    throw new Error(`Release assets directory does not exist: ${releaseAssetsRoot}`)
+  }
+}
+
+async function verifyTargetAssets(
+  releaseAssetsRoot: string,
+  expectedVersion: string,
+  target: ReleaseTarget,
+) {
+  const metadataName = `stable-${target.os}-${target.arch}-update.json`
+  const metadataPath = await findFile(releaseAssetsRoot, metadataName)
+  if (!metadataPath) throw new Error(`Missing ${metadataName}`)
+
+  const metadata = parseMetadata(await readFile(metadataPath, 'utf8'), metadataPath)
+  if (metadata.version !== expectedVersion) {
+    throw new Error(
+      `${metadataName} version ${metadata.version} does not match package.json ${expectedVersion}`,
+    )
+  }
+
+  const assetName = metadata.assetUrl
+    ? path.basename(new URL(metadata.assetUrl).pathname)
+    : `howcode-${target.os}-${target.arch}.tar.gz`
+  const archivePath = await findFile(releaseAssetsRoot, assetName)
+  if (!archivePath) throw new Error(`${metadataName} points to missing archive ${assetName}`)
+
+  const actualHash = await sha256File(archivePath)
+  if (actualHash !== metadata.hash) {
+    throw new Error(
+      `${metadataName} hash ${metadata.hash} does not match ${assetName} sha256 ${actualHash}`,
+    )
+  }
+}
+
+async function verifyReleaseAssets() {
+  const releaseAssetsRoot = process.argv[2] ?? path.join(process.cwd(), 'release-assets')
+  const rootPackageJson = JSON.parse(
+    await readFile(path.join(process.cwd(), 'package.json'), 'utf8'),
+  ) as { version?: unknown }
+  const expectedVersion = rootPackageJson.version
+  if (typeof expectedVersion !== 'string' || !semverPattern.test(expectedVersion)) {
+    throw new Error(`package.json has invalid version ${String(expectedVersion)}`)
+  }
+
+  await assertReleaseAssetsRootExists(releaseAssetsRoot)
+
+  for (const target of expectedTargets) {
+    await verifyTargetAssets(releaseAssetsRoot, expectedVersion, target)
+  }
+
+  console.log(
+    `Verified ${expectedTargets.length} stable update metadata files in ${releaseAssetsRoot}`,
+  )
+}
+
+void verifyReleaseAssets().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Add a release asset verification script that checks every stable update JSON points at an existing archive with a matching SHA256.
- Fail channel and versioned GitHub release publishing if stable metadata versions diverge from root `package.json`.
- Guard against npm launcher / desktop release metadata skew like the stale `/download/main` assets reported in #248.

## Validation

- `bun run ai:check`
- `bun run publish:howcode:dry-run`

Refs #248
