### PR TITLE
Fix macOS window controls

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -18,3 +18,5 @@ kikaraage gogogogo!
 BlockedPath macOS terminal report #253
 
 Chris79OG WSL work #139
+
+marcinkardas macOS bug reports and PR #288

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 - Updated Pi SDK/runtime packages to 0.79.1.
 - Bumped app/build dependencies, including Electron 41.7.2.
 - Added headless/browser mode, including LAN access with token auth and browser-side file uploads.
+- Fixed macOS window dragging and native Cmd+A select-all.
 
 #### 0.1.66 Hotfixes (because .67 has to be more special)
 

--- a/src/app/app-shell/app-shell-layout-view.tsx
+++ b/src/app/app-shell/app-shell-layout-view.tsx
@@ -324,10 +324,21 @@ function AppShellToast(props: AppShellLayoutViewProps) {
   )
 }
 
+function MacWindowDragZones() {
+  return (
+    <div className="mac-window-drag-zones" aria-hidden="true">
+      <div className="mac-window-drag-zone mac-window-drag-zone--top-left" />
+      <div className="mac-window-drag-zone mac-window-drag-zone--left-edge" />
+      <div className="mac-window-drag-zone mac-window-drag-zone--bottom-left" />
+    </div>
+  )
+}
+
 export function AppShellLayoutView(props: AppShellLayoutViewProps) {
   return (
     <>
       <div className={appShellRootClass}>
+        <MacWindowDragZones />
         <DesktopSidebarFrame {...props} />
         <CompactSidebarOverlay {...props} />
         <CompactSidebarPanel {...props} />

--- a/src/app/app-shell/app-shell-layout-view.tsx
+++ b/src/app/app-shell/app-shell-layout-view.tsx
@@ -327,9 +327,7 @@ function AppShellToast(props: AppShellLayoutViewProps) {
 function MacWindowDragZones() {
   return (
     <div className="mac-window-drag-zones" aria-hidden="true">
-      <div className="mac-window-drag-zone mac-window-drag-zone--top-left" />
-      <div className="mac-window-drag-zone mac-window-drag-zone--left-edge" />
-      <div className="mac-window-drag-zone mac-window-drag-zone--bottom-left" />
+      <div className="mac-window-drag-zone mac-window-drag-zone--titlebar" />
     </div>
   )
 }

--- a/src/electron/main/app/application-menu.ts
+++ b/src/electron/main/app/application-menu.ts
@@ -144,6 +144,8 @@ export async function installApplicationMenu(input: {
           { role: 'cut' },
           { role: 'copy' },
           { role: 'paste' },
+          { type: 'separator' },
+          { role: 'selectAll' },
         ],
       },
     ]),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,10 @@ import { queryClient } from './app/query/query-client'
 function applyDesktopPlatformAttribute() {
   const platform = window.piDesktop?.platform ?? 'browser'
   document.documentElement.setAttribute('data-desktop-platform', platform)
+  document.documentElement.setAttribute(
+    'data-desktop-shell',
+    window.piDesktop && !window.howcodeDevWebBridge ? 'electron' : 'browser',
+  )
 }
 
 if (import.meta.env.DEV) {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -26,7 +26,7 @@ body {
   display: none;
 }
 
-:root[data-desktop-platform="darwin"] .mac-window-drag-zones {
+:root[data-desktop-platform="darwin"][data-desktop-shell="electron"] .mac-window-drag-zones {
   display: block;
 }
 
@@ -37,25 +37,11 @@ body {
   -webkit-app-region: drag;
 }
 
-.mac-window-drag-zone--top-left {
+.mac-window-drag-zone--titlebar {
   top: 0;
   left: 5.5rem;
   width: 13.25rem;
   height: 2rem;
-}
-
-.mac-window-drag-zone--left-edge {
-  top: 5rem;
-  bottom: 5rem;
-  left: 0;
-  width: 0.5rem;
-}
-
-.mac-window-drag-zone--bottom-left {
-  bottom: 0;
-  left: 0;
-  width: 4rem;
-  height: 1rem;
 }
 
 button,

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -22,6 +22,42 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.mac-window-drag-zones {
+  display: none;
+}
+
+:root[data-desktop-platform="darwin"] .mac-window-drag-zones {
+  display: block;
+}
+
+.mac-window-drag-zone {
+  position: fixed;
+  z-index: 45;
+  background: transparent;
+  -webkit-app-region: drag;
+}
+
+.mac-window-drag-zone--top-left {
+  top: 0;
+  left: 5.5rem;
+  width: 13.25rem;
+  height: 2rem;
+}
+
+.mac-window-drag-zone--left-edge {
+  top: 5rem;
+  bottom: 5rem;
+  left: 0;
+  width: 0.5rem;
+}
+
+.mac-window-drag-zone--bottom-left {
+  bottom: 0;
+  left: 0;
+  width: 4rem;
+  height: 1rem;
+}
+
 button,
 input,
 textarea {

--- a/src/test/macos-window-controls.test.ts
+++ b/src/test/macos-window-controls.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 const projectRoot = path.resolve(__dirname, '..', '..')
 const macDragZonesPattern =
-  /:root\[data-desktop-platform="darwin"\] \.mac-window-drag-zones\s*\{[^}]*display:\s*block;/s
+  /:root\[data-desktop-platform="darwin"\]\[data-desktop-shell="electron"\] \.mac-window-drag-zones\s*\{[^}]*display:\s*block;/s
 const dragRegionPattern = /\.mac-window-drag-zone\s*\{[^}]*-webkit-app-region:\s*drag;/s
 
 function readProjectFile(filePath: string) {
@@ -30,6 +30,7 @@ describe('macOS window controls', () => {
 
     expect(baseStyles).toMatch(macDragZonesPattern)
     expect(baseStyles).toMatch(dragRegionPattern)
-    expect(baseStyles).not.toContain('mac-window-drag-zone--right')
+    expect(baseStyles).not.toContain('mac-window-drag-zone--left-edge')
+    expect(baseStyles).not.toContain('mac-window-drag-zone--bottom-left')
   })
 })

--- a/src/test/macos-window-controls.test.ts
+++ b/src/test/macos-window-controls.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(__dirname, '..', '..')
+const macDragZonesPattern =
+  /:root\[data-desktop-platform="darwin"\] \.mac-window-drag-zones\s*\{[^}]*display:\s*block;/s
+const dragRegionPattern = /\.mac-window-drag-zone\s*\{[^}]*-webkit-app-region:\s*drag;/s
+
+function readProjectFile(filePath: string) {
+  return readFileSync(path.join(projectRoot, filePath), 'utf8')
+}
+
+describe('macOS window controls', () => {
+  it('keeps native select-all in the Electron Edit menu', () => {
+    const applicationMenuSource = readProjectFile('src/electron/main/app/application-menu.ts')
+
+    expect(applicationMenuSource).toContain("{ role: 'selectAll' }")
+  })
+
+  it('keeps invisible macOS drag zones mounted in the app shell', () => {
+    const appShellLayout = readProjectFile('src/app/app-shell/app-shell-layout-view.tsx')
+
+    expect(appShellLayout).toContain('function MacWindowDragZones()')
+    expect(appShellLayout).toContain('<MacWindowDragZones />')
+  })
+
+  it('keeps macOS drag zones platform-scoped and draggable', () => {
+    const baseStyles = readProjectFile('src/styles/base.css')
+
+    expect(baseStyles).toMatch(macDragZonesPattern)
+    expect(baseStyles).toMatch(dragRegionPattern)
+    expect(baseStyles).not.toContain('mac-window-drag-zone--right')
+  })
+})


### PR DESCRIPTION
## Summary

- add a macOS-only invisible titlebar drag zone so the hidden-inset window can be moved without layout shifts
- restore native Cmd+A select-all via Electron's Edit menu
- vouch @marcinkardas after the macOS reports/PR

## Notes

The drag zone is gated to the Electron shell only, so Mac browser/headless mode does not get invisible click-stealing overlays. I also kept it away from the right side and resize edges.

Refs #281
Refs #287

## Validation

- CDP inspected the live app drag-zone geometry
- `bunx vitest run src/test/macos-window-controls.test.ts`
- commit/push hooks ran `bun run ai:check`

No Codex review requested because it is currently not working.
