### PR TITLE
fix macOS select all and window dragging

### DIFF
--- a/src/app/app-shell/app-shell-layout-view.tsx
+++ b/src/app/app-shell/app-shell-layout-view.tsx
@@ -228,6 +228,7 @@ function AppShellWorkspaceSection(props: AppShellLayoutViewProps) {
       ref={mainSectionRef}
       className="flex min-w-0 min-h-0 h-full flex-1 flex-col overflow-hidden bg-[color:var(--workspace)]"
     >
+      {sidebarCollapsed || sidebarCompactMode ? <div className="window-drag-region" /> : null}
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         <div
           data-open={takeoverVisible ? 'false' : 'true'}

--- a/src/electron/main/app/application-menu.ts
+++ b/src/electron/main/app/application-menu.ts
@@ -144,6 +144,8 @@ export async function installApplicationMenu(input: {
           { role: 'cut' },
           { role: 'copy' },
           { role: 'paste' },
+          { type: 'separator' },
+          { role: 'selectAll' },
         ],
       },
     ]),

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -22,6 +22,17 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.window-drag-region {
+  display: none;
+}
+
+:root[data-desktop-platform="darwin"] .window-drag-region {
+  display: block;
+  height: 2.375rem;
+  flex: none;
+  -webkit-app-region: drag;
+}
+
 button,
 input,
 textarea {

--- a/src/styles/sidebar/base.css
+++ b/src/styles/sidebar/base.css
@@ -43,6 +43,14 @@
   padding-top: 2.375rem;
 }
 
+:root[data-desktop-platform="darwin"] .sidebar-shell::before {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2.375rem;
+  content: "";
+  -webkit-app-region: drag;
+}
+
 .sidebar-mode-nav {
   display: grid;
   gap: 0.125rem;

--- a/src/test/macos-window-controls.test.ts
+++ b/src/test/macos-window-controls.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+const macSidebarDragRegionPattern =
+  /:root\[data-desktop-platform="darwin"\] \.sidebar-shell::before\s*\{[^}]*-webkit-app-region:\s*drag;/s
+const macWorkspaceDragRegionPattern =
+  /:root\[data-desktop-platform="darwin"\] \.window-drag-region\s*\{[^}]*-webkit-app-region:\s*drag;/s
+
+function readProjectFile(filePath: string) {
+  return readFileSync(path.join(projectRoot, filePath), 'utf8')
+}
+
+describe('macOS window controls', () => {
+  it('keeps the native select-all command in the Electron Edit menu', () => {
+    const applicationMenuSource = readProjectFile('src/electron/main/app/application-menu.ts')
+
+    expect(applicationMenuSource).toContain("{ role: 'selectAll' }")
+  })
+
+  it('keeps the empty macOS sidebar title-bar area draggable', () => {
+    const sidebarStyles = readProjectFile('src/styles/sidebar/base.css')
+
+    expect(sidebarStyles).toMatch(macSidebarDragRegionPattern)
+  })
+
+  it('keeps a macOS drag area available when the sidebar is hidden', () => {
+    const appShellLayout = readProjectFile('src/app/app-shell/app-shell-layout-view.tsx')
+    const baseStyles = readProjectFile('src/styles/base.css')
+
+    expect(appShellLayout).toContain(
+      'sidebarCollapsed || sidebarCompactMode ? <div className="window-drag-region" /> : null',
+    )
+    expect(baseStyles).toMatch(macWorkspaceDragRegionPattern)
+  })
+})


### PR DESCRIPTION
## Summary

- restore native `Cmd+A` text selection on macOS by adding Electron's `selectAll` Edit menu role
- add draggable title-bar regions so the window can be moved with the sidebar visible or collapsed
- add regression coverage for the macOS window controls

## Validation

- manually verified `Cmd+A` selects text in the chat window
- manually verified the window can be dragged with the sidebar visible and collapsed
- `bunx vitest run src/test/macos-window-controls.test.ts src/test/electron-runtime-boundary.test.ts`
- `bun run build:runtime`

## Changelog

- [x] I considered `docs/changelog.md`.
- [x] This PR genuinely does not need a changelog bullet.