### PR TITLE
Hotfix artifacts, launcher, and sidebar polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "deadcode": "react-doctor . --offline --project howcode --dead-code --fail-on warning",
     "react-doctor": "react-doctor . --offline --project howcode --dead-code",
     "typography:audit": "bun ./scripts/audit-typography.ts",
-    "pack:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev pack 0.1.68-dev.1",
-    "publish:howcode:dev:dry-run": "bun ./scripts/pack-howcode-launcher.ts dev publish-dry-run 0.1.68-dev.1",
+    "pack:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev pack 0.1.69-dev.1",
+    "publish:howcode:dev:dry-run": "bun ./scripts/pack-howcode-launcher.ts dev publish-dry-run 0.1.69-dev.1",
     "publish:howcode": "bun ./scripts/pack-howcode-launcher.ts main publish",
-    "publish:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev publish 0.1.68-dev.1",
+    "publish:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev publish 0.1.69-dev.1",
     "typography:generate": "bun ./scripts/generate-typography-css.ts",
     "polls:deploy": "cd workers/polls && bunx wrangler deploy",
     "polls:migrate": "cd workers/polls && bunx wrangler d1 migrations apply howcode_polls --remote"

--- a/packages/howcode/lib/howcode.js
+++ b/packages/howcode/lib/howcode.js
@@ -155,6 +155,20 @@ function shellSingleQuote(value) {
   return `'${value.replace(/'/g, `'"'"'`)}'`
 }
 
+function spawnLinuxDetachedLauncher(executablePath, env) {
+  return spawn(
+    '/bin/sh',
+    ['-c', `nohup ${shellSingleQuote(executablePath)} >/dev/null 2>&1 </dev/null &`],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      cwd: path.dirname(executablePath),
+      env,
+    },
+  )
+}
+
 async function writeLinuxCommandLauncher(paths) {
   const launcherPath = getLinuxCommandLauncherPath()
   const launcherDirectory = path.dirname(launcherPath)
@@ -532,6 +546,10 @@ function spawnLauncherProcess(executablePath, options = {}) {
     ...(options.env || {}),
   }
   Reflect.deleteProperty(env, 'NODE_TLS_REJECT_UNAUTHORIZED')
+
+  if (process.platform === 'linux') {
+    return spawnLinuxDetachedLauncher(executablePath, env)
+  }
 
   return spawn(executablePath, [], {
     detached: true,

--- a/packages/howcode/package.json
+++ b/packages/howcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "howcode",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Desktop coding app for Pi with projects, terminal, git, and diff workflows.",
   "license": "MIT",
   "author": "Igor Warzocha",

--- a/src/app/chat-workspace/chat-workspace-composer.tsx
+++ b/src/app/chat-workspace/chat-workspace-composer.tsx
@@ -276,7 +276,6 @@ export function ChatComposerDock(props: ChatWorkspaceComposerProps) {
     <WorkspaceComposerDock
       compactControls={sidebarAutoHidden || sidebarCollapsed}
       left={<SidebarToggleButton {...props} />}
-      leftClassName="!mb-[3.35rem]"
       center={<ChatComposerCenter {...props} />}
       rightClassName={cn(
         'min-[1400px]:opacity-100',

--- a/src/app/components/sidebar/project-work/branch-thread-groups.tsx
+++ b/src/app/components/sidebar/project-work/branch-thread-groups.tsx
@@ -126,13 +126,12 @@ function getThreadAssignBranchForGroup(group: BranchThreadGroup, currentBranch: 
 
 function getBranchGroupDividerState(input: {
   collapsed: boolean
-  hasWorktrees: boolean
   showBottomDivider: boolean
   showTopDivider: boolean
 }) {
   if (input.collapsed) return { before: 'false', after: 'false' }
   return {
-    before: input.showTopDivider || input.hasWorktrees ? 'true' : 'false',
+    before: input.showTopDivider ? 'true' : 'false',
     after: input.showBottomDivider ? 'true' : 'false',
   }
 }
@@ -272,7 +271,6 @@ export function BranchThreadGroupSection({
   const visibilityState = getBranchGroupVisibilityState(group)
   const dividerState = getBranchGroupDividerState({
     collapsed,
-    hasWorktrees: visibilityState.hasWorktrees,
     showBottomDivider,
     showTopDivider,
   })

--- a/src/app/components/sidebar/project-work/compact-branch-groups.tsx
+++ b/src/app/components/sidebar/project-work/compact-branch-groups.tsx
@@ -212,13 +212,16 @@ export function ProjectCompactBranchGroups({
       {worktreeGroups.map((group, index) => {
         const groupKey = `${project.id}:${group.id}`
         const visualGroupKey = getCompactBranchVisualGroupKey(group, currentBranch)
-        const previousGroup =
-          index > 0 ? (worktreeGroups[index - 1] ?? currentBranchGroup) : currentBranchGroup
-        const previousVisualGroupKey = getCompactBranchVisualGroupKey(previousGroup, currentBranch)
+        const nextGroup = index < worktreeGroups.length - 1 ? worktreeGroups[index + 1] : undefined
+        const nextVisualGroupKey = nextGroup
+          ? getCompactBranchVisualGroupKey(nextGroup, currentBranch)
+          : null
         const collapsed = normalizedSearchQuery
           ? false
           : (collapsedBranchIds[groupKey] ??
             (group.threads.length === 0 && group.worktrees.length === 0))
+        const showBottomDivider =
+          !collapsed && nextVisualGroupKey !== null && visualGroupKey !== nextVisualGroupKey
         return (
           <BranchThreadGroupSection
             key={group.id}
@@ -232,7 +235,7 @@ export function ProjectCompactBranchGroups({
             selectedThreadId={selectedThreadId}
             terminalRunningSessionPaths={terminalRunningSessionPaths}
             onAction={onAction}
-            showTopDivider={!collapsed && visualGroupKey !== previousVisualGroupKey}
+            showBottomDivider={showBottomDivider}
             onThreadOpen={onThreadOpen}
             onToggle={() =>
               onSetCollapsedBranchIds((current) => ({

--- a/src/app/native/artifact-shell/artifact-panel-body.tsx
+++ b/src/app/native/artifact-shell/artifact-panel-body.tsx
@@ -1,4 +1,3 @@
-import { HistoricalMarkdownPreview } from '@howcode/native-markdown-artifacts'
 import { lazy, Suspense, useEffect, useState } from 'react'
 import {
   appToneDangerClass,
@@ -14,6 +13,7 @@ import {
   artifactPreviewSurfaceClass,
 } from '../../ui/classes'
 import { cn } from '../../utils/cn'
+import { HistoricalMarkdownPreview } from '../markdown-artifacts/artifact-markdown-preview'
 import { formatArtifactSlug } from './artifactFormat'
 import type { useArtifactPanelState } from './useArtifactPanelState'
 
@@ -22,6 +22,7 @@ const ArtifactMarkdownEditor = lazy(async () => {
   // @mdxeditor/@lexical code highlighting expects Prism on the browser global.
   // Install it only on the markdown editor path so HTML/React previews stay isolated.
   globalThis.Prism = Prism
+  Object.assign(globalThis, { prism: Prism })
   const module = await import('@howcode/native-markdown-artifacts')
   return { default: module.ArtifactMarkdownEditor }
 })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -57,8 +57,9 @@ import type {
 } from './app/desktop/types'
 
 declare global {
-  // Prism is installed by src/main.tsx for @mdxeditor/@lexical code highlighting.
+  // Prism is installed lazily for @mdxeditor/@lexical code highlighting.
   var Prism: unknown
+  var prism: unknown
 
   interface Window {
     howcodeDevWebBridge?: boolean


### PR DESCRIPTION
## Summary
- fix artifact launches failing on missing Prism globals
- detach the Linux npm launcher so closing the terminal does not close Howcode
- fix chat sidebar toggle placement and sidebar branch dividers
- bump only the npm launcher package to 0.1.69

## Validation
- bun run ai:check

No changelog for this hotfix.