### PR TITLE
Fix macOS terminal posix_spawnp failure

### DIFF
--- a/desktop/terminal/node-pty-packaging.test.ts
+++ b/desktop/terminal/node-pty-packaging.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const { NODE_PTY_UNIX_TERMINAL_PATTERN, patchUnixTerminal, unpackAsarPath } =
+  require('../../scripts/patch-node-pty-helper.cjs') as {
+    NODE_PTY_UNIX_TERMINAL_PATTERN: string
+    patchUnixTerminal: (unixTerminalPath: string) => { patched: boolean; reason?: string }
+    unpackAsarPath: (value: string, marker: string) => string
+  }
+
+describe('node-pty helper packaging patch', () => {
+  it('does not double-unpack an app.asar.unpacked path', () => {
+    expect(
+      unpackAsarPath(
+        '/Applications/howcode.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper',
+        'app.asar',
+      ),
+    ).toBe(
+      '/Applications/howcode.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper',
+    )
+  })
+
+  it('unpacks an app.asar path once', () => {
+    expect(
+      unpackAsarPath(
+        '/Applications/howcode.app/Contents/Resources/app.asar/node_modules/node-pty/build/Release/spawn-helper',
+        'app.asar',
+      ),
+    ).toBe(
+      '/Applications/howcode.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper',
+    )
+  })
+
+  it('patches node-pty unixTerminal helperPath resolution idempotently', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'howcode-node-pty-patch-'))
+    const unixTerminalPath = path.join(tempDir, 'unixTerminal.js')
+    writeFileSync(unixTerminalPath, `${NODE_PTY_UNIX_TERMINAL_PATTERN}\n`, 'utf8')
+
+    expect(patchUnixTerminal(unixTerminalPath)).toEqual({ patched: true })
+    expect(readFileSync(unixTerminalPath, 'utf8')).toContain(
+      'return value.indexOf(unpacked) !== -1 ? value : value.replace(marker, unpacked);',
+    )
+    expect(patchUnixTerminal(unixTerminalPath)).toEqual({
+      patched: false,
+      reason: 'already-patched',
+    })
+  })
+})

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,7 @@ files:
   - "!node_modules/**/*.map"
   - "!node_modules/lucide-react/**"
 asar: true
+afterPack: scripts/after-pack-electron.cjs
 extraResources:
   - from: desktop/resources
     to: resources

--- a/scripts/after-pack-electron.cjs
+++ b/scripts/after-pack-electron.cjs
@@ -1,0 +1,16 @@
+const path = require('node:path')
+const { patchPackagedNodePty } = require('./patch-node-pty-helper.cjs')
+
+exports.default = async function afterPack(context) {
+  const resourcesPath = path.join(
+    context.appOutDir,
+    process.platform === 'darwin'
+      ? `${context.packager.appInfo.productFilename}.app/Contents/Resources`
+      : 'resources',
+  )
+
+  const result = patchPackagedNodePty(resourcesPath)
+  console.log(
+    `Patched packaged node-pty helper resolution at ${result.unixTerminalPath}; executable helpers: ${result.executableHelpers.length}`,
+  )
+}

--- a/scripts/patch-node-pty-helper.cjs
+++ b/scripts/patch-node-pty-helper.cjs
@@ -1,0 +1,90 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const NODE_PTY_UNIX_TERMINAL_PATTERN = `var helperPath = native.dir + '/spawn-helper';
+helperPath = path.resolve(__dirname, helperPath);
+helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');`
+
+const NODE_PTY_UNIX_TERMINAL_REPLACEMENT = `var helperPath = native.dir + '/spawn-helper';
+helperPath = path.resolve(__dirname, helperPath);
+function unpackAsarPath(value, marker) {
+    var unpacked = marker + '.unpacked';
+    return value.indexOf(unpacked) !== -1 ? value : value.replace(marker, unpacked);
+}
+helperPath = unpackAsarPath(helperPath, 'app.asar');
+helperPath = unpackAsarPath(helperPath, 'node_modules.asar');`
+
+function unpackAsarPath(value, marker) {
+  const unpacked = `${marker}.unpacked`
+  return value.includes(unpacked) ? value : value.replace(marker, unpacked)
+}
+
+function resolveNodePtyRoot(resourcesPath) {
+  return path.join(resourcesPath, 'app.asar.unpacked', 'node_modules', 'node-pty')
+}
+
+function patchUnixTerminal(unixTerminalPath) {
+  const source = fs.readFileSync(unixTerminalPath, 'utf8')
+  if (source.includes('function unpackAsarPath(value, marker)')) {
+    return { patched: false, reason: 'already-patched' }
+  }
+
+  if (!source.includes(NODE_PTY_UNIX_TERMINAL_PATTERN)) {
+    throw new Error(`node-pty helperPath pattern not found in ${unixTerminalPath}`)
+  }
+
+  fs.writeFileSync(
+    unixTerminalPath,
+    source.replace(NODE_PTY_UNIX_TERMINAL_PATTERN, NODE_PTY_UNIX_TERMINAL_REPLACEMENT),
+  )
+  return { patched: true }
+}
+
+function chmodExecutableIfPresent(filePath) {
+  if (!fs.existsSync(filePath)) return false
+  fs.chmodSync(filePath, 0o755)
+  return true
+}
+
+function ensureNodePtySpawnHelpersExecutable(nodePtyRoot) {
+  const candidates = [
+    path.join(nodePtyRoot, 'build', 'Release', 'spawn-helper'),
+    path.join(nodePtyRoot, 'prebuilds', 'darwin-arm64', 'spawn-helper'),
+    path.join(nodePtyRoot, 'prebuilds', 'darwin-x64', 'spawn-helper'),
+  ]
+
+  return candidates.filter(chmodExecutableIfPresent)
+}
+
+function patchPackagedNodePty(resourcesPath) {
+  const nodePtyRoot = resolveNodePtyRoot(resourcesPath)
+  const unixTerminalPath = path.join(nodePtyRoot, 'lib', 'unixTerminal.js')
+  const buildHelperPath = path.join(nodePtyRoot, 'build', 'Release', 'spawn-helper')
+
+  if (!fs.existsSync(unixTerminalPath)) {
+    throw new Error(`Packaged node-pty unixTerminal.js not found: ${unixTerminalPath}`)
+  }
+  if (!fs.existsSync(buildHelperPath)) {
+    throw new Error(`Packaged node-pty spawn-helper not found: ${buildHelperPath}`)
+  }
+
+  const patchResult = patchUnixTerminal(unixTerminalPath)
+  const executableHelpers = ensureNodePtySpawnHelpersExecutable(nodePtyRoot)
+
+  return {
+    nodePtyRoot,
+    unixTerminalPath,
+    patchResult,
+    executableHelpers,
+  }
+}
+
+module.exports = {
+  NODE_PTY_UNIX_TERMINAL_PATTERN,
+  NODE_PTY_UNIX_TERMINAL_REPLACEMENT,
+  unpackAsarPath,
+  patchUnixTerminal,
+  ensureNodePtySpawnHelpersExecutable,
+  patchPackagedNodePty,
+}


### PR DESCRIPTION
Summary

Fix Howcode’s packaged terminal startup on macOS when node-pty fails with:

posix_spawnp failed

The packaged node-pty helper path rewrite could incorrectly rewrite paths that already live under app.asar.unpacked, causing paths like:

app.asar.unpacked.unpacked

This PR adds an Electron afterPack patch that makes the helper path rewrite idempotent and ensures packaged node-pty spawn-helper files are executable after packaging.

Changes

* Add scripts/after-pack-electron.cjs as an electron-builder afterPack hook.
* Add scripts/patch-node-pty-helper.cjs to patch packaged node-pty helper resolution.
* Prevent app.asar.unpacked from becoming app.asar.unpacked.unpacked.
* Ensure packaged spawn-helper binaries are executable.
* Add regression coverage for helper path rewriting and idempotent patching.

Validation

* bunx vitest run desktop/terminal/node-pty-packaging.test.ts ✅
* bun run typecheck:desktop ✅
* bun run typecheck:scripts ✅
* bunx biome check electron-builder.yml scripts/patch-node-pty-helper.cjs scripts/after-pack-electron.cjs desktop/terminal/node-pty-packaging.test.ts ✅

Notes

The full repo test suite currently has an unrelated macOS temp path assertion failure in desktop/project-create.test.ts involving /var vs /private/var.