### PR TITLE
Package service native deps for supported Node ABIs

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -96,6 +96,22 @@ jobs:
           fi
           bun run build:release
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25.9.0
+
+      - name: Build Node 25 service native bundle
+        shell: bash
+        run: node scripts/build-service-native-abi-bundle.cjs "$(node scripts/resolve-packaged-resources-path.cjs)"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26.1.0
+
+      - name: Build Node 26 service native bundle
+        shell: bash
+        run: node scripts/build-service-native-abi-bundle.cjs "$(node scripts/resolve-packaged-resources-path.cjs)"
+
       - name: Build launcher archives
         env:
           HOWCODE_RELEASE_ASSET_BASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_type == 'tag' && github.ref_name || format('channel-{0}', github.ref_name) }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -135,6 +135,7 @@ jobs:
             artifacts/npm-launcher/*.tar.gz
             artifacts/electron/*.AppImage
             artifacts/electron/*.exe
+            artifacts/electron/*.zip
 
       - name: Upload main artifacts
         if: github.event_name == 'push' && github.ref_name == 'main'
@@ -148,6 +149,7 @@ jobs:
             artifacts/npm-launcher/*.tar.gz
             artifacts/electron/*.AppImage
             artifacts/electron/*.exe
+            artifacts/electron/*.zip
 
       - name: Upload manual preview artifacts
         if: github.event_name == 'workflow_dispatch'
@@ -161,6 +163,7 @@ jobs:
             artifacts/npm-launcher/*.tar.gz
             artifacts/electron/*.AppImage
             artifacts/electron/*.exe
+            artifacts/electron/*.zip
 
       - name: Upload release files
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -174,6 +177,7 @@ jobs:
             artifacts/npm-launcher/*.tar.gz
             artifacts/electron/*.AppImage
             artifacts/electron/*.exe
+            artifacts/electron/*.zip
 
   cleanup-dev-artifacts:
     name: Cleanup old dev artifacts
@@ -245,7 +249,7 @@ jobs:
           path: release-assets
 
       - name: List channel release assets
-        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
+        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' -o -name '*.zip' \) -print | sort
 
       - name: Prepare channel release notes
         env:
@@ -272,7 +276,7 @@ jobs:
           CHANNEL: ${{ github.ref_name }}
         run: |
           RELEASE_TAG="channel-$CHANNEL"
-          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
+          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' -o -name '*.zip' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
             exit 1
@@ -288,7 +292,7 @@ jobs:
           release_title=$(cat channel-release-title.txt)
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|archive-howcode-[^-]+-[^-]+-[a-f0-9]{64}\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
+            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|archive-howcode-[^-]+-[^-]+-[a-f0-9]{64}\\.tar\\.gz|.*\\.AppImage|.*\\.exe|.*\\.zip)$"))')
             for old_asset in "${old_assets[@]}"; do
               gh release delete-asset "$RELEASE_TAG" "$old_asset" --yes
             done
@@ -315,13 +319,13 @@ jobs:
           path: release-assets
 
       - name: List release assets
-        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
+        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' -o -name '*.zip' \) -print | sort
 
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
+          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' -o -name '*.zip' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
             exit 1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -127,8 +127,6 @@ jobs:
           path: |
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
-            artifacts/electron/*.AppImage
-            artifacts/electron/*.exe
 
       - name: Upload main artifacts
         if: github.event_name == 'push' && github.ref_name == 'main'
@@ -140,8 +138,6 @@ jobs:
           path: |
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
-            artifacts/electron/*.AppImage
-            artifacts/electron/*.exe
 
       - name: Upload manual preview artifacts
         if: github.event_name == 'workflow_dispatch'
@@ -151,9 +147,8 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           path: |
-            artifacts/*
-            !artifacts/npm-launcher
-            artifacts/npm-launcher/*
+            artifacts/stable-*-update.json
+            artifacts/npm-launcher/*.tar.gz
 
       - name: Upload release files
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -165,8 +160,6 @@ jobs:
           path: |
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
-            artifacts/electron/*.AppImage
-            artifacts/electron/*.exe
 
   cleanup-dev-artifacts:
     name: Cleanup old dev artifacts
@@ -238,7 +231,7 @@ jobs:
           path: release-assets
 
       - name: List channel release assets
-        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
+        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print | sort
 
       - name: Prepare channel release notes
         env:
@@ -265,7 +258,7 @@ jobs:
           CHANNEL: ${{ github.ref_name }}
         run: |
           RELEASE_TAG="channel-$CHANNEL"
-          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
+          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
             exit 1
@@ -281,7 +274,7 @@ jobs:
           release_title=$(cat channel-release-title.txt)
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|archive-howcode-[^-]+-[^-]+-[a-f0-9]{64}\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
+            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|archive-howcode-[^-]+-[^-]+-[a-f0-9]{64}\\.tar\\.gz)$"))')
             for old_asset in "${old_assets[@]}"; do
               gh release delete-asset "$RELEASE_TAG" "$old_asset" --yes
             done
@@ -308,13 +301,13 @@ jobs:
           path: release-assets
 
       - name: List release assets
-        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
+        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print | sort
 
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
+          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
             exit 1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -153,7 +153,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
-          name: preview-${{ github.ref_name }}-${{ matrix.name }}
+          name: preview-${{ matrix.name }}
           retention-days: 1
           if-no-files-found: error
           path: |

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Capture Node 25 path
         shell: bash
-        run: echo "HOWCODE_NODE_25_PATH=$(node -p \"process.execPath\")" >> "$GITHUB_ENV"
+        run: echo "HOWCODE_NODE_25_PATH=$(node -p 'process.execPath')" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v6
         with:
@@ -90,7 +90,7 @@ jobs:
 
       - name: Capture Node 26 path
         shell: bash
-        run: echo "HOWCODE_NODE_26_PATH=$(node -p \"process.execPath\")" >> "$GITHUB_ENV"
+        run: echo "HOWCODE_NODE_26_PATH=$(node -p 'process.execPath')" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -76,6 +76,26 @@ jobs:
         if: matrix.name == 'windows-arm64'
         run: npm install --no-save --ignore-scripts --no-audit --no-fund @rollup/rollup-win32-arm64-msvc@4.60.2
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25.9.0
+
+      - name: Capture Node 25 path
+        shell: bash
+        run: echo "HOWCODE_NODE_25_PATH=$(command -v node)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26.1.0
+
+      - name: Capture Node 26 path
+        shell: bash
+        run: echo "HOWCODE_NODE_26_PATH=$(command -v node)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.15.0
+
       - name: Verify release version alignment
         shell: bash
         run: |
@@ -90,27 +110,13 @@ jobs:
 
       - name: Build stable desktop release
         shell: bash
+        env:
+          HOWCODE_BUILD_ALL_SERVICE_NATIVE_ABIS: '1'
         run: |
           if [ "${RUNNER_OS}" = "macOS" ]; then
             ulimit -n 65536 || ulimit -n 10240 || true
           fi
           bun run build:release
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 25.9.0
-
-      - name: Build Node 25 service native bundle
-        shell: bash
-        run: node scripts/build-service-native-abi-bundle.cjs "$(node scripts/resolve-packaged-resources-path.cjs)"
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 26.1.0
-
-      - name: Build Node 26 service native bundle
-        shell: bash
-        run: node scripts/build-service-native-abi-bundle.cjs "$(node scripts/resolve-packaged-resources-path.cjs)"
 
       - name: Build launcher archives
         env:
@@ -127,6 +133,8 @@ jobs:
           path: |
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
+            artifacts/electron/*.AppImage
+            artifacts/electron/*.exe
 
       - name: Upload main artifacts
         if: github.event_name == 'push' && github.ref_name == 'main'
@@ -138,6 +146,8 @@ jobs:
           path: |
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
+            artifacts/electron/*.AppImage
+            artifacts/electron/*.exe
 
       - name: Upload manual preview artifacts
         if: github.event_name == 'workflow_dispatch'
@@ -149,6 +159,8 @@ jobs:
           path: |
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
+            artifacts/electron/*.AppImage
+            artifacts/electron/*.exe
 
       - name: Upload release files
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -160,6 +172,8 @@ jobs:
           path: |
             artifacts/stable-*-update.json
             artifacts/npm-launcher/*.tar.gz
+            artifacts/electron/*.AppImage
+            artifacts/electron/*.exe
 
   cleanup-dev-artifacts:
     name: Cleanup old dev artifacts
@@ -231,7 +245,7 @@ jobs:
           path: release-assets
 
       - name: List channel release assets
-        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print | sort
+        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
 
       - name: Prepare channel release notes
         env:
@@ -258,7 +272,7 @@ jobs:
           CHANNEL: ${{ github.ref_name }}
         run: |
           RELEASE_TAG="channel-$CHANNEL"
-          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print0 | sort -z)
+          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
             exit 1
@@ -274,7 +288,7 @@ jobs:
           release_title=$(cat channel-release-title.txt)
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|archive-howcode-[^-]+-[^-]+-[a-f0-9]{64}\\.tar\\.gz)$"))')
+            mapfile -t old_assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name | select(test("^(stable-.*-update\\.json|howcode-[^-]+-[^-]+\\.tar\\.gz|archive-howcode-[^-]+-[^-]+-[a-f0-9]{64}\\.tar\\.gz|.*\\.AppImage|.*\\.exe)$"))')
             for old_asset in "${old_assets[@]}"; do
               gh release delete-asset "$RELEASE_TAG" "$old_asset" --yes
             done
@@ -301,13 +315,13 @@ jobs:
           path: release-assets
 
       - name: List release assets
-        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print | sort
+        run: find release-assets -maxdepth 2 -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print | sort
 
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' \) -print0 | sort -z)
+          mapfile -d '' assets < <(find release-assets -type f \( -name 'stable-*-update.json' -o -name '*.tar.gz' -o -name '*.AppImage' -o -name '*.exe' \) -print0 | sort -z)
           if [ ${#assets[@]} -eq 0 ]; then
             echo "No release assets found"
             exit 1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Capture Node 25 path
         shell: bash
-        run: echo "HOWCODE_NODE_25_PATH=$(command -v node)" >> "$GITHUB_ENV"
+        run: echo "HOWCODE_NODE_25_PATH=$(node -p \"process.execPath\")" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v6
         with:
@@ -90,7 +90,7 @@ jobs:
 
       - name: Capture Node 26 path
         shell: bash
-        run: echo "HOWCODE_NODE_26_PATH=$(command -v node)" >> "$GITHUB_ENV"
+        run: echo "HOWCODE_NODE_26_PATH=$(node -p \"process.execPath\")" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v6
         with:
@@ -110,8 +110,6 @@ jobs:
 
       - name: Build stable desktop release
         shell: bash
-        env:
-          HOWCODE_BUILD_ALL_SERVICE_NATIVE_ABIS: '1'
         run: |
           if [ "${RUNNER_OS}" = "macOS" ]; then
             ulimit -n 65536 || ulimit -n 10240 || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@
 - Do not consider substantive implementation work complete while `ai:check` is failing.
 - Never weaken strict Biome or TypeScript rules just to silence warnings quickly. Fix the issue properly or add a narrow, justified override.
 - Prefer modular structure before piling more branches into an existing file. When a change adds a new concern, platform split, state machine, or UI surface, first consider a small folder/module boundary instead of growing a godfile/godfunction.
-- Platform-specific behavior should live in platform adapters, not scattered `if (process.platform)` checks across orchestration code.
 
 ## Project Workflow
 - In dev, assume the app dev server is already running; do not start it manually, and use Electron CDP at `127.0.0.1:39217`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@
 - If you touch a subsystem with its own fast deterministic tests, run those too.
 - Do not consider substantive implementation work complete while `ai:check` is failing.
 - Never weaken strict Biome or TypeScript rules just to silence warnings quickly. Fix the issue properly or add a narrow, justified override.
+- Prefer modular structure before piling more branches into an existing file. When a change adds a new concern, platform split, state machine, or UI surface, first consider a small folder/module boundary instead of growing a godfile/godfunction.
+- Platform-specific behavior should live in platform adapters, not scattered `if (process.platform)` checks across orchestration code.
 
 ## Project Workflow
 - In dev, assume the app dev server is already running; do not start it manually, and use Electron CDP at `127.0.0.1:39217`.

--- a/desktop/service-host-runtime.ts
+++ b/desktop/service-host-runtime.ts
@@ -1,0 +1,118 @@
+import { loadAppSettings } from './app-settings/readers.ts'
+import { getPiModule } from './pi-module.ts'
+import * as piSkills from './pi-skills.ts'
+import * as piThreads from './pi-threads.ts'
+import * as skillCreator from './skill-creator-session.ts'
+import * as terminalManager from './terminal/manager.ts'
+import { getDesktopUserDataPath } from './user-data-path.ts'
+
+type ServiceRequest = {
+  type: 'request'
+  id: string
+  module: string
+  method: string
+  args: unknown[]
+}
+
+type ServiceResponse = {
+  type: 'response'
+  id: string
+  ok: boolean
+  result?: unknown
+  error?: string
+  stack?: string
+}
+
+const modules = {
+  piThreads,
+  piSkills,
+  skillCreator,
+  terminalManager,
+} satisfies Record<string, Record<string, unknown>>
+
+type ServiceModuleName = keyof typeof modules
+
+function isServiceModuleName(value: string): value is ServiceModuleName {
+  return Object.hasOwn(modules, value)
+}
+
+function getServiceMethod(moduleName: ServiceModuleName, methodName: string) {
+  const targetModule: Record<string, unknown> = modules[moduleName]
+  if (!Object.hasOwn(targetModule, methodName)) return null
+  const target = targetModule[methodName]
+  return typeof target === 'function' ? target : null
+}
+
+async function getServiceDiagnostics() {
+  let piAgentDir: string | null = null
+  try {
+    const { getAgentDir } = await getPiModule()
+    piAgentDir = getAgentDir()
+  } catch {
+    piAgentDir = null
+  }
+
+  return {
+    nodeExecPath: process.execPath,
+    nodeVersion: process.version,
+    nodeAbi: process.versions.modules,
+    cwd: process.cwd(),
+    userDataPath: getDesktopUserDataPath(),
+    piAgentDir,
+    customPiDirectory: loadAppSettings().customPiDirectory,
+  }
+}
+
+piThreads.subscribeDesktopEvents((event) => {
+  process.send?.({ type: 'desktop-event', event })
+})
+
+terminalManager.subscribeTerminalEvents((event) => {
+  process.send?.({ type: 'terminal-event', event })
+})
+
+async function handleRequest(message: ServiceRequest): Promise<ServiceResponse> {
+  try {
+    if (!isServiceModuleName(message.module)) {
+      throw new Error(`Unknown desktop service module: ${message.module}`)
+    }
+
+    const target = getServiceMethod(message.module, message.method)
+    if (!target) {
+      throw new Error(`Unknown desktop service method: ${message.module}.${message.method}`)
+    }
+
+    const result = await target(...message.args)
+    return { type: 'response', id: message.id, ok: true, result }
+  } catch (error) {
+    const stack = error instanceof Error ? error.stack : undefined
+    return {
+      type: 'response',
+      id: message.id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      ...(stack ? { stack } : {}),
+    }
+  }
+}
+
+process.on('message', (message: ServiceRequest) => {
+  if (!message || message.type !== 'request') return
+  void handleRequest(message).then((response) => process.send?.(response))
+})
+
+async function shutdown() {
+  await Promise.allSettled([
+    piThreads.disposeDesktopRuntime?.(),
+    terminalManager.closeAllTerminals?.(),
+  ])
+  process.exit(0)
+}
+
+process.once('disconnect', () => void shutdown())
+process.once('SIGTERM', () => void shutdown())
+process.once('SIGINT', () => void shutdown())
+
+void getServiceDiagnostics().then((diagnostics) => {
+  process.send?.({ type: 'ready', diagnostics })
+})

--- a/desktop/service-host.ts
+++ b/desktop/service-host.ts
@@ -1,118 +1,37 @@
-import { loadAppSettings } from './app-settings/readers.ts'
-import { getPiModule } from './pi-module.ts'
-import * as piSkills from './pi-skills.ts'
-import * as piThreads from './pi-threads.ts'
-import * as skillCreator from './skill-creator-session.ts'
-import * as terminalManager from './terminal/manager.ts'
-import { getDesktopUserDataPath } from './user-data-path.ts'
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
 
-type ServiceRequest = {
-  type: 'request'
-  id: string
-  module: string
-  method: string
-  args: unknown[]
+const nativeServiceAbiDirectoryName = 'native-node-abi'
+const nativeRuntimeFiles = [
+  path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
+  path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
+]
+
+function getElectronResourcesPath() {
+  // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
+  return process.env['HOWCODE_ELECTRON_RESOURCES_PATH']?.trim() ?? ''
 }
 
-type ServiceResponse = {
-  type: 'response'
-  id: string
-  ok: boolean
-  result?: unknown
-  error?: string
-  stack?: string
-}
+function installNativeDependenciesForCurrentNode() {
+  const resourcesPath = getElectronResourcesPath()
+  if (!resourcesPath) return
 
-const modules = {
-  piThreads,
-  piSkills,
-  skillCreator,
-  terminalManager,
-} satisfies Record<string, Record<string, unknown>>
+  const unpackedAppPath = path.join(resourcesPath, 'app.asar.unpacked')
+  if (!existsSync(unpackedAppPath)) return
 
-type ServiceModuleName = keyof typeof modules
+  const abi = process.versions.modules
+  const abiBundleRoot = path.join(unpackedAppPath, nativeServiceAbiDirectoryName, abi)
+  if (!existsSync(abiBundleRoot)) return
 
-function isServiceModuleName(value: string): value is ServiceModuleName {
-  return Object.hasOwn(modules, value)
-}
-
-function getServiceMethod(moduleName: ServiceModuleName, methodName: string) {
-  const targetModule: Record<string, unknown> = modules[moduleName]
-  if (!Object.hasOwn(targetModule, methodName)) return null
-  const target = targetModule[methodName]
-  return typeof target === 'function' ? target : null
-}
-
-async function getServiceDiagnostics() {
-  let piAgentDir: string | null = null
-  try {
-    const { getAgentDir } = await getPiModule()
-    piAgentDir = getAgentDir()
-  } catch {
-    piAgentDir = null
-  }
-
-  return {
-    nodeExecPath: process.execPath,
-    nodeVersion: process.version,
-    nodeAbi: process.versions.modules,
-    cwd: process.cwd(),
-    userDataPath: getDesktopUserDataPath(),
-    piAgentDir,
-    customPiDirectory: loadAppSettings().customPiDirectory,
+  for (const relativePath of nativeRuntimeFiles) {
+    const sourcePath = path.join(abiBundleRoot, relativePath)
+    const destinationPath = path.join(unpackedAppPath, relativePath)
+    if (!existsSync(sourcePath)) continue
+    mkdirSync(path.dirname(destinationPath), { recursive: true })
+    copyFileSync(sourcePath, destinationPath)
   }
 }
 
-piThreads.subscribeDesktopEvents((event) => {
-  process.send?.({ type: 'desktop-event', event })
-})
-
-terminalManager.subscribeTerminalEvents((event) => {
-  process.send?.({ type: 'terminal-event', event })
-})
-
-async function handleRequest(message: ServiceRequest): Promise<ServiceResponse> {
-  try {
-    if (!isServiceModuleName(message.module)) {
-      throw new Error(`Unknown desktop service module: ${message.module}`)
-    }
-
-    const target = getServiceMethod(message.module, message.method)
-    if (!target) {
-      throw new Error(`Unknown desktop service method: ${message.module}.${message.method}`)
-    }
-
-    const result = await target(...message.args)
-    return { type: 'response', id: message.id, ok: true, result }
-  } catch (error) {
-    const stack = error instanceof Error ? error.stack : undefined
-    return {
-      type: 'response',
-      id: message.id,
-      ok: false,
-      error: error instanceof Error ? error.message : String(error),
-      ...(stack ? { stack } : {}),
-    }
-  }
-}
-
-process.on('message', (message: ServiceRequest) => {
-  if (!message || message.type !== 'request') return
-  void handleRequest(message).then((response) => process.send?.(response))
-})
-
-async function shutdown() {
-  await Promise.allSettled([
-    piThreads.disposeDesktopRuntime?.(),
-    terminalManager.closeAllTerminals?.(),
-  ])
-  process.exit(0)
-}
-
-process.once('disconnect', () => void shutdown())
-process.once('SIGTERM', () => void shutdown())
-process.once('SIGINT', () => void shutdown())
-
-void getServiceDiagnostics().then((diagnostics) => {
-  process.send?.({ type: 'ready', diagnostics })
-})
+installNativeDependenciesForCurrentNode()
+const runtimeEntrypoint = './service-host-runtime.mjs'
+await import(runtimeEntrypoint)

--- a/desktop/service-host.ts
+++ b/desktop/service-host.ts
@@ -1,18 +1,13 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import path from 'node:path'
-
-const nativeServiceAbiDirectoryName = 'native-node-abi'
-const nativeRuntimeFiles = [
-  path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
-  path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
-]
+import serviceNativeAbi from '../shared/service-native-abi.json'
 
 function getElectronResourcesPath() {
   // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
   return process.env['HOWCODE_ELECTRON_RESOURCES_PATH']?.trim() ?? ''
 }
 
-function installNativeDependenciesForCurrentNode() {
+function activateNativeDependenciesForCurrentNode() {
   const resourcesPath = getElectronResourcesPath()
   if (!resourcesPath) return
 
@@ -20,18 +15,17 @@ function installNativeDependenciesForCurrentNode() {
   if (!existsSync(unpackedAppPath)) return
 
   const abi = process.versions.modules
-  const abiBundleRoot = path.join(unpackedAppPath, nativeServiceAbiDirectoryName, abi)
+  const abiBundleRoot = path.join(
+    unpackedAppPath,
+    serviceNativeAbi.nativeServiceAbiDirectoryName,
+    abi,
+  )
   if (!existsSync(abiBundleRoot)) return
-
-  for (const relativePath of nativeRuntimeFiles) {
-    const sourcePath = path.join(abiBundleRoot, relativePath)
-    const destinationPath = path.join(unpackedAppPath, relativePath)
-    if (!existsSync(sourcePath)) continue
-    mkdirSync(path.dirname(destinationPath), { recursive: true })
-    copyFileSync(sourcePath, destinationPath)
-  }
+  const abiNodeModulesPath = path.join(abiBundleRoot, 'node_modules')
+  // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
+  process.env['HOWCODE_SERVICE_NATIVE_NODE_MODULES'] = abiNodeModulesPath
 }
 
-installNativeDependenciesForCurrentNode()
+activateNativeDependenciesForCurrentNode()
 const runtimeEntrypoint = './service-host-runtime.mjs'
 await import(runtimeEntrypoint)

--- a/desktop/terminal/node-pty.ts
+++ b/desktop/terminal/node-pty.ts
@@ -1,4 +1,19 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
 import type { PtyAdapter, PtyExitEvent, PtyProcess, PtySpawnInput } from './types.ts'
+
+const require = createRequire(import.meta.url)
+type NodePtyModule = typeof import('node-pty')
+
+function loadNodePty(): Promise<NodePtyModule> | NodePtyModule {
+  // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
+  const serviceNativeNodeModulesPath = process.env['HOWCODE_SERVICE_NATIVE_NODE_MODULES']?.trim()
+  if (serviceNativeNodeModulesPath) {
+    return require(path.join(serviceNativeNodeModulesPath, 'node-pty')) as NodePtyModule
+  }
+
+  return import('node-pty')
+}
 
 class NodePtyProcess implements PtyProcess {
   private readonly process: import('node-pty').IPty
@@ -44,7 +59,7 @@ class NodePtyProcess implements PtyProcess {
 export const nodePtyAdapter: PtyAdapter = {
   name: 'node-pty',
   async spawn(input: PtySpawnInput) {
-    const nodePty = await import('node-pty')
+    const nodePty = await loadNodePty()
     const processHandle = nodePty.spawn(input.shell, input.args ?? [], {
       cwd: input.cwd,
       cols: input.cols,

--- a/desktop/thread-state-db/db.ts
+++ b/desktop/thread-state-db/db.ts
@@ -4,6 +4,22 @@ import Database from 'better-sqlite3'
 import { getDesktopUserDataPath } from '../user-data-path.ts'
 import { ensureThreadStateSchema } from './schema.ts'
 
+type DatabaseConstructor = new (filename: string, options?: { nativeBinding?: string }) => Database
+
+function getNativeBindingPath() {
+  // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
+  const serviceNativeNodeModulesPath = process.env['HOWCODE_SERVICE_NATIVE_NODE_MODULES']?.trim()
+  return serviceNativeNodeModulesPath
+    ? path.join(
+        serviceNativeNodeModulesPath,
+        'better-sqlite3',
+        'build',
+        'Release',
+        'better_sqlite3.node',
+      )
+    : null
+}
+
 let database: Database | null = null
 
 function getDatabasePath() {
@@ -14,7 +30,11 @@ function getDatabasePath() {
 
 export function getThreadStateDatabase() {
   if (!database) {
-    database = new Database(getDatabasePath())
+    const nativeBinding = getNativeBindingPath()
+    const DatabaseConstructor = Database as unknown as DatabaseConstructor
+    database = nativeBinding
+      ? new DatabaseConstructor(getDatabasePath(), { nativeBinding })
+      : new DatabaseConstructor(getDatabasePath())
   }
 
   ensureThreadStateSchema(database)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 ### 0.1.66
 
 - Split desktop Pi/runtime work into a stock-Node service so native deps stop fighting Electron.
+- Made packaged builds carry Node 24/25/26 native bundles, so the stock-Node service can start cleanly across user Node installs.
 - Added custom Pi directory settings and branch switching/selectors in the dashboard and composer.
 - Added configurable app keybindings.
 - Added thread find and result highlights.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,11 +16,13 @@ extraResources:
   - from: desktop/resources
     to: resources
 mac:
+  artifactName: ${productName}-${version}-${arch}.${ext}
   category: public.app-category.developer-tools
   extendInfo:
     NSMicrophoneUsageDescription: Howcode needs microphone access for local dictation.
   target:
     - dir
+    - zip
 linux:
   target:
     - dir

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:release": "vite build && bun run build:runtime && electron-builder --config electron-builder.yml --publish never",
     "build:launcher-artifacts": "bun ./scripts/package-launcher-artifacts.ts",
     "build:service-native-abi-bundles": "node ./scripts/build-release-service-native-abi-bundles.cjs",
-    "release:prepare": "bun run build:release && bun run build:service-native-abi-bundles && bun run build:launcher-artifacts",
+    "release:prepare": "HOWCODE_BUILD_ALL_SERVICE_NATIVE_ABIS=1 bun run build:release && bun run build:launcher-artifacts",
     "pack:howcode": "bun ./scripts/pack-howcode-launcher.ts main pack",
     "publish:howcode:dry-run": "bun ./scripts/pack-howcode-launcher.ts main publish-dry-run",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "build/electron/main/index.cjs",
   "packageManager": "bun@1.3.10",
   "engines": {
-    "node": ">=24.15.0"
+    "node": ">=24.15.0 <27"
   },
   "scripts": {
     "dev": "bun run dev:clean && concurrently -k \"bun run dev:web\" \"bun run dev:runtime\" \"bun run dev:desktop\"",
@@ -24,7 +24,8 @@
     "build": "vite build && bun run build:runtime && electron-builder --dir --config electron-builder.yml",
     "build:release": "vite build && bun run build:runtime && electron-builder --config electron-builder.yml --publish never",
     "build:launcher-artifacts": "bun ./scripts/package-launcher-artifacts.ts",
-    "release:prepare": "bun run build:release && bun run build:launcher-artifacts",
+    "build:service-native-abi-bundles": "node ./scripts/build-release-service-native-abi-bundles.cjs",
+    "release:prepare": "bun run build:release && bun run build:service-native-abi-bundles && bun run build:launcher-artifacts",
     "pack:howcode": "bun ./scripts/pack-howcode-launcher.ts main pack",
     "publish:howcode:dry-run": "bun ./scripts/pack-howcode-launcher.ts main publish-dry-run",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:release": "vite build && bun run build:runtime && electron-builder --config electron-builder.yml --publish never",
     "build:launcher-artifacts": "bun ./scripts/package-launcher-artifacts.ts",
     "build:service-native-abi-bundles": "node ./scripts/build-release-service-native-abi-bundles.cjs",
-    "release:prepare": "HOWCODE_BUILD_ALL_SERVICE_NATIVE_ABIS=1 bun run build:release && bun run build:launcher-artifacts",
+    "release:prepare": "bun run build:release && bun run build:launcher-artifacts",
     "pack:howcode": "bun ./scripts/pack-howcode-launcher.ts main pack",
     "publish:howcode:dry-run": "bun ./scripts/pack-howcode-launcher.ts main publish-dry-run",
     "preview": "vite preview",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,8 @@
+## Packaged runtime artifacts
+
+- Packaged desktop artifacts are meant to be universal for the supported service Node range, not just the Node used by the builder.
+- Keep AppImage, Windows installers, macOS zip, and launcher archives carrying the same service-native ABI bundle set.
+- `build:release` / `electron-builder` should build all supported service-native ABI bundles during packaging. Do not gate this behind an optional env var unless there is also a clearly named non-universal build path.
+- Service-native ABI bundles must cover every native module loaded by the stock-Node desktop service, currently `better-sqlite3` and `node-pty`.
+- The root unpacked `node_modules` native files should be restored to the builder/current Node ABI after building the matrix; runtime service loading should use the ABI-specific bundle.
+

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -5,4 +5,4 @@
 - `build:release` / `electron-builder` should build all supported service-native ABI bundles during packaging. Do not gate this behind an optional env var unless there is also a clearly named non-universal build path.
 - Service-native ABI bundles must cover every native module loaded by the stock-Node desktop service, currently `better-sqlite3` and `node-pty`.
 - The root unpacked `node_modules` native files should be restored to the builder/current Node ABI after building the matrix; runtime service loading should use the ABI-specific bundle.
-
+- Keep OS-specific native packaging behavior in `scripts/service-native/platforms/*`. Do not scatter platform branches through the release orchestration scripts.

--- a/scripts/after-pack-electron.cjs
+++ b/scripts/after-pack-electron.cjs
@@ -48,8 +48,6 @@ exports.default = async function afterPack(context) {
     validateCurrentNativeDependenciesLoad(resourcesPath)
   }
 
-  if (process.env.HOWCODE_BUILD_ALL_SERVICE_NATIVE_ABIS === '1') {
-    buildReleaseServiceNativeAbiBundles(resourcesPath)
-    patchNodePtyBundles()
-  }
+  buildReleaseServiceNativeAbiBundles(resourcesPath)
+  patchNodePtyBundles()
 }

--- a/scripts/after-pack-electron.cjs
+++ b/scripts/after-pack-electron.cjs
@@ -2,10 +2,12 @@ const path = require('node:path')
 const {
   buildReleaseServiceNativeAbiBundles,
 } = require('./build-release-service-native-abi-bundles.cjs')
-const { patchPackagedNodePty } = require('./patch-node-pty-helper.cjs')
+const { patchNodePtyRoot, patchPackagedNodePty } = require('./patch-node-pty-helper.cjs')
 const {
   copyCurrentNativeDependenciesToAbiBundle,
+  getAbiBundleRoot,
   rebuildServiceNativeDependencies,
+  supportedServiceNodeAbis,
   validateCurrentNativeDependenciesLoad,
 } = require('./service-native-abi.cjs')
 
@@ -18,19 +20,36 @@ exports.default = async function afterPack(context) {
         )
       : path.join(context.appOutDir, 'resources')
 
+  const shouldPatchNodePty = context.electronPlatformName !== 'win32'
+  const patchNodePtyBundles = () => {
+    if (!shouldPatchNodePty) return
+
+    const patchResults = [patchPackagedNodePty(resourcesPath)]
+    for (const abi of supportedServiceNodeAbis) {
+      patchResults.push(
+        patchNodePtyRoot(
+          path.join(getAbiBundleRoot(resourcesPath, abi), 'node_modules', 'node-pty'),
+          {
+            optional: true,
+          },
+        ),
+      )
+    }
+    for (const result of patchResults) {
+      console.log(
+        `Patched packaged node-pty helper resolution at ${result.unixTerminalPath}; executable helpers: ${result.executableHelpers.length}`,
+      )
+    }
+  }
+
   if (rebuildServiceNativeDependencies(resourcesPath)) {
     copyCurrentNativeDependenciesToAbiBundle(resourcesPath)
+    patchNodePtyBundles()
     validateCurrentNativeDependenciesLoad(resourcesPath)
   }
 
   if (process.env.HOWCODE_BUILD_ALL_SERVICE_NATIVE_ABIS === '1') {
     buildReleaseServiceNativeAbiBundles(resourcesPath)
+    patchNodePtyBundles()
   }
-
-  if (context.electronPlatformName === 'win32') return
-
-  const result = patchPackagedNodePty(resourcesPath)
-  console.log(
-    `Patched packaged node-pty helper resolution at ${result.unixTerminalPath}; executable helpers: ${result.executableHelpers.length}`,
-  )
 }

--- a/scripts/after-pack-electron.cjs
+++ b/scripts/after-pack-electron.cjs
@@ -1,9 +1,36 @@
+const { spawnSync } = require('node:child_process')
 const path = require('node:path')
+const { existsSync } = require('node:fs')
 const { patchPackagedNodePty } = require('./patch-node-pty-helper.cjs')
 
-exports.default = async function afterPack(context) {
-  if (context.electronPlatformName === 'win32') return
+const serviceNativePackages = ['better-sqlite3', 'node-pty']
 
+function runNpmRebuildForServiceRuntime(resourcesPath) {
+  const unpackedAppPath = path.join(resourcesPath, 'app.asar.unpacked')
+  if (!existsSync(unpackedAppPath)) {
+    console.warn(`Skipping service native rebuild: ${unpackedAppPath} does not exist.`)
+    return
+  }
+
+  const result = spawnSync('npm', ['rebuild', ...serviceNativePackages, '--build-from-source'], {
+    cwd: unpackedAppPath,
+    env: {
+      ...process.env,
+      npm_config_runtime: 'node',
+      npm_config_target: process.versions.node,
+      npm_config_disturl: 'https://nodejs.org/download/release',
+    },
+    stdio: 'inherit',
+  })
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to rebuild packaged service native dependencies for stock Node: ${serviceNativePackages.join(', ')}.`,
+    )
+  }
+}
+
+exports.default = async function afterPack(context) {
   const resourcesPath =
     context.electronPlatformName === 'darwin'
       ? path.join(
@@ -11,6 +38,10 @@ exports.default = async function afterPack(context) {
           `${context.packager.appInfo.productFilename}.app/Contents/Resources`,
         )
       : path.join(context.appOutDir, 'resources')
+
+  runNpmRebuildForServiceRuntime(resourcesPath)
+
+  if (context.electronPlatformName === 'win32') return
 
   const result = patchPackagedNodePty(resourcesPath)
   console.log(

--- a/scripts/after-pack-electron.cjs
+++ b/scripts/after-pack-electron.cjs
@@ -1,34 +1,10 @@
-const { spawnSync } = require('node:child_process')
 const path = require('node:path')
-const { existsSync } = require('node:fs')
 const { patchPackagedNodePty } = require('./patch-node-pty-helper.cjs')
-
-const serviceNativePackages = ['better-sqlite3', 'node-pty']
-
-function runNpmRebuildForServiceRuntime(resourcesPath) {
-  const unpackedAppPath = path.join(resourcesPath, 'app.asar.unpacked')
-  if (!existsSync(unpackedAppPath)) {
-    console.warn(`Skipping service native rebuild: ${unpackedAppPath} does not exist.`)
-    return
-  }
-
-  const result = spawnSync('npm', ['rebuild', ...serviceNativePackages, '--build-from-source'], {
-    cwd: unpackedAppPath,
-    env: {
-      ...process.env,
-      npm_config_runtime: 'node',
-      npm_config_target: process.versions.node,
-      npm_config_disturl: 'https://nodejs.org/download/release',
-    },
-    stdio: 'inherit',
-  })
-
-  if (result.status !== 0) {
-    throw new Error(
-      `Failed to rebuild packaged service native dependencies for stock Node: ${serviceNativePackages.join(', ')}.`,
-    )
-  }
-}
+const {
+  copyCurrentNativeDependenciesToAbiBundle,
+  rebuildServiceNativeDependencies,
+  validateCurrentNativeDependenciesLoad,
+} = require('./service-native-abi.cjs')
 
 exports.default = async function afterPack(context) {
   const resourcesPath =
@@ -39,7 +15,10 @@ exports.default = async function afterPack(context) {
         )
       : path.join(context.appOutDir, 'resources')
 
-  runNpmRebuildForServiceRuntime(resourcesPath)
+  if (rebuildServiceNativeDependencies(resourcesPath)) {
+    copyCurrentNativeDependenciesToAbiBundle(resourcesPath)
+    validateCurrentNativeDependenciesLoad(resourcesPath)
+  }
 
   if (context.electronPlatformName === 'win32') return
 

--- a/scripts/after-pack-electron.cjs
+++ b/scripts/after-pack-electron.cjs
@@ -1,4 +1,7 @@
 const path = require('node:path')
+const {
+  buildReleaseServiceNativeAbiBundles,
+} = require('./build-release-service-native-abi-bundles.cjs')
 const { patchPackagedNodePty } = require('./patch-node-pty-helper.cjs')
 const {
   copyCurrentNativeDependenciesToAbiBundle,
@@ -18,6 +21,10 @@ exports.default = async function afterPack(context) {
   if (rebuildServiceNativeDependencies(resourcesPath)) {
     copyCurrentNativeDependenciesToAbiBundle(resourcesPath)
     validateCurrentNativeDependenciesLoad(resourcesPath)
+  }
+
+  if (process.env.HOWCODE_BUILD_ALL_SERVICE_NATIVE_ABIS === '1') {
+    buildReleaseServiceNativeAbiBundles(resourcesPath)
   }
 
   if (context.electronPlatformName === 'win32') return

--- a/scripts/after-pack-electron.cjs
+++ b/scripts/after-pack-electron.cjs
@@ -2,7 +2,8 @@ const path = require('node:path')
 const {
   buildReleaseServiceNativeAbiBundles,
 } = require('./build-release-service-native-abi-bundles.cjs')
-const { patchNodePtyRoot, patchPackagedNodePty } = require('./patch-node-pty-helper.cjs')
+const { patchNodePtyRoot } = require('./patch-node-pty-helper.cjs')
+const { getPatchableNodePtyRoots } = require('./service-native/platform.cjs')
 const {
   copyCurrentNativeDependenciesToAbiBundle,
   getAbiBundleRoot,
@@ -20,20 +21,17 @@ exports.default = async function afterPack(context) {
         )
       : path.join(context.appOutDir, 'resources')
 
-  const shouldPatchNodePty = context.electronPlatformName !== 'win32'
   const patchNodePtyBundles = () => {
-    if (!shouldPatchNodePty) return
-
-    const patchResults = [patchPackagedNodePty(resourcesPath)]
+    const patchResults = []
+    for (const nodePtyRoot of getPatchableNodePtyRoots(
+      path.join(resourcesPath, 'app.asar.unpacked'),
+    )) {
+      patchResults.push(patchNodePtyRoot(nodePtyRoot, { optional: true }))
+    }
     for (const abi of supportedServiceNodeAbis) {
-      patchResults.push(
-        patchNodePtyRoot(
-          path.join(getAbiBundleRoot(resourcesPath, abi), 'node_modules', 'node-pty'),
-          {
-            optional: true,
-          },
-        ),
-      )
+      for (const nodePtyRoot of getPatchableNodePtyRoots(getAbiBundleRoot(resourcesPath, abi))) {
+        patchResults.push(patchNodePtyRoot(nodePtyRoot, { optional: true }))
+      }
     }
     for (const result of patchResults) {
       console.log(

--- a/scripts/build-electron-runtime.ts
+++ b/scripts/build-electron-runtime.ts
@@ -25,6 +25,7 @@ const buildTargets = [
       path.join(projectRoot, 'desktop', 'pi-threads.ts'),
       path.join(projectRoot, 'desktop', 'pi-skills.ts'),
       path.join(projectRoot, 'desktop', 'service-host.ts'),
+      path.join(projectRoot, 'desktop', 'service-host-runtime.ts'),
       path.join(projectRoot, 'desktop', 'skill-creator-session.ts'),
       path.join(projectRoot, 'desktop', 'runtime-host', 'worker.ts'),
     ],

--- a/scripts/build-release-service-native-abi-bundles.cjs
+++ b/scripts/build-release-service-native-abi-bundles.cjs
@@ -38,35 +38,45 @@ function runBundleBuilderWithNode(nodeExecutable, targetResourcesPath) {
   ])
 }
 
-const resourcesPath =
-  process.argv[2] ||
-  capture(process.execPath, [path.join(__dirname, 'resolve-packaged-resources-path.cjs')])
+function buildReleaseServiceNativeAbiBundles(resourcesPath) {
+  for (const major of supportedServiceNodeMajors) {
+    if (currentNodeMajor() === major) {
+      runBundleBuilderWithNode(process.execPath, resourcesPath)
+      continue
+    }
 
-if (!resourcesPath) {
-  console.error('Could not resolve packaged resources path. Run `bun run build:release` first.')
-  process.exit(1)
+    const envNodePath = envNodePathForMajor(major)
+    if (envNodePath) {
+      runBundleBuilderWithNode(envNodePath, resourcesPath)
+      continue
+    }
+
+    const miseNodePath = resolveMiseNode(major)
+    if (miseNodePath) {
+      runBundleBuilderWithNode(miseNodePath, resourcesPath)
+      continue
+    }
+
+    console.error(
+      `Missing Node ${major} for service native ABI bundle. Install it with mise, or set HOWCODE_NODE_${major}_PATH to an absolute node executable.`,
+    )
+    process.exit(1)
+  }
 }
 
-for (const major of supportedServiceNodeMajors) {
-  if (currentNodeMajor() === major) {
-    runBundleBuilderWithNode(process.execPath, resourcesPath)
-    continue
-  }
-
-  const envNodePath = envNodePathForMajor(major)
-  if (envNodePath) {
-    runBundleBuilderWithNode(envNodePath, resourcesPath)
-    continue
-  }
-
-  const miseNodePath = resolveMiseNode(major)
-  if (miseNodePath) {
-    runBundleBuilderWithNode(miseNodePath, resourcesPath)
-    continue
-  }
-
-  console.error(
-    `Missing Node ${major} for service native ABI bundle. Install it with mise, or set HOWCODE_NODE_${major}_PATH to an absolute node executable.`,
-  )
-  process.exit(1)
+function resolveDefaultResourcesPath() {
+  return capture(process.execPath, [path.join(__dirname, 'resolve-packaged-resources-path.cjs')])
 }
+
+if (require.main === module) {
+  const resourcesPath = process.argv[2] || resolveDefaultResourcesPath()
+
+  if (!resourcesPath) {
+    console.error('Could not resolve packaged resources path. Run `bun run build:release` first.')
+    process.exit(1)
+  }
+
+  buildReleaseServiceNativeAbiBundles(resourcesPath)
+}
+
+module.exports = { buildReleaseServiceNativeAbiBundles }

--- a/scripts/build-release-service-native-abi-bundles.cjs
+++ b/scripts/build-release-service-native-abi-bundles.cjs
@@ -2,7 +2,11 @@
 const { spawnSync } = require('node:child_process')
 const { existsSync } = require('node:fs')
 const path = require('node:path')
-const { supportedServiceNodeMajors } = require('./service-native-abi.cjs')
+const {
+  copyCurrentNativeDependenciesToAbiBundle,
+  rebuildServiceNativeDependencies,
+  supportedServiceNodeMajors,
+} = require('./service-native-abi.cjs')
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { stdio: 'inherit', shell: false, ...options })
@@ -62,6 +66,16 @@ function buildReleaseServiceNativeAbiBundles(resourcesPath) {
     )
     process.exit(1)
   }
+
+  // The ABI bundles are what the packaged desktop service loads at runtime, but
+  // each rebuild also updates the root unpacked node_modules tree. Leave that
+  // root tree matching the Node that is running electron-builder rather than
+  // whichever supported ABI happened to be built last.
+  if (!rebuildServiceNativeDependencies(resourcesPath)) {
+    console.error(`Could not restore root service native dependencies in ${resourcesPath}.`)
+    process.exit(1)
+  }
+  copyCurrentNativeDependenciesToAbiBundle(resourcesPath)
 }
 
 function resolveDefaultResourcesPath() {

--- a/scripts/build-release-service-native-abi-bundles.cjs
+++ b/scripts/build-release-service-native-abi-bundles.cjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process')
+const { existsSync } = require('node:fs')
+const path = require('node:path')
+const { supportedServiceNodeMajors } = require('./service-native-abi.cjs')
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', shell: false, ...options })
+  if (result.status === 0) return true
+  if (result.error && options.optional) return false
+  if (options.optional) return false
+  process.exit(result.status || 1)
+}
+
+function capture(command, args) {
+  const result = spawnSync(command, args, { encoding: 'utf8' })
+  if (result.status !== 0) return null
+  return result.stdout.trim()
+}
+
+function currentNodeMajor() {
+  return process.versions.node.split('.')[0]
+}
+
+function envNodePathForMajor(major) {
+  return process.env[`HOWCODE_NODE_${major}_PATH`] || process.env[`NODE_${major}_PATH`] || ''
+}
+
+function resolveMiseNode(major) {
+  const output = capture('mise', ['which', `node@${major}`])
+  return output && existsSync(output) ? output : null
+}
+
+function runBundleBuilderWithNode(nodeExecutable, targetResourcesPath) {
+  return run(nodeExecutable, [
+    path.join(__dirname, 'build-service-native-abi-bundle.cjs'),
+    targetResourcesPath,
+  ])
+}
+
+const resourcesPath =
+  process.argv[2] ||
+  capture(process.execPath, [path.join(__dirname, 'resolve-packaged-resources-path.cjs')])
+
+if (!resourcesPath) {
+  console.error('Could not resolve packaged resources path. Run `bun run build:release` first.')
+  process.exit(1)
+}
+
+for (const major of supportedServiceNodeMajors) {
+  if (currentNodeMajor() === major) {
+    runBundleBuilderWithNode(process.execPath, resourcesPath)
+    continue
+  }
+
+  const envNodePath = envNodePathForMajor(major)
+  if (envNodePath) {
+    runBundleBuilderWithNode(envNodePath, resourcesPath)
+    continue
+  }
+
+  const miseNodePath = resolveMiseNode(major)
+  if (miseNodePath) {
+    runBundleBuilderWithNode(miseNodePath, resourcesPath)
+    continue
+  }
+
+  console.error(
+    `Missing Node ${major} for service native ABI bundle. Install it with mise, or set HOWCODE_NODE_${major}_PATH to an absolute node executable.`,
+  )
+  process.exit(1)
+}

--- a/scripts/build-service-native-abi-bundle.cjs
+++ b/scripts/build-service-native-abi-bundle.cjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const path = require('node:path')
+const { patchNodePtyRoot } = require('./patch-node-pty-helper.cjs')
 const {
   copyCurrentNativeDependenciesToAbiBundle,
   rebuildServiceNativeDependencies,
@@ -20,6 +21,9 @@ if (!rebuildServiceNativeDependencies(resolvedResourcesPath)) {
   process.exit(1)
 }
 const bundleRoot = copyCurrentNativeDependenciesToAbiBundle(resolvedResourcesPath)
+if (process.platform !== 'win32') {
+  patchNodePtyRoot(path.join(bundleRoot, 'node_modules', 'node-pty'))
+}
 validateCurrentNativeDependenciesLoad(resolvedResourcesPath)
 console.log(
   `Built service native ABI bundle ${process.versions.modules} for ${process.version} at ${bundleRoot}`,

--- a/scripts/build-service-native-abi-bundle.cjs
+++ b/scripts/build-service-native-abi-bundle.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const path = require('node:path')
 const { patchNodePtyRoot } = require('./patch-node-pty-helper.cjs')
+const { getPatchableNodePtyRoots } = require('./service-native/platform.cjs')
 const {
   copyCurrentNativeDependenciesToAbiBundle,
   rebuildServiceNativeDependencies,
@@ -21,8 +22,8 @@ if (!rebuildServiceNativeDependencies(resolvedResourcesPath)) {
   process.exit(1)
 }
 const bundleRoot = copyCurrentNativeDependenciesToAbiBundle(resolvedResourcesPath)
-if (process.platform !== 'win32') {
-  patchNodePtyRoot(path.join(bundleRoot, 'node_modules', 'node-pty'))
+for (const nodePtyRoot of getPatchableNodePtyRoots(bundleRoot)) {
+  patchNodePtyRoot(nodePtyRoot)
 }
 validateCurrentNativeDependenciesLoad(resolvedResourcesPath)
 console.log(

--- a/scripts/build-service-native-abi-bundle.cjs
+++ b/scripts/build-service-native-abi-bundle.cjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const path = require('node:path')
+const {
+  copyCurrentNativeDependenciesToAbiBundle,
+  rebuildServiceNativeDependencies,
+  validateCurrentNativeDependenciesLoad,
+} = require('./service-native-abi.cjs')
+
+const resourcesPath = process.argv[2]
+if (!resourcesPath) {
+  console.error('Usage: node scripts/build-service-native-abi-bundle.cjs <packaged resources path>')
+  process.exit(1)
+}
+
+const resolvedResourcesPath = path.resolve(resourcesPath)
+rebuildServiceNativeDependencies(resolvedResourcesPath)
+const bundleRoot = copyCurrentNativeDependenciesToAbiBundle(resolvedResourcesPath)
+validateCurrentNativeDependenciesLoad(resolvedResourcesPath)
+console.log(
+  `Built service native ABI bundle ${process.versions.modules} for ${process.version} at ${bundleRoot}`,
+)

--- a/scripts/build-service-native-abi-bundle.cjs
+++ b/scripts/build-service-native-abi-bundle.cjs
@@ -13,7 +13,12 @@ if (!resourcesPath) {
 }
 
 const resolvedResourcesPath = path.resolve(resourcesPath)
-rebuildServiceNativeDependencies(resolvedResourcesPath)
+if (!rebuildServiceNativeDependencies(resolvedResourcesPath)) {
+  console.error(
+    `Could not rebuild service native dependencies: ${resolvedResourcesPath} is not a packaged resources path with app.asar.unpacked.`,
+  )
+  process.exit(1)
+}
 const bundleRoot = copyCurrentNativeDependenciesToAbiBundle(resolvedResourcesPath)
 validateCurrentNativeDependenciesLoad(resolvedResourcesPath)
 console.log(

--- a/scripts/package-launcher-artifacts.ts
+++ b/scripts/package-launcher-artifacts.ts
@@ -5,10 +5,18 @@ import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { existsSync, mkdirSync } from 'node:fs'
 import { copyFile, cp, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
 
 const appName = 'howcode'
+const require = createRequire(import.meta.url)
+const { supportedServiceNodeAbis, serviceNativePackages, nativeServiceAbiDirectoryName } =
+  require('./service-native-abi.cjs') as {
+    supportedServiceNodeAbis: string[]
+    serviceNativePackages: string[]
+    nativeServiceAbiDirectoryName: string
+  }
 
 const electronOutputRoot = path.join(process.cwd(), 'artifacts', 'electron')
 const artifactRoot = path.join(process.cwd(), 'artifacts')
@@ -19,8 +27,6 @@ const requiredUnpackedRuntimePaths = [
   path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
   path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
 ]
-
-const nativeServiceRuntimePackages = ['better-sqlite3', 'node-pty']
 
 type Target = {
   os: 'macos' | 'linux' | 'win'
@@ -165,7 +171,7 @@ async function createNormalizedArchive(bundlePath: string, target: Target) {
     )
   }
 
-  validateUnpackedNativeRuntime(unpackedRoot)
+  validateUnpackedNativeRuntimeBundles(unpackedRoot)
 
   const tarResult = spawnSync('tar', ['-czf', archivePath, '-C', tempRoot, normalizedBundleName], {
     stdio: 'inherit',
@@ -180,23 +186,43 @@ async function createNormalizedArchive(bundlePath: string, target: Target) {
   return archivePath
 }
 
-function validateUnpackedNativeRuntime(unpackedRoot: string) {
-  const nodeModulesPath = path.join(unpackedRoot, 'node_modules')
+function validateUnpackedNativeRuntimeBundles(unpackedRoot: string) {
+  const missingAbiBundles = supportedServiceNodeAbis.filter((abi) =>
+    serviceNativePackages.some(
+      (packageName) =>
+        !existsSync(
+          path.join(unpackedRoot, nativeServiceAbiDirectoryName, abi, 'node_modules', packageName),
+        ),
+    ),
+  )
+  if (missingAbiBundles.length > 0) {
+    throw new Error(
+      `Packaged Electron bundle is missing service native dependency bundles for Node ABI: ${missingAbiBundles.join(', ')}.`,
+    )
+  }
+
+  const currentAbi = process.versions.modules
+  if (!supportedServiceNodeAbis.includes(currentAbi)) return
+
+  const currentAbiNodeModulesPath = path.join(
+    unpackedRoot,
+    nativeServiceAbiDirectoryName,
+    currentAbi,
+    'node_modules',
+  )
+  const currentAbiRoot = path.dirname(currentAbiNodeModulesPath)
+  const fallbackNodeModulesPath = path.join(unpackedRoot, 'node_modules')
   const result = spawnSync(
     process.execPath,
     [
       '-e',
-      `
-        for (const packageName of ${JSON.stringify(nativeServiceRuntimePackages)}) {
-          require(packageName)
-        }
-      `,
+      `for (const packageName of ${JSON.stringify(serviceNativePackages)}) require(packageName)`,
     ],
     {
-      cwd: unpackedRoot,
+      cwd: currentAbiRoot,
       env: {
         ...process.env,
-        NODE_PATH: nodeModulesPath,
+        NODE_PATH: [currentAbiNodeModulesPath, fallbackNodeModulesPath].join(path.delimiter),
       },
       encoding: 'utf8',
     },
@@ -205,7 +231,7 @@ function validateUnpackedNativeRuntime(unpackedRoot: string) {
   if (result.status !== 0) {
     throw new Error(
       [
-        `Packaged native service dependencies do not load under stock Node ${process.version} (ABI ${process.versions.modules}).`,
+        `Packaged native service dependency bundle for ABI ${currentAbi} does not load under ${process.version}.`,
         result.stdout.trim(),
         result.stderr.trim(),
       ]

--- a/scripts/package-launcher-artifacts.ts
+++ b/scripts/package-launcher-artifacts.ts
@@ -20,6 +20,8 @@ const requiredUnpackedRuntimePaths = [
   path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
 ]
 
+const nativeServiceRuntimePackages = ['better-sqlite3', 'node-pty']
+
 type Target = {
   os: 'macos' | 'linux' | 'win'
   arch: 'arm64' | 'x64'
@@ -163,6 +165,8 @@ async function createNormalizedArchive(bundlePath: string, target: Target) {
     )
   }
 
+  validateUnpackedNativeRuntime(unpackedRoot)
+
   const tarResult = spawnSync('tar', ['-czf', archivePath, '-C', tempRoot, normalizedBundleName], {
     stdio: 'inherit',
   })
@@ -174,6 +178,41 @@ async function createNormalizedArchive(bundlePath: string, target: Target) {
   }
 
   return archivePath
+}
+
+function validateUnpackedNativeRuntime(unpackedRoot: string) {
+  const nodeModulesPath = path.join(unpackedRoot, 'node_modules')
+  const result = spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `
+        for (const packageName of ${JSON.stringify(nativeServiceRuntimePackages)}) {
+          require(packageName)
+        }
+      `,
+    ],
+    {
+      cwd: unpackedRoot,
+      env: {
+        ...process.env,
+        NODE_PATH: nodeModulesPath,
+      },
+      encoding: 'utf8',
+    },
+  )
+
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `Packaged native service dependencies do not load under stock Node ${process.version} (ABI ${process.versions.modules}).`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
 }
 
 async function createUpdateMetadata(archivePath: string, target: Target, version: string) {

--- a/scripts/package-launcher-artifacts.ts
+++ b/scripts/package-launcher-artifacts.ts
@@ -11,12 +11,17 @@ import path from 'node:path'
 
 const appName = 'howcode'
 const require = createRequire(import.meta.url)
-const { supportedServiceNodeAbis, serviceNativePackages, nativeServiceAbiDirectoryName } =
-  require('./service-native-abi.cjs') as {
-    supportedServiceNodeAbis: string[]
-    serviceNativePackages: string[]
-    nativeServiceAbiDirectoryName: string
-  }
+const {
+  nativeServiceAbiDirectoryName,
+  serviceNativePackages,
+  supportedServiceNodeAbis,
+  validateAbiBundle,
+} = require('./service-native-abi.cjs') as {
+  supportedServiceNodeAbis: string[]
+  serviceNativePackages: string[]
+  nativeServiceAbiDirectoryName: string
+  validateAbiBundle: (resourcesPath: string, abi: string) => void
+}
 
 const electronOutputRoot = path.join(process.cwd(), 'artifacts', 'electron')
 const artifactRoot = path.join(process.cwd(), 'artifacts')
@@ -187,18 +192,9 @@ async function createNormalizedArchive(bundlePath: string, target: Target) {
 }
 
 function validateUnpackedNativeRuntimeBundles(unpackedRoot: string) {
-  const missingAbiBundles = supportedServiceNodeAbis.filter((abi) =>
-    serviceNativePackages.some(
-      (packageName) =>
-        !existsSync(
-          path.join(unpackedRoot, nativeServiceAbiDirectoryName, abi, 'node_modules', packageName),
-        ),
-    ),
-  )
-  if (missingAbiBundles.length > 0) {
-    throw new Error(
-      `Packaged Electron bundle is missing service native dependency bundles for Node ABI: ${missingAbiBundles.join(', ')}.`,
-    )
+  const resourcesPath = path.dirname(unpackedRoot)
+  for (const abi of supportedServiceNodeAbis) {
+    validateAbiBundle(resourcesPath, abi)
   }
 
   const currentAbi = process.versions.modules

--- a/scripts/package-launcher-artifacts.ts
+++ b/scripts/package-launcher-artifacts.ts
@@ -10,18 +10,15 @@ import os from 'node:os'
 import path from 'node:path'
 
 const appName = 'howcode'
+const nodeMajorVersionPattern = /^v?(\d+)/
+
 const require = createRequire(import.meta.url)
-const {
-  nativeServiceAbiDirectoryName,
-  serviceNativePackages,
-  supportedServiceNodeAbis,
-  validateAbiBundle,
-} = require('./service-native-abi.cjs') as {
-  supportedServiceNodeAbis: string[]
-  serviceNativePackages: string[]
-  nativeServiceAbiDirectoryName: string
-  validateAbiBundle: (resourcesPath: string, abi: string) => void
-}
+const { supportedServiceNodeAbis, validateAbiBundle, validateCurrentNativeDependenciesLoad } =
+  require('./service-native-abi.cjs') as {
+    supportedServiceNodeAbis: string[]
+    validateAbiBundle: (resourcesPath: string, abi: string) => void
+    validateCurrentNativeDependenciesLoad: (resourcesPath: string, nodeExecutable?: string) => void
+  }
 
 const electronOutputRoot = path.join(process.cwd(), 'artifacts', 'electron')
 const artifactRoot = path.join(process.cwd(), 'artifacts')
@@ -191,50 +188,27 @@ async function createNormalizedArchive(bundlePath: string, target: Target) {
   return archivePath
 }
 
+function getValidationNodeExecutable() {
+  const currentMajor = process.version.match(nodeMajorVersionPattern)?.[1]
+  const preferredNodePath = currentMajor
+    ? process.env[`HOWCODE_NODE_${currentMajor}_PATH`]
+    : undefined
+  return (
+    preferredNodePath?.trim() ||
+    process.env['HOWCODE_NODE_PATH']?.trim() ||
+    process.env['NODE']?.trim() ||
+    'node'
+  )
+}
+
 function validateUnpackedNativeRuntimeBundles(unpackedRoot: string) {
   const resourcesPath = path.dirname(unpackedRoot)
   for (const abi of supportedServiceNodeAbis) {
     validateAbiBundle(resourcesPath, abi)
   }
 
-  const currentAbi = process.versions.modules
-  if (!supportedServiceNodeAbis.includes(currentAbi)) return
-
-  const currentAbiNodeModulesPath = path.join(
-    unpackedRoot,
-    nativeServiceAbiDirectoryName,
-    currentAbi,
-    'node_modules',
-  )
-  const currentAbiRoot = path.dirname(currentAbiNodeModulesPath)
-  const fallbackNodeModulesPath = path.join(unpackedRoot, 'node_modules')
-  const result = spawnSync(
-    process.execPath,
-    [
-      '-e',
-      `for (const packageName of ${JSON.stringify(serviceNativePackages)}) require(packageName)`,
-    ],
-    {
-      cwd: currentAbiRoot,
-      env: {
-        ...process.env,
-        NODE_PATH: [currentAbiNodeModulesPath, fallbackNodeModulesPath].join(path.delimiter),
-      },
-      encoding: 'utf8',
-    },
-  )
-
-  if (result.status !== 0) {
-    throw new Error(
-      [
-        `Packaged native service dependency bundle for ABI ${currentAbi} does not load under ${process.version}.`,
-        result.stdout.trim(),
-        result.stderr.trim(),
-      ]
-        .filter(Boolean)
-        .join('\n'),
-    )
-  }
+  const validationNodeExecutable = getValidationNodeExecutable()
+  validateCurrentNativeDependenciesLoad(resourcesPath, validationNodeExecutable)
 }
 
 async function createUpdateMetadata(archivePath: string, target: Target, version: string) {

--- a/scripts/package-launcher-artifacts.ts
+++ b/scripts/package-launcher-artifacts.ts
@@ -27,7 +27,6 @@ const launcherOutputRoot = path.join(artifactRoot, 'npm-launcher')
 const requiredUnpackedRuntimePaths = [
   path.join('build', 'desktop', 'service-host.mjs'),
   path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
-  path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
 ]
 
 type Target = {

--- a/scripts/package-launcher-artifacts.ts
+++ b/scripts/package-launcher-artifacts.ts
@@ -195,7 +195,9 @@ function getValidationNodeExecutable() {
     : undefined
   return (
     preferredNodePath?.trim() ||
+    // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
     process.env['HOWCODE_NODE_PATH']?.trim() ||
+    // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
     process.env['NODE']?.trim() ||
     'node'
   )
@@ -203,12 +205,12 @@ function getValidationNodeExecutable() {
 
 function validateUnpackedNativeRuntimeBundles(unpackedRoot: string) {
   const resourcesPath = path.dirname(unpackedRoot)
+  const validationNodeExecutable = getValidationNodeExecutable()
+  validateCurrentNativeDependenciesLoad(resourcesPath, validationNodeExecutable)
+
   for (const abi of supportedServiceNodeAbis) {
     validateAbiBundle(resourcesPath, abi)
   }
-
-  const validationNodeExecutable = getValidationNodeExecutable()
-  validateCurrentNativeDependenciesLoad(resourcesPath, validationNodeExecutable)
 }
 
 async function createUpdateMetadata(archivePath: string, target: Target, version: string) {

--- a/scripts/patch-node-pty-helper.cjs
+++ b/scripts/patch-node-pty-helper.cjs
@@ -24,43 +24,7 @@ function resolveNodePtyRoot(resourcesPath) {
   return path.join(resourcesPath, 'app.asar.unpacked', 'node_modules', 'node-pty')
 }
 
-function patchUnixTerminal(unixTerminalPath) {
-  const source = fs.readFileSync(unixTerminalPath, 'utf8')
-  if (source.includes('function unpackAsarPath(value, marker)')) {
-    return { patched: false, reason: 'already-patched' }
-  }
-
-  if (!source.includes(NODE_PTY_UNIX_TERMINAL_PATTERN)) {
-    throw new Error(`node-pty helperPath pattern not found in ${unixTerminalPath}`)
-  }
-
-  fs.writeFileSync(
-    unixTerminalPath,
-    source.replace(NODE_PTY_UNIX_TERMINAL_PATTERN, NODE_PTY_UNIX_TERMINAL_REPLACEMENT),
-  )
-  return { patched: true }
-}
-
-function chmodExecutableIfPresent(filePath) {
-  if (!fs.existsSync(filePath)) return false
-  fs.chmodSync(filePath, 0o755)
-  return true
-}
-
-function getNodePtySpawnHelperCandidates(nodePtyRoot) {
-  return [
-    path.join(nodePtyRoot, 'build', 'Release', 'spawn-helper'),
-    path.join(nodePtyRoot, 'prebuilds', 'darwin-arm64', 'spawn-helper'),
-    path.join(nodePtyRoot, 'prebuilds', 'darwin-x64', 'spawn-helper'),
-  ]
-}
-
-function ensureNodePtySpawnHelpersExecutable(nodePtyRoot) {
-  return getNodePtySpawnHelperCandidates(nodePtyRoot).filter(chmodExecutableIfPresent)
-}
-
-function patchPackagedNodePty(resourcesPath, options = {}) {
-  const nodePtyRoot = resolveNodePtyRoot(resourcesPath)
+function patchNodePtyRoot(nodePtyRoot, options = {}) {
   const unixTerminalPath = path.join(nodePtyRoot, 'lib', 'unixTerminal.js')
   const helperCandidates = getNodePtySpawnHelperCandidates(nodePtyRoot)
   const existingHelpers = helperCandidates.filter((candidate) => fs.existsSync(candidate))
@@ -99,11 +63,51 @@ function patchPackagedNodePty(resourcesPath, options = {}) {
   }
 }
 
+function patchUnixTerminal(unixTerminalPath) {
+  const source = fs.readFileSync(unixTerminalPath, 'utf8')
+  if (source.includes('function unpackAsarPath(value, marker)')) {
+    return { patched: false, reason: 'already-patched' }
+  }
+
+  if (!source.includes(NODE_PTY_UNIX_TERMINAL_PATTERN)) {
+    throw new Error(`node-pty helperPath pattern not found in ${unixTerminalPath}`)
+  }
+
+  fs.writeFileSync(
+    unixTerminalPath,
+    source.replace(NODE_PTY_UNIX_TERMINAL_PATTERN, NODE_PTY_UNIX_TERMINAL_REPLACEMENT),
+  )
+  return { patched: true }
+}
+
+function chmodExecutableIfPresent(filePath) {
+  if (!fs.existsSync(filePath)) return false
+  fs.chmodSync(filePath, 0o755)
+  return true
+}
+
+function getNodePtySpawnHelperCandidates(nodePtyRoot) {
+  return [
+    path.join(nodePtyRoot, 'build', 'Release', 'spawn-helper'),
+    path.join(nodePtyRoot, 'prebuilds', 'darwin-arm64', 'spawn-helper'),
+    path.join(nodePtyRoot, 'prebuilds', 'darwin-x64', 'spawn-helper'),
+  ]
+}
+
+function ensureNodePtySpawnHelpersExecutable(nodePtyRoot) {
+  return getNodePtySpawnHelperCandidates(nodePtyRoot).filter(chmodExecutableIfPresent)
+}
+
+function patchPackagedNodePty(resourcesPath, options = {}) {
+  return patchNodePtyRoot(resolveNodePtyRoot(resourcesPath), options)
+}
+
 module.exports = {
   NODE_PTY_UNIX_TERMINAL_PATTERN,
   NODE_PTY_UNIX_TERMINAL_REPLACEMENT,
   unpackAsarPath,
   patchUnixTerminal,
+  patchNodePtyRoot,
   getNodePtySpawnHelperCandidates,
   ensureNodePtySpawnHelpersExecutable,
   patchPackagedNodePty,

--- a/scripts/resolve-packaged-resources-path.cjs
+++ b/scripts/resolve-packaged-resources-path.cjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const { existsSync, readdirSync, statSync } = require('node:fs')
+const path = require('node:path')
+
+const electronOutputRoot = path.join(process.cwd(), 'artifacts', 'electron')
+const appName = 'howcode'
+const unpackedDirectoryPattern = /unpacked$/i
+
+function walkDirectories(root) {
+  const stack = [root]
+  const directories = []
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (!current) continue
+    directories.push(current)
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (entry.isDirectory()) stack.push(path.join(current, entry.name))
+    }
+  }
+  return directories
+}
+
+function getCandidateResourcesPaths() {
+  if (!existsSync(electronOutputRoot)) return []
+  if (process.platform === 'darwin') {
+    return walkDirectories(electronOutputRoot)
+      .filter((entryPath) => entryPath.endsWith(`${appName}.app`))
+      .map((appPath) => path.join(appPath, 'Contents', 'Resources'))
+  }
+
+  return walkDirectories(electronOutputRoot)
+    .filter((entryPath) => unpackedDirectoryPattern.test(path.basename(entryPath)))
+    .map((bundlePath) => path.join(bundlePath, 'resources'))
+}
+
+const candidates = getCandidateResourcesPaths().filter(
+  (resourcesPath) =>
+    existsSync(path.join(resourcesPath, 'app.asar')) ||
+    existsSync(path.join(resourcesPath, 'app', 'package.json')),
+)
+
+if (candidates.length === 0) {
+  console.error(
+    'Could not find packaged Electron resources path. Run `bun run build:release` first.',
+  )
+  process.exit(1)
+}
+
+candidates.sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs)
+console.log(candidates[0])

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -54,14 +54,11 @@ function rebuildServiceNativeDependencies(resourcesPath) {
       `${JSON.stringify({ private: true, dependencies }, null, 2)}\n`,
     )
 
-    const result = spawnSync('npm', ['install', '--build-from-source', '--no-audit', '--no-fund'], {
+    const result = spawnSync('npm', ['install', '--no-audit', '--no-fund'], {
       cwd: tempRoot,
       env: {
         ...process.env,
         PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH || ''}`,
-        npm_config_runtime: 'node',
-        npm_config_target: process.versions.node,
-        npm_config_disturl: 'https://nodejs.org/download/release',
       },
       stdio: 'inherit',
     })

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -12,14 +12,13 @@ const {
 const os = require('node:os')
 const path = require('node:path')
 
-const serviceNativePackages = ['better-sqlite3', 'node-pty']
-const nativeServiceAbiDirectoryName = 'native-node-abi'
-const supportedServiceNodeMajors = ['24', '25', '26']
-const supportedServiceNodeAbis = ['137', '141', '147']
-const nativeRuntimeFiles = [
-  path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
-  path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
-]
+const {
+  nativeServiceAbiDirectoryName,
+  nativeRuntimeFiles,
+  serviceNativePackages,
+  supportedServiceNodeAbis,
+  supportedServiceNodeMajors,
+} = require('../shared/service-native-abi.json')
 
 function getUnpackedAppPath(resourcesPath) {
   return path.join(resourcesPath, 'app.asar.unpacked')
@@ -130,27 +129,6 @@ function copyCurrentNativeDependenciesToAbiBundle(resourcesPath, abi = process.v
   return abiBundleRoot
 }
 
-function installAbiNativeDependencies(resourcesPath, abi) {
-  const unpackedAppPath = getUnpackedAppPath(resourcesPath)
-  const abiBundleRoot = getAbiBundleRoot(resourcesPath, abi)
-
-  if (!existsSync(abiBundleRoot)) {
-    throw new Error(
-      `Missing packaged native dependencies for Node ABI ${abi}. Supported ABIs: ${supportedServiceNodeAbis.join(', ')}.`,
-    )
-  }
-
-  for (const relativePath of nativeRuntimeFiles) {
-    const sourcePath = path.join(abiBundleRoot, relativePath)
-    const destinationPath = path.join(unpackedAppPath, relativePath)
-    if (!existsSync(sourcePath)) {
-      throw new Error(`Missing packaged native dependency for ABI ${abi}: ${sourcePath}`)
-    }
-    mkdirSync(path.dirname(destinationPath), { recursive: true })
-    copyFileSync(sourcePath, destinationPath)
-  }
-}
-
 function validateCurrentNativeDependenciesLoad(resourcesPath) {
   const unpackedAppPath = getUnpackedAppPath(resourcesPath)
   const result = spawnSync(
@@ -197,6 +175,39 @@ function readAbiManifest(resourcesPath, abi) {
   return JSON.parse(readFileSync(manifestPath, 'utf8'))
 }
 
+function validateAbiBundle(resourcesPath, abi) {
+  const abiBundleRoot = getAbiBundleRoot(resourcesPath, abi)
+  const manifestPath = path.join(abiBundleRoot, 'manifest.json')
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Missing service native ABI manifest for Node ABI ${abi}: ${manifestPath}`)
+  }
+
+  const manifest = readAbiManifest(resourcesPath, abi)
+  if (manifest.abi !== String(abi)) {
+    throw new Error(`Service native ABI manifest mismatch at ${manifestPath}: expected ${abi}.`)
+  }
+
+  const manifestFiles = Array.isArray(manifest.files) ? manifest.files : []
+  for (const relativePath of nativeRuntimeFiles) {
+    if (!manifestFiles.includes(relativePath)) {
+      throw new Error(`Service native ABI manifest ${manifestPath} is missing ${relativePath}.`)
+    }
+    const filePath = path.join(abiBundleRoot, relativePath)
+    if (!existsSync(filePath)) {
+      throw new Error(`Missing service native dependency for Node ABI ${abi}: ${filePath}`)
+    }
+  }
+
+  for (const packageName of serviceNativePackages) {
+    const packageJsonPath = path.join(abiBundleRoot, 'node_modules', packageName, 'package.json')
+    if (!existsSync(packageJsonPath)) {
+      throw new Error(
+        `Missing service native package manifest for Node ABI ${abi}: ${packageJsonPath}`,
+      )
+    }
+  }
+}
+
 module.exports = {
   nativeRuntimeFiles,
   nativeServiceAbiDirectoryName,
@@ -206,9 +217,9 @@ module.exports = {
   copyCurrentNativeDependenciesToAbiBundle,
   getAbiBundleRoot,
   getUnpackedAppPath,
-  installAbiNativeDependencies,
   listPackagedAbiBundles,
   readAbiManifest,
   rebuildServiceNativeDependencies,
+  validateAbiBundle,
   validateCurrentNativeDependenciesLoad,
 }

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -143,13 +143,15 @@ function probeNodeAbi(nodeExecutable) {
     encoding: 'utf8',
   })
   if (result.error || result.signal || result.status !== 0) {
+    const stdout = result.stdout?.trim() || ''
+    const stderr = result.stderr?.trim() || ''
     throw new Error(
       [
         `Failed to probe Node ABI for ${nodeExecutable}.`,
         result.error ? `error: ${result.error.message}` : '',
         result.signal ? `signal: ${result.signal}` : '',
-        result.stdout.trim(),
-        result.stderr.trim(),
+        stdout,
+        stderr,
       ]
         .filter(Boolean)
         .join('\n'),
@@ -210,13 +212,15 @@ function validateCurrentNativeDependenciesLoad(resourcesPath, nodeExecutable = p
   })
 
   if (result.error || result.signal || result.status !== 0) {
+    const stdout = result.stdout?.trim() || ''
+    const stderr = result.stderr?.trim() || ''
     throw new Error(
       [
         `Packaged native service dependency bundle for ABI ${abi} does not load under stock Node ${nodeExecutable}.`,
         result.error ? `error: ${result.error.message}` : '',
         result.signal ? `signal: ${result.signal}` : '',
-        result.stdout.trim(),
-        result.stderr.trim(),
+        stdout,
+        stderr,
       ]
         .filter(Boolean)
         .join('\n'),

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -64,9 +64,20 @@ function rebuildServiceNativeDependencies(resourcesPath) {
     })
 
     if (result.status !== 0) {
-      throw new Error(
-        `Failed to build service native dependencies for stock Node: ${serviceNativePackages.join(', ')}.`,
+      console.warn(
+        `Service native dependency install exited with ${result.status}; checking required built files before failing.`,
       )
+    }
+
+    for (const packageName of serviceNativePackages) {
+      const sourcePackagePath = path.join(tempRoot, 'node_modules', packageName)
+      const destinationPackagePath = path.join(unpackedAppPath, 'node_modules', packageName)
+      if (!existsSync(sourcePackagePath)) {
+        throw new Error(`Missing installed service native package: ${sourcePackagePath}`)
+      }
+      rmSync(destinationPackagePath, { recursive: true, force: true })
+      mkdirSync(path.dirname(destinationPackagePath), { recursive: true })
+      cpSync(sourcePackagePath, destinationPackagePath, { recursive: true })
     }
 
     for (const relativePath of nativeRuntimeFiles) {

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -142,10 +142,12 @@ function probeNodeAbi(nodeExecutable) {
   const result = spawnSync(nodeExecutable, ['-p', 'process.versions.modules'], {
     encoding: 'utf8',
   })
-  if (result.status !== 0) {
+  if (result.error || result.signal || result.status !== 0) {
     throw new Error(
       [
         `Failed to probe Node ABI for ${nodeExecutable}.`,
+        result.error ? `error: ${result.error.message}` : '',
+        result.signal ? `signal: ${result.signal}` : '',
         result.stdout.trim(),
         result.stderr.trim(),
       ]
@@ -168,6 +170,15 @@ function getNativeValidationScript() {
     if (process.platform === 'win32') {
       const shell = process.env.ComSpec || 'cmd.exe'
       const pty = nodePty.spawn(shell, ['/d', '/s', '/c', 'exit 0'], {
+        cols: 80,
+        rows: 24,
+        cwd: process.cwd(),
+        env: process.env,
+      })
+      setTimeout(() => pty.kill(), 2000).unref?.()
+      pty.onExit(() => process.exit(0))
+    } else {
+      const pty = nodePty.spawn('/bin/sh', ['-lc', 'exit 0'], {
         cols: 80,
         rows: 24,
         cwd: process.cwd(),
@@ -198,10 +209,12 @@ function validateCurrentNativeDependenciesLoad(resourcesPath, nodeExecutable = p
     timeout: 10_000,
   })
 
-  if (result.status !== 0) {
+  if (result.error || result.signal || result.status !== 0) {
     throw new Error(
       [
         `Packaged native service dependency bundle for ABI ${abi} does not load under stock Node ${nodeExecutable}.`,
+        result.error ? `error: ${result.error.message}` : '',
+        result.signal ? `signal: ${result.signal}` : '',
         result.stdout.trim(),
         result.stderr.trim(),
       ]

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -14,12 +14,17 @@ const path = require('node:path')
 
 const {
   nativeServiceAbiDirectoryName,
-  nativeRuntimeFiles,
-  requiredNativeRuntimeFiles = nativeRuntimeFiles,
   serviceNativePackages,
   supportedServiceNodeAbis,
   supportedServiceNodeMajors,
-} = require('../shared/service-native-abi.json')
+} = require('./service-native/contract.cjs')
+const {
+  getNpmExecutable,
+  getPlatformNativeRuntimeFiles,
+  getPtyValidationScript,
+  getRequiredNativeRuntimeFiles,
+  shouldUseShellForNpmInstall,
+} = require('./service-native/platform.cjs')
 
 function getUnpackedAppPath(resourcesPath) {
   return path.join(resourcesPath, 'app.asar.unpacked')
@@ -72,13 +77,14 @@ function rebuildServiceNativeDependencies(resourcesPath) {
       `${JSON.stringify({ private: true, dependencies }, null, 2)}\n`,
     )
 
-    const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const npmExecutable = getNpmExecutable()
     const result = spawnSync(npmExecutable, ['install', '--no-audit', '--no-fund'], {
       cwd: tempRoot,
       env: {
         ...process.env,
         PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH || ''}`,
       },
+      shell: shouldUseShellForNpmInstall(),
       stdio: 'inherit',
     })
 
@@ -95,11 +101,11 @@ function rebuildServiceNativeDependencies(resourcesPath) {
       cpSync(sourcePackagePath, destinationPackagePath, { recursive: true })
     }
 
-    for (const relativePath of nativeRuntimeFiles) {
+    for (const relativePath of getPlatformNativeRuntimeFiles()) {
       const sourcePath = path.join(tempRoot, relativePath)
       const destinationPath = path.join(unpackedAppPath, relativePath)
       if (!existsSync(sourcePath)) {
-        if (requiredNativeRuntimeFiles.includes(relativePath)) {
+        if (getRequiredNativeRuntimeFiles().includes(relativePath)) {
           throw new Error(`Missing built native dependency: ${sourcePath}`)
         }
         continue
@@ -130,11 +136,11 @@ function copyCurrentNativeDependenciesToAbiBundle(resourcesPath, abi = process.v
   }
 
   const copiedFiles = []
-  for (const relativePath of nativeRuntimeFiles) {
+  for (const relativePath of getPlatformNativeRuntimeFiles()) {
     const sourcePath = path.join(unpackedAppPath, relativePath)
     const destinationPath = path.join(abiBundleRoot, relativePath)
     if (!existsSync(sourcePath)) {
-      if (requiredNativeRuntimeFiles.includes(relativePath)) {
+      if (getRequiredNativeRuntimeFiles().includes(relativePath)) {
         throw new Error(`Missing rebuilt native dependency: ${sourcePath}`)
       }
       continue
@@ -192,26 +198,9 @@ function getNativeValidationScript() {
     db.close()
 
     const nodePty = require('node-pty')
-    if (process.platform === 'win32') {
-      const shell = process.env.ComSpec || 'cmd.exe'
-      const pty = nodePty.spawn(shell, ['/d', '/s', '/c', 'exit 0'], {
-        cols: 80,
-        rows: 24,
-        cwd: process.cwd(),
-        env: process.env,
-      })
-      setTimeout(() => pty.kill(), 2000).unref?.()
-      pty.onExit(() => process.exit(0))
-    } else {
-      const pty = nodePty.spawn('/bin/sh', ['-lc', 'exit 0'], {
-        cols: 80,
-        rows: 24,
-        cwd: process.cwd(),
-        env: process.env,
-      })
-      setTimeout(() => pty.kill(), 2000).unref?.()
-      pty.onExit(() => process.exit(0))
-    }
+    ${getPtyValidationScript()}
+    setTimeout(() => pty.kill(), 2000).unref?.()
+    pty.onExit(() => process.exit(0))
   `
 }
 
@@ -270,7 +259,7 @@ function assertManifestFileExists(abiBundleRoot, abi, relativePath) {
 }
 
 function validateAbiManifestFiles(abiBundleRoot, abi, manifestPath, manifestFiles) {
-  for (const relativePath of requiredNativeRuntimeFiles) {
+  for (const relativePath of getRequiredNativeRuntimeFiles()) {
     if (!manifestFiles.includes(relativePath)) {
       throw new Error(`Service native ABI manifest ${manifestPath} is missing ${relativePath}.`)
     }
@@ -278,7 +267,7 @@ function validateAbiManifestFiles(abiBundleRoot, abi, manifestPath, manifestFile
   }
 
   for (const relativePath of manifestFiles) {
-    if (!nativeRuntimeFiles.includes(relativePath)) {
+    if (!getPlatformNativeRuntimeFiles().includes(relativePath)) {
       throw new Error(
         `Service native ABI manifest ${manifestPath} lists unexpected file ${relativePath}.`,
       )
@@ -313,8 +302,8 @@ function validateAbiBundle(resourcesPath, abi) {
 }
 
 module.exports = {
-  nativeRuntimeFiles,
-  requiredNativeRuntimeFiles,
+  getPlatformNativeRuntimeFiles,
+  getRequiredNativeRuntimeFiles,
   nativeServiceAbiDirectoryName,
   serviceNativePackages,
   supportedServiceNodeMajors,

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -1,0 +1,214 @@
+const { spawnSync } = require('node:child_process')
+const {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const serviceNativePackages = ['better-sqlite3', 'node-pty']
+const nativeServiceAbiDirectoryName = 'native-node-abi'
+const supportedServiceNodeMajors = ['24', '25', '26']
+const supportedServiceNodeAbis = ['137', '141', '147']
+const nativeRuntimeFiles = [
+  path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
+  path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
+]
+
+function getUnpackedAppPath(resourcesPath) {
+  return path.join(resourcesPath, 'app.asar.unpacked')
+}
+
+function getAbiBundleRoot(resourcesPath, abi = process.versions.modules) {
+  return path.join(getUnpackedAppPath(resourcesPath), nativeServiceAbiDirectoryName, String(abi))
+}
+
+function rebuildServiceNativeDependencies(resourcesPath) {
+  const unpackedAppPath = getUnpackedAppPath(resourcesPath)
+  if (!existsSync(unpackedAppPath)) {
+    console.warn(`Skipping service native rebuild: ${unpackedAppPath} does not exist.`)
+    return false
+  }
+
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'howcode-service-native-'))
+  try {
+    const dependencies = Object.fromEntries(
+      serviceNativePackages.map((packageName) => {
+        const packageJson = JSON.parse(
+          readFileSync(
+            path.join(unpackedAppPath, 'node_modules', packageName, 'package.json'),
+            'utf8',
+          ),
+        )
+        return [packageName, packageJson.version]
+      }),
+    )
+    writeFileSync(
+      path.join(tempRoot, 'package.json'),
+      `${JSON.stringify({ private: true, dependencies }, null, 2)}\n`,
+    )
+
+    const result = spawnSync('npm', ['install', '--build-from-source', '--no-audit', '--no-fund'], {
+      cwd: tempRoot,
+      env: {
+        ...process.env,
+        PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH || ''}`,
+        npm_config_runtime: 'node',
+        npm_config_target: process.versions.node,
+        npm_config_disturl: 'https://nodejs.org/download/release',
+      },
+      stdio: 'inherit',
+    })
+
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to build service native dependencies for stock Node: ${serviceNativePackages.join(', ')}.`,
+      )
+    }
+
+    for (const relativePath of nativeRuntimeFiles) {
+      const sourcePath = path.join(tempRoot, relativePath)
+      const destinationPath = path.join(unpackedAppPath, relativePath)
+      if (!existsSync(sourcePath)) {
+        throw new Error(`Missing built native dependency: ${sourcePath}`)
+      }
+      mkdirSync(path.dirname(destinationPath), { recursive: true })
+      copyFileSync(sourcePath, destinationPath)
+    }
+
+    return true
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+function copyCurrentNativeDependenciesToAbiBundle(resourcesPath, abi = process.versions.modules) {
+  const unpackedAppPath = getUnpackedAppPath(resourcesPath)
+  const abiBundleRoot = getAbiBundleRoot(resourcesPath, abi)
+
+  for (const packageName of serviceNativePackages) {
+    const sourcePackagePath = path.join(unpackedAppPath, 'node_modules', packageName)
+    const destinationPackagePath = path.join(abiBundleRoot, 'node_modules', packageName)
+    if (!existsSync(sourcePackagePath)) {
+      throw new Error(`Missing rebuilt native package: ${sourcePackagePath}`)
+    }
+    rmSync(destinationPackagePath, { recursive: true, force: true })
+    mkdirSync(path.dirname(destinationPackagePath), { recursive: true })
+    cpSync(sourcePackagePath, destinationPackagePath, { recursive: true })
+  }
+
+  for (const relativePath of nativeRuntimeFiles) {
+    const sourcePath = path.join(unpackedAppPath, relativePath)
+    const destinationPath = path.join(abiBundleRoot, relativePath)
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Missing rebuilt native dependency: ${sourcePath}`)
+    }
+    mkdirSync(path.dirname(destinationPath), { recursive: true })
+    copyFileSync(sourcePath, destinationPath)
+  }
+
+  writeFileSync(
+    path.join(abiBundleRoot, 'manifest.json'),
+    `${JSON.stringify(
+      {
+        abi: String(abi),
+        nodeVersion: process.version,
+        packages: serviceNativePackages,
+        files: nativeRuntimeFiles,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+
+  return abiBundleRoot
+}
+
+function installAbiNativeDependencies(resourcesPath, abi) {
+  const unpackedAppPath = getUnpackedAppPath(resourcesPath)
+  const abiBundleRoot = getAbiBundleRoot(resourcesPath, abi)
+
+  if (!existsSync(abiBundleRoot)) {
+    throw new Error(
+      `Missing packaged native dependencies for Node ABI ${abi}. Supported ABIs: ${supportedServiceNodeAbis.join(', ')}.`,
+    )
+  }
+
+  for (const relativePath of nativeRuntimeFiles) {
+    const sourcePath = path.join(abiBundleRoot, relativePath)
+    const destinationPath = path.join(unpackedAppPath, relativePath)
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Missing packaged native dependency for ABI ${abi}: ${sourcePath}`)
+    }
+    mkdirSync(path.dirname(destinationPath), { recursive: true })
+    copyFileSync(sourcePath, destinationPath)
+  }
+}
+
+function validateCurrentNativeDependenciesLoad(resourcesPath) {
+  const unpackedAppPath = getUnpackedAppPath(resourcesPath)
+  const result = spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `
+        for (const packageName of ${JSON.stringify(serviceNativePackages)}) {
+          require(packageName)
+        }
+      `,
+    ],
+    {
+      cwd: unpackedAppPath,
+      env: {
+        ...process.env,
+        NODE_PATH: path.join(unpackedAppPath, 'node_modules'),
+      },
+      encoding: 'utf8',
+    },
+  )
+
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `Packaged native service dependencies do not load under stock Node ${process.version} (ABI ${process.versions.modules}).`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
+}
+
+function listPackagedAbiBundles(resourcesPath) {
+  const root = path.join(getUnpackedAppPath(resourcesPath), nativeServiceAbiDirectoryName)
+  if (!existsSync(root)) return []
+  return supportedServiceNodeAbis.filter((abi) => existsSync(path.join(root, abi, 'manifest.json')))
+}
+
+function readAbiManifest(resourcesPath, abi) {
+  const manifestPath = path.join(getAbiBundleRoot(resourcesPath, abi), 'manifest.json')
+  return JSON.parse(readFileSync(manifestPath, 'utf8'))
+}
+
+module.exports = {
+  nativeRuntimeFiles,
+  nativeServiceAbiDirectoryName,
+  serviceNativePackages,
+  supportedServiceNodeMajors,
+  supportedServiceNodeAbis,
+  copyCurrentNativeDependenciesToAbiBundle,
+  getAbiBundleRoot,
+  getUnpackedAppPath,
+  installAbiNativeDependencies,
+  listPackagedAbiBundles,
+  readAbiManifest,
+  rebuildServiceNativeDependencies,
+  validateCurrentNativeDependenciesLoad,
+}

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -15,6 +15,7 @@ const path = require('node:path')
 const {
   nativeServiceAbiDirectoryName,
   nativeRuntimeFiles,
+  requiredNativeRuntimeFiles = nativeRuntimeFiles,
   serviceNativePackages,
   supportedServiceNodeAbis,
   supportedServiceNodeMajors,
@@ -75,7 +76,10 @@ function rebuildServiceNativeDependencies(resourcesPath) {
       const sourcePath = path.join(tempRoot, relativePath)
       const destinationPath = path.join(unpackedAppPath, relativePath)
       if (!existsSync(sourcePath)) {
-        throw new Error(`Missing built native dependency: ${sourcePath}`)
+        if (requiredNativeRuntimeFiles.includes(relativePath)) {
+          throw new Error(`Missing built native dependency: ${sourcePath}`)
+        }
+        continue
       }
       mkdirSync(path.dirname(destinationPath), { recursive: true })
       copyFileSync(sourcePath, destinationPath)
@@ -102,14 +106,19 @@ function copyCurrentNativeDependenciesToAbiBundle(resourcesPath, abi = process.v
     cpSync(sourcePackagePath, destinationPackagePath, { recursive: true })
   }
 
+  const copiedFiles = []
   for (const relativePath of nativeRuntimeFiles) {
     const sourcePath = path.join(unpackedAppPath, relativePath)
     const destinationPath = path.join(abiBundleRoot, relativePath)
     if (!existsSync(sourcePath)) {
-      throw new Error(`Missing rebuilt native dependency: ${sourcePath}`)
+      if (requiredNativeRuntimeFiles.includes(relativePath)) {
+        throw new Error(`Missing rebuilt native dependency: ${sourcePath}`)
+      }
+      continue
     }
     mkdirSync(path.dirname(destinationPath), { recursive: true })
     copyFileSync(sourcePath, destinationPath)
+    copiedFiles.push(relativePath)
   }
 
   writeFileSync(
@@ -119,7 +128,7 @@ function copyCurrentNativeDependenciesToAbiBundle(resourcesPath, abi = process.v
         abi: String(abi),
         nodeVersion: process.version,
         packages: serviceNativePackages,
-        files: nativeRuntimeFiles,
+        files: copiedFiles,
       },
       null,
       2,
@@ -129,32 +138,70 @@ function copyCurrentNativeDependenciesToAbiBundle(resourcesPath, abi = process.v
   return abiBundleRoot
 }
 
-function validateCurrentNativeDependenciesLoad(resourcesPath) {
+function probeNodeAbi(nodeExecutable) {
+  const result = spawnSync(nodeExecutable, ['-p', 'process.versions.modules'], {
+    encoding: 'utf8',
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `Failed to probe Node ABI for ${nodeExecutable}.`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
+  return result.stdout.trim()
+}
+
+function getNativeValidationScript() {
+  return `
+    const betterSqlite3 = require('better-sqlite3')
+    const Database = betterSqlite3.default || betterSqlite3
+    const db = new Database(':memory:')
+    db.prepare('select 1').get()
+    db.close()
+
+    const nodePty = require('node-pty')
+    if (process.platform === 'win32') {
+      const shell = process.env.ComSpec || 'cmd.exe'
+      const pty = nodePty.spawn(shell, ['/d', '/s', '/c', 'exit 0'], {
+        cols: 80,
+        rows: 24,
+        cwd: process.cwd(),
+        env: process.env,
+      })
+      setTimeout(() => pty.kill(), 2000).unref?.()
+      pty.onExit(() => process.exit(0))
+    }
+  `
+}
+
+function validateCurrentNativeDependenciesLoad(resourcesPath, nodeExecutable = process.execPath) {
   const unpackedAppPath = getUnpackedAppPath(resourcesPath)
-  const result = spawnSync(
-    process.execPath,
-    [
-      '-e',
-      `
-        for (const packageName of ${JSON.stringify(serviceNativePackages)}) {
-          require(packageName)
-        }
-      `,
-    ],
-    {
-      cwd: unpackedAppPath,
-      env: {
-        ...process.env,
-        NODE_PATH: path.join(unpackedAppPath, 'node_modules'),
-      },
-      encoding: 'utf8',
+  const abi = probeNodeAbi(nodeExecutable)
+  const abiBundleRoot = getAbiBundleRoot(resourcesPath, abi)
+  validateAbiBundle(resourcesPath, abi)
+
+  const result = spawnSync(nodeExecutable, ['-e', getNativeValidationScript()], {
+    cwd: abiBundleRoot,
+    env: {
+      ...process.env,
+      NODE_PATH: [
+        path.join(abiBundleRoot, 'node_modules'),
+        path.join(unpackedAppPath, 'node_modules'),
+      ].join(path.delimiter),
     },
-  )
+    encoding: 'utf8',
+    timeout: 10_000,
+  })
 
   if (result.status !== 0) {
     throw new Error(
       [
-        `Packaged native service dependencies do not load under stock Node ${process.version} (ABI ${process.versions.modules}).`,
+        `Packaged native service dependency bundle for ABI ${abi} does not load under stock Node ${nodeExecutable}.`,
         result.stdout.trim(),
         result.stderr.trim(),
       ]
@@ -175,6 +222,31 @@ function readAbiManifest(resourcesPath, abi) {
   return JSON.parse(readFileSync(manifestPath, 'utf8'))
 }
 
+function assertManifestFileExists(abiBundleRoot, abi, relativePath) {
+  const filePath = path.join(abiBundleRoot, relativePath)
+  if (!existsSync(filePath)) {
+    throw new Error(`Missing service native dependency for Node ABI ${abi}: ${filePath}`)
+  }
+}
+
+function validateAbiManifestFiles(abiBundleRoot, abi, manifestPath, manifestFiles) {
+  for (const relativePath of requiredNativeRuntimeFiles) {
+    if (!manifestFiles.includes(relativePath)) {
+      throw new Error(`Service native ABI manifest ${manifestPath} is missing ${relativePath}.`)
+    }
+    assertManifestFileExists(abiBundleRoot, abi, relativePath)
+  }
+
+  for (const relativePath of manifestFiles) {
+    if (!nativeRuntimeFiles.includes(relativePath)) {
+      throw new Error(
+        `Service native ABI manifest ${manifestPath} lists unexpected file ${relativePath}.`,
+      )
+    }
+    assertManifestFileExists(abiBundleRoot, abi, relativePath)
+  }
+}
+
 function validateAbiBundle(resourcesPath, abi) {
   const abiBundleRoot = getAbiBundleRoot(resourcesPath, abi)
   const manifestPath = path.join(abiBundleRoot, 'manifest.json')
@@ -188,15 +260,7 @@ function validateAbiBundle(resourcesPath, abi) {
   }
 
   const manifestFiles = Array.isArray(manifest.files) ? manifest.files : []
-  for (const relativePath of nativeRuntimeFiles) {
-    if (!manifestFiles.includes(relativePath)) {
-      throw new Error(`Service native ABI manifest ${manifestPath} is missing ${relativePath}.`)
-    }
-    const filePath = path.join(abiBundleRoot, relativePath)
-    if (!existsSync(filePath)) {
-      throw new Error(`Missing service native dependency for Node ABI ${abi}: ${filePath}`)
-    }
-  }
+  validateAbiManifestFiles(abiBundleRoot, abi, manifestPath, manifestFiles)
 
   for (const packageName of serviceNativePackages) {
     const packageJsonPath = path.join(abiBundleRoot, 'node_modules', packageName, 'package.json')
@@ -210,6 +274,7 @@ function validateAbiBundle(resourcesPath, abi) {
 
 module.exports = {
   nativeRuntimeFiles,
+  requiredNativeRuntimeFiles,
   nativeServiceAbiDirectoryName,
   serviceNativePackages,
   supportedServiceNodeMajors,

--- a/scripts/service-native-abi.cjs
+++ b/scripts/service-native-abi.cjs
@@ -29,6 +29,24 @@ function getAbiBundleRoot(resourcesPath, abi = process.versions.modules) {
   return path.join(getUnpackedAppPath(resourcesPath), nativeServiceAbiDirectoryName, String(abi))
 }
 
+function validateServiceNativeInstallResult(result, npmExecutable) {
+  if (result.error) {
+    throw new Error(
+      `Failed to run ${npmExecutable} for service native dependencies: ${result.error.message}`,
+    )
+  }
+  if (result.signal) {
+    throw new Error(
+      `Service native dependency install was terminated by ${result.signal}: ${serviceNativePackages.join(', ')}.`,
+    )
+  }
+  if (result.status !== 0) {
+    console.warn(
+      `Service native dependency install exited with ${result.status}; checking required built files before failing.`,
+    )
+  }
+}
+
 function rebuildServiceNativeDependencies(resourcesPath) {
   const unpackedAppPath = getUnpackedAppPath(resourcesPath)
   if (!existsSync(unpackedAppPath)) {
@@ -54,7 +72,8 @@ function rebuildServiceNativeDependencies(resourcesPath) {
       `${JSON.stringify({ private: true, dependencies }, null, 2)}\n`,
     )
 
-    const result = spawnSync('npm', ['install', '--no-audit', '--no-fund'], {
+    const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const result = spawnSync(npmExecutable, ['install', '--no-audit', '--no-fund'], {
       cwd: tempRoot,
       env: {
         ...process.env,
@@ -63,11 +82,7 @@ function rebuildServiceNativeDependencies(resourcesPath) {
       stdio: 'inherit',
     })
 
-    if (result.status !== 0) {
-      console.warn(
-        `Service native dependency install exited with ${result.status}; checking required built files before failing.`,
-      )
-    }
+    validateServiceNativeInstallResult(result, npmExecutable)
 
     for (const packageName of serviceNativePackages) {
       const sourcePackagePath = path.join(tempRoot, 'node_modules', packageName)

--- a/scripts/service-native/contract.cjs
+++ b/scripts/service-native/contract.cjs
@@ -1,0 +1,21 @@
+const path = require('node:path')
+const contract = require('../../shared/service-native-abi.json')
+
+function getUnpackedAppPath(resourcesPath) {
+  return path.join(resourcesPath, 'app.asar.unpacked')
+}
+
+function getAbiBundleRoot(resourcesPath, abi = process.versions.modules) {
+  return path.join(
+    getUnpackedAppPath(resourcesPath),
+    contract.nativeServiceAbiDirectoryName,
+    String(abi),
+  )
+}
+
+module.exports = {
+  ...contract,
+  requiredNativeRuntimeFiles: contract.requiredNativeRuntimeFiles || contract.nativeRuntimeFiles,
+  getUnpackedAppPath,
+  getAbiBundleRoot,
+}

--- a/scripts/service-native/platform.cjs
+++ b/scripts/service-native/platform.cjs
@@ -1,0 +1,41 @@
+const path = require('node:path')
+
+function loadPlatformAdapter(platform = process.platform) {
+  if (platform === 'darwin') return require('./platforms/darwin.cjs')
+  if (platform === 'win32') return require('./platforms/win32.cjs')
+  return require('./platforms/linux.cjs')
+}
+
+function getNpmExecutable(platform = process.platform) {
+  return loadPlatformAdapter(platform).npmExecutable()
+}
+
+function getPlatformNativeRuntimeFiles(platform = process.platform, arch = process.arch) {
+  return loadPlatformAdapter(platform).nativeRuntimeFiles(arch)
+}
+
+function getRequiredNativeRuntimeFiles(platform = process.platform) {
+  return loadPlatformAdapter(platform).requiredNativeRuntimeFiles()
+}
+
+function getPtyValidationScript(platform = process.platform) {
+  return loadPlatformAdapter(platform).ptyValidationScript()
+}
+
+function shouldUseShellForNpmInstall(platform = process.platform) {
+  return Boolean(loadPlatformAdapter(platform).useShellForNpmInstall)
+}
+
+function getPatchableNodePtyRoots(bundleRoot, platform = process.platform) {
+  if (!loadPlatformAdapter(platform).patchNodePty) return []
+  return [path.join(bundleRoot, 'node_modules', 'node-pty')]
+}
+
+module.exports = {
+  getNpmExecutable,
+  getPatchableNodePtyRoots,
+  getPlatformNativeRuntimeFiles,
+  getPtyValidationScript,
+  getRequiredNativeRuntimeFiles,
+  shouldUseShellForNpmInstall,
+}

--- a/scripts/service-native/platforms/darwin.cjs
+++ b/scripts/service-native/platforms/darwin.cjs
@@ -1,0 +1,40 @@
+const betterSqliteFile = 'node_modules/better-sqlite3/build/Release/better_sqlite3.node'
+
+function unique(values) {
+  return [...new Set(values)]
+}
+
+function nativeRuntimeFiles(arch = process.arch) {
+  const arches = unique([arch, 'x64', 'arm64'])
+  return [
+    betterSqliteFile,
+    ...arches.flatMap((targetArch) => [
+      `node_modules/node-pty/prebuilds/darwin-${targetArch}/pty.node`,
+      `node_modules/node-pty/prebuilds/darwin-${targetArch}/spawn-helper`,
+    ]),
+    'node_modules/node-pty/build/Release/pty.node',
+  ]
+}
+
+function requiredNativeRuntimeFiles() {
+  return [betterSqliteFile]
+}
+
+function ptyValidationScript() {
+  return `
+      const pty = nodePty.spawn('/bin/sh', ['-lc', 'exit 0'], {
+        cols: 80,
+        rows: 24,
+        cwd: process.cwd(),
+        env: process.env,
+      })
+    `
+}
+
+module.exports = {
+  nativeRuntimeFiles,
+  npmExecutable: () => 'npm',
+  patchNodePty: true,
+  ptyValidationScript,
+  requiredNativeRuntimeFiles,
+}

--- a/scripts/service-native/platforms/linux.cjs
+++ b/scripts/service-native/platforms/linux.cjs
@@ -1,0 +1,28 @@
+const betterSqliteFile = 'node_modules/better-sqlite3/build/Release/better_sqlite3.node'
+
+function nativeRuntimeFiles() {
+  return [betterSqliteFile, 'node_modules/node-pty/build/Release/pty.node']
+}
+
+function requiredNativeRuntimeFiles() {
+  return [betterSqliteFile]
+}
+
+function ptyValidationScript() {
+  return `
+      const pty = nodePty.spawn('/bin/sh', ['-lc', 'exit 0'], {
+        cols: 80,
+        rows: 24,
+        cwd: process.cwd(),
+        env: process.env,
+      })
+    `
+}
+
+module.exports = {
+  nativeRuntimeFiles,
+  npmExecutable: () => 'npm',
+  patchNodePty: true,
+  ptyValidationScript,
+  requiredNativeRuntimeFiles,
+}

--- a/scripts/service-native/platforms/win32.cjs
+++ b/scripts/service-native/platforms/win32.cjs
@@ -1,0 +1,52 @@
+const betterSqliteFile = 'node_modules/better-sqlite3/build/Release/better_sqlite3.node'
+
+function unique(values) {
+  return [...new Set(values)]
+}
+
+function nativeRuntimeFiles(arch = process.arch) {
+  const arches = unique([arch, 'x64', 'arm64'])
+  return [
+    betterSqliteFile,
+    'node_modules/node-pty/build/Release/pty.node',
+    'node_modules/node-pty/build/Release/conpty.node',
+    'node_modules/node-pty/build/Release/conpty_console_list.node',
+    'node_modules/node-pty/build/Release/winpty.dll',
+    'node_modules/node-pty/build/Release/winpty-agent.exe',
+    ...arches.flatMap((targetArch) => [
+      `node_modules/node-pty/prebuilds/win32-${targetArch}/pty.node`,
+      `node_modules/node-pty/prebuilds/win32-${targetArch}/conpty.node`,
+      `node_modules/node-pty/prebuilds/win32-${targetArch}/conpty_console_list.node`,
+      `node_modules/node-pty/prebuilds/win32-${targetArch}/winpty.dll`,
+      `node_modules/node-pty/prebuilds/win32-${targetArch}/winpty-agent.exe`,
+      `node_modules/node-pty/prebuilds/win32-${targetArch}/conpty/conpty.dll`,
+      `node_modules/node-pty/prebuilds/win32-${targetArch}/conpty/OpenConsole.exe`,
+    ]),
+  ]
+}
+
+function requiredNativeRuntimeFiles() {
+  return [betterSqliteFile]
+}
+
+function ptyValidationScript() {
+  return `
+      const shell = process.env.ComSpec || 'cmd.exe'
+      const pty = nodePty.spawn(shell, ['/d', '/s', '/c', 'exit 0'], {
+        cols: 80,
+        rows: 24,
+        cwd: process.cwd(),
+        env: process.env,
+      })
+    `
+}
+
+module.exports = {
+  nativeRuntimeFiles,
+  // Bun/Node spawnSync can throw EINVAL for .cmd with shell:false on Windows.
+  npmExecutable: () => 'npm.cmd',
+  patchNodePty: false,
+  ptyValidationScript,
+  requiredNativeRuntimeFiles,
+  useShellForNpmInstall: true,
+}

--- a/shared/service-native-abi.json
+++ b/shared/service-native-abi.json
@@ -1,0 +1,10 @@
+{
+  "nativeServiceAbiDirectoryName": "native-node-abi",
+  "serviceNativePackages": ["better-sqlite3", "node-pty"],
+  "supportedServiceNodeMajors": ["24", "25", "26"],
+  "supportedServiceNodeAbis": ["137", "141", "147"],
+  "nativeRuntimeFiles": [
+    "node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+    "node_modules/node-pty/build/Release/pty.node"
+  ]
+}

--- a/shared/service-native-abi.json
+++ b/shared/service-native-abi.json
@@ -5,6 +5,24 @@
   "supportedServiceNodeAbis": ["137", "141", "147"],
   "nativeRuntimeFiles": [
     "node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+    "node_modules/node-pty/build/Release/pty.node",
+    "node_modules/node-pty/build/Release/conpty.node",
+    "node_modules/node-pty/build/Release/conpty_console_list.node",
+    "node_modules/node-pty/build/Release/winpty.dll",
+    "node_modules/node-pty/build/Release/winpty-agent.exe",
+    "node_modules/node-pty/prebuilds/win32-x64/pty.node",
+    "node_modules/node-pty/prebuilds/win32-x64/conpty.node",
+    "node_modules/node-pty/prebuilds/win32-x64/conpty_console_list.node",
+    "node_modules/node-pty/prebuilds/win32-x64/winpty.dll",
+    "node_modules/node-pty/prebuilds/win32-x64/winpty-agent.exe",
+    "node_modules/node-pty/prebuilds/win32-arm64/pty.node",
+    "node_modules/node-pty/prebuilds/win32-arm64/conpty.node",
+    "node_modules/node-pty/prebuilds/win32-arm64/conpty_console_list.node",
+    "node_modules/node-pty/prebuilds/win32-arm64/winpty.dll",
+    "node_modules/node-pty/prebuilds/win32-arm64/winpty-agent.exe"
+  ],
+  "requiredNativeRuntimeFiles": [
+    "node_modules/better-sqlite3/build/Release/better_sqlite3.node",
     "node_modules/node-pty/build/Release/pty.node"
   ]
 }

--- a/shared/service-native-abi.json
+++ b/shared/service-native-abi.json
@@ -19,10 +19,15 @@
     "node_modules/node-pty/prebuilds/win32-arm64/conpty.node",
     "node_modules/node-pty/prebuilds/win32-arm64/conpty_console_list.node",
     "node_modules/node-pty/prebuilds/win32-arm64/winpty.dll",
-    "node_modules/node-pty/prebuilds/win32-arm64/winpty-agent.exe"
+    "node_modules/node-pty/prebuilds/win32-arm64/winpty-agent.exe",
+    "node_modules/node-pty/prebuilds/darwin-arm64/pty.node",
+    "node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper",
+    "node_modules/node-pty/prebuilds/darwin-x64/pty.node",
+    "node_modules/node-pty/prebuilds/darwin-x64/spawn-helper",
+    "node_modules/node-pty/prebuilds/win32-x64/conpty/conpty.dll",
+    "node_modules/node-pty/prebuilds/win32-x64/conpty/OpenConsole.exe",
+    "node_modules/node-pty/prebuilds/win32-arm64/conpty/conpty.dll",
+    "node_modules/node-pty/prebuilds/win32-arm64/conpty/OpenConsole.exe"
   ],
-  "requiredNativeRuntimeFiles": [
-    "node_modules/better-sqlite3/build/Release/better_sqlite3.node",
-    "node_modules/node-pty/build/Release/pty.node"
-  ]
+  "requiredNativeRuntimeFiles": ["node_modules/better-sqlite3/build/Release/better_sqlite3.node"]
 }

--- a/src/desktop-host/desktop-service-client.ts
+++ b/src/desktop-host/desktop-service-client.ts
@@ -174,15 +174,22 @@ export class DesktopServiceClient {
     if (this.process && !this.process.killed && this.process.exitCode === null) return this.process
 
     this.startPromise = (async () => {
-      const nodeExecutable =
-        typeof this.options.nodeExecutable === 'function'
-          ? await this.options.nodeExecutable()
-          : this.options.nodeExecutable
-      const nodeRuntime = await prepareServiceNativeRuntime({
-        nodeExecutable,
-        // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
-        resourcesPath: this.options.env?.['HOWCODE_ELECTRON_RESOURCES_PATH'],
-      })
+      let nodeExecutable: string
+      let nodeRuntime: Awaited<ReturnType<typeof prepareServiceNativeRuntime>>
+      try {
+        nodeExecutable =
+          typeof this.options.nodeExecutable === 'function'
+            ? await this.options.nodeExecutable()
+            : this.options.nodeExecutable
+        nodeRuntime = await prepareServiceNativeRuntime({
+          nodeExecutable,
+          // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
+          resourcesPath: this.options.env?.['HOWCODE_ELECTRON_RESOURCES_PATH'],
+        })
+      } catch (error) {
+        this.startPromise = null
+        throw error
+      }
 
       return await new Promise<ChildProcess>((resolve, reject) => {
         const child = spawn(nodeExecutable, [this.options.serviceHostPath], {

--- a/src/desktop-host/desktop-service-client.ts
+++ b/src/desktop-host/desktop-service-client.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import type { DesktopEvent } from '../../shared/desktop-contracts'
 import type { DesktopServiceRuntime } from '../../shared/desktop-service-contracts'
 import type { TerminalEvent } from '../../shared/terminal-contracts'
+import { prepareServiceNativeRuntime } from './service-native-runtime'
 
 export type DesktopServiceApi = DesktopServiceRuntime
 export type DesktopServiceModuleName = keyof DesktopServiceApi
@@ -177,6 +178,11 @@ export class DesktopServiceClient {
         typeof this.options.nodeExecutable === 'function'
           ? await this.options.nodeExecutable()
           : this.options.nodeExecutable
+      const nodeRuntime = await prepareServiceNativeRuntime({
+        nodeExecutable,
+        // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
+        resourcesPath: this.options.env?.['HOWCODE_ELECTRON_RESOURCES_PATH'],
+      })
 
       return await new Promise<ChildProcess>((resolve, reject) => {
         const child = spawn(nodeExecutable, [this.options.serviceHostPath], {
@@ -186,6 +192,8 @@ export class DesktopServiceClient {
             ...this.options.env,
             HOWCODE_HANDLE_LOCAL_HOST_REQUESTS: '1',
             HOWCODE_REPO_ROOT: this.options.cwd,
+            HOWCODE_SERVICE_NODE_ABI: nodeRuntime.abi,
+            HOWCODE_SERVICE_NODE_VERSION: nodeRuntime.version,
           },
           stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
         })

--- a/src/desktop-host/service-native-runtime.ts
+++ b/src/desktop-host/service-native-runtime.ts
@@ -62,7 +62,7 @@ export async function probeNodeRuntime(nodeExecutable: string): Promise<NodeRunt
     child.once('error', (error) => {
       finish(() => reject(error))
     })
-    child.once('exit', (code) => {
+    child.once('close', (code) => {
       finish(() => {
         if (code !== 0) {
           reject(rejectNodeProbeExit(nodeExecutable, stderr, code))
@@ -117,6 +117,10 @@ function validateAbiNativeDependencies(resourcesPath: string, abi: string) {
   }
 }
 
+function hasPackagedNativeDependencies(resourcesPath: string) {
+  return existsSync(getUnpackedAppPath(resourcesPath))
+}
+
 export async function prepareServiceNativeRuntime(input: {
   nodeExecutable: string
   resourcesPath?: string | undefined
@@ -129,11 +133,7 @@ export async function prepareServiceNativeRuntime(input: {
   }
 
   const resourcesPath = input.resourcesPath?.trim()
-  if (resourcesPath) {
-    const unpackedAppPath = path.join(resourcesPath, 'app.asar.unpacked')
-    if (!existsSync(unpackedAppPath)) {
-      throw new Error(`Packaged resources path is missing app.asar.unpacked: ${unpackedAppPath}`)
-    }
+  if (resourcesPath && hasPackagedNativeDependencies(resourcesPath)) {
     validateAbiNativeDependencies(resourcesPath, runtime.abi)
   }
 

--- a/src/desktop-host/service-native-runtime.ts
+++ b/src/desktop-host/service-native-runtime.ts
@@ -1,13 +1,9 @@
 import { spawn } from 'node:child_process'
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
+import serviceNativeAbi from '../../shared/service-native-abi.json'
 
-const nativeServiceAbiDirectoryName = 'native-node-abi'
-const supportedServiceNodeAbis = new Set(['137', '141', '147'])
-const nativeRuntimeFiles = [
-  path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
-  path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
-]
+const supportedServiceNodeAbis = new Set(serviceNativeAbi.supportedServiceNodeAbis)
 
 type NodeRuntimeProbe = {
   version: string
@@ -66,9 +62,13 @@ function getUnpackedAppPath(resourcesPath: string) {
   return path.join(resourcesPath, 'app.asar.unpacked')
 }
 
-function installAbiNativeDependencies(resourcesPath: string, abi: string) {
+function validateAbiNativeDependencies(resourcesPath: string, abi: string) {
   const unpackedAppPath = getUnpackedAppPath(resourcesPath)
-  const abiBundleRoot = path.join(unpackedAppPath, nativeServiceAbiDirectoryName, abi)
+  const abiBundleRoot = path.join(
+    unpackedAppPath,
+    serviceNativeAbi.nativeServiceAbiDirectoryName,
+    abi,
+  )
 
   if (!existsSync(abiBundleRoot)) {
     throw new Error(
@@ -76,14 +76,24 @@ function installAbiNativeDependencies(resourcesPath: string, abi: string) {
     )
   }
 
-  for (const relativePath of nativeRuntimeFiles) {
+  const manifestPath = path.join(abiBundleRoot, 'manifest.json')
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Missing packaged native dependency manifest for ABI ${abi}: ${manifestPath}`)
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+    abi?: unknown
+    files?: unknown
+  }
+  if (manifest.abi !== abi || !Array.isArray(manifest.files)) {
+    throw new Error(`Invalid packaged native dependency manifest for ABI ${abi}: ${manifestPath}`)
+  }
+
+  for (const relativePath of serviceNativeAbi.nativeRuntimeFiles) {
     const sourcePath = path.join(abiBundleRoot, relativePath)
-    const destinationPath = path.join(unpackedAppPath, relativePath)
     if (!existsSync(sourcePath)) {
       throw new Error(`Missing packaged native dependency for ABI ${abi}: ${sourcePath}`)
     }
-    mkdirSync(path.dirname(destinationPath), { recursive: true })
-    copyFileSync(sourcePath, destinationPath)
   }
 }
 
@@ -100,7 +110,7 @@ export async function prepareServiceNativeRuntime(input: {
 
   const resourcesPath = input.resourcesPath?.trim()
   if (resourcesPath && existsSync(path.join(resourcesPath, 'app.asar.unpacked'))) {
-    installAbiNativeDependencies(resourcesPath, runtime.abi)
+    validateAbiNativeDependencies(resourcesPath, runtime.abi)
   }
 
   return runtime

--- a/src/desktop-host/service-native-runtime.ts
+++ b/src/desktop-host/service-native-runtime.ts
@@ -1,0 +1,107 @@
+import { spawn } from 'node:child_process'
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+
+const nativeServiceAbiDirectoryName = 'native-node-abi'
+const supportedServiceNodeAbis = new Set(['137', '141', '147'])
+const nativeRuntimeFiles = [
+  path.join('node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
+  path.join('node_modules', 'node-pty', 'build', 'Release', 'pty.node'),
+]
+
+type NodeRuntimeProbe = {
+  version: string
+  abi: string
+}
+
+export function getSupportedServiceNodeAbiLabel() {
+  return [...supportedServiceNodeAbis].join(', ')
+}
+
+export async function probeNodeRuntime(nodeExecutable: string): Promise<NodeRuntimeProbe> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(
+      nodeExecutable,
+      ['-p', 'JSON.stringify({version: process.version, abi: process.versions.modules})'],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let stdout = ''
+    let stderr = ''
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`Timed out probing Node runtime: ${nodeExecutable}`))
+    }, 3_000)
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      if (code !== 0) {
+        reject(new Error(`Failed to probe Node runtime ${nodeExecutable}: ${stderr.trim()}`))
+        return
+      }
+      try {
+        const parsed = JSON.parse(stdout.trim()) as Partial<NodeRuntimeProbe>
+        if (typeof parsed.version !== 'string' || typeof parsed.abi !== 'string') {
+          throw new Error('probe did not return version/abi')
+        }
+        resolve({ version: parsed.version, abi: parsed.abi })
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+  })
+}
+
+function getUnpackedAppPath(resourcesPath: string) {
+  return path.join(resourcesPath, 'app.asar.unpacked')
+}
+
+function installAbiNativeDependencies(resourcesPath: string, abi: string) {
+  const unpackedAppPath = getUnpackedAppPath(resourcesPath)
+  const abiBundleRoot = path.join(unpackedAppPath, nativeServiceAbiDirectoryName, abi)
+
+  if (!existsSync(abiBundleRoot)) {
+    throw new Error(
+      `Missing packaged native dependencies for Node ABI ${abi}. Supported ABIs: ${getSupportedServiceNodeAbiLabel()}.`,
+    )
+  }
+
+  for (const relativePath of nativeRuntimeFiles) {
+    const sourcePath = path.join(abiBundleRoot, relativePath)
+    const destinationPath = path.join(unpackedAppPath, relativePath)
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Missing packaged native dependency for ABI ${abi}: ${sourcePath}`)
+    }
+    mkdirSync(path.dirname(destinationPath), { recursive: true })
+    copyFileSync(sourcePath, destinationPath)
+  }
+}
+
+export async function prepareServiceNativeRuntime(input: {
+  nodeExecutable: string
+  resourcesPath?: string | undefined
+}) {
+  const runtime = await probeNodeRuntime(input.nodeExecutable)
+  if (!supportedServiceNodeAbis.has(runtime.abi)) {
+    throw new Error(
+      `Howcode desktop service requires Node ABI ${getSupportedServiceNodeAbiLabel()} (Node 24-26). ${input.nodeExecutable} is ${runtime.version} ABI ${runtime.abi}.`,
+    )
+  }
+
+  const resourcesPath = input.resourcesPath?.trim()
+  if (resourcesPath && existsSync(path.join(resourcesPath, 'app.asar.unpacked'))) {
+    installAbiNativeDependencies(resourcesPath, runtime.abi)
+  }
+
+  return runtime
+}

--- a/src/desktop-host/service-native-runtime.ts
+++ b/src/desktop-host/service-native-runtime.ts
@@ -89,7 +89,7 @@ function validateAbiNativeDependencies(resourcesPath: string, abi: string) {
     throw new Error(`Invalid packaged native dependency manifest for ABI ${abi}: ${manifestPath}`)
   }
 
-  for (const relativePath of serviceNativeAbi.nativeRuntimeFiles) {
+  for (const relativePath of serviceNativeAbi.requiredNativeRuntimeFiles) {
     const sourcePath = path.join(abiBundleRoot, relativePath)
     if (!existsSync(sourcePath)) {
       throw new Error(`Missing packaged native dependency for ABI ${abi}: ${sourcePath}`)

--- a/src/desktop-host/service-native-runtime.ts
+++ b/src/desktop-host/service-native-runtime.ts
@@ -14,6 +14,20 @@ export function getSupportedServiceNodeAbiLabel() {
   return [...supportedServiceNodeAbis].join(', ')
 }
 
+function parseNodeRuntimeProbe(stdout: string): NodeRuntimeProbe {
+  const parsed = JSON.parse(stdout.trim()) as Partial<NodeRuntimeProbe>
+  if (typeof parsed.version !== 'string' || typeof parsed.abi !== 'string') {
+    throw new Error('probe did not return version/abi')
+  }
+  return { version: parsed.version, abi: parsed.abi }
+}
+
+function rejectNodeProbeExit(nodeExecutable: string, stderr: string, code: number | null) {
+  return new Error(
+    `Failed to probe Node runtime ${nodeExecutable} (exit ${code ?? 'unknown'}): ${stderr.trim()}`,
+  )
+}
+
 export async function probeNodeRuntime(nodeExecutable: string): Promise<NodeRuntimeProbe> {
   return await new Promise((resolve, reject) => {
     const child = spawn(
@@ -23,10 +37,20 @@ export async function probeNodeRuntime(nodeExecutable: string): Promise<NodeRunt
     )
     let stdout = ''
     let stderr = ''
+    let settled = false
+
+    const finish = (callback: () => void) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      callback()
+    }
+
     const timeout = setTimeout(() => {
       child.kill('SIGTERM')
-      reject(new Error(`Timed out probing Node runtime: ${nodeExecutable}`))
+      finish(() => reject(new Error(`Timed out probing Node runtime: ${nodeExecutable}`)))
     }, 3_000)
+
     child.stdout?.setEncoding('utf8')
     child.stderr?.setEncoding('utf8')
     child.stdout?.on('data', (chunk) => {
@@ -36,24 +60,20 @@ export async function probeNodeRuntime(nodeExecutable: string): Promise<NodeRunt
       stderr += chunk
     })
     child.once('error', (error) => {
-      clearTimeout(timeout)
-      reject(error)
+      finish(() => reject(error))
     })
     child.once('exit', (code) => {
-      clearTimeout(timeout)
-      if (code !== 0) {
-        reject(new Error(`Failed to probe Node runtime ${nodeExecutable}: ${stderr.trim()}`))
-        return
-      }
-      try {
-        const parsed = JSON.parse(stdout.trim()) as Partial<NodeRuntimeProbe>
-        if (typeof parsed.version !== 'string' || typeof parsed.abi !== 'string') {
-          throw new Error('probe did not return version/abi')
+      finish(() => {
+        if (code !== 0) {
+          reject(rejectNodeProbeExit(nodeExecutable, stderr, code))
+          return
         }
-        resolve({ version: parsed.version, abi: parsed.abi })
-      } catch (error) {
-        reject(error instanceof Error ? error : new Error(String(error)))
-      }
+        try {
+          resolve(parseNodeRuntimeProbe(stdout))
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)))
+        }
+      })
     })
   })
 }
@@ -109,7 +129,11 @@ export async function prepareServiceNativeRuntime(input: {
   }
 
   const resourcesPath = input.resourcesPath?.trim()
-  if (resourcesPath && existsSync(path.join(resourcesPath, 'app.asar.unpacked'))) {
+  if (resourcesPath) {
+    const unpackedAppPath = path.join(resourcesPath, 'app.asar.unpacked')
+    if (!existsSync(unpackedAppPath)) {
+      throw new Error(`Packaged resources path is missing app.asar.unpacked: ${unpackedAppPath}`)
+    }
     validateAbiNativeDependencies(resourcesPath, runtime.abi)
   }
 

--- a/src/test/pi-runtime-boundary.test.ts
+++ b/src/test/pi-runtime-boundary.test.ts
@@ -15,6 +15,7 @@ const allowedPiRuntimeImportPrefixes = [
   'desktop/runtime-host/',
   'desktop/runtime/',
   'desktop/service-host.ts',
+  'desktop/service-host-runtime.ts',
   'desktop/pi-module.ts',
   // Package internals are only exported to Electron through runtime-host-bridge.ts; the host
   // imports these implementations directly so native package-manager dependencies stay in Node.


### PR DESCRIPTION
## Summary

- package service-native deps by Node ABI for Node 24/25/26
- make AppImage, Windows installer, macOS zip, and launcher archives carry the same ABI bundle set
- select the matching ABI bundle at desktop service startup instead of loading Electron-built native modules
- split native packaging logic into OS adapters for Linux, macOS, and Windows
- harden release validation for `better-sqlite3` and `node-pty`

## Validation

- `bun run ai:check`
- GitHub Actions manual preview build passed for all 6 targets: linux/macOS/windows x64 + arm64
- downloaded linux-x64 artifact and verified ABI bundles for 137/141/147
- smoked packaged Linux app with Node 24.15.0, 25.9.0, and 26.1.0 via `HOWCODE_NODE_PATH`
- verified `better-sqlite3` and `node-pty` load/spawn against each matching ABI bundle
- launched all three packaged Linux variants on Hyprland workspace 4 and confirmed desktop service/worker processes use the selected Node

## Notes

Pi/user extension native deps are still tied to the user's Pi Node install. That is intentional: Howcode owns its packaged native deps, but external Pi extension npm trees remain user-runtime territory.

Changelog updated.
