### PR TITLE
Fix session view refresh and worktree routing

### DIFF
--- a/desktop/runtime-host/live-runtime-registry.ts
+++ b/desktop/runtime-host/live-runtime-registry.ts
@@ -14,7 +14,7 @@ import {
   isRuntimeExtensionCommandRunning,
   refreshRuntimeExtensionBindings as refreshRuntimeExtensionBindingsWithReload,
 } from './live-runtime-factory.ts'
-import { publishComposerUpdate } from './live-thread-publisher.ts'
+import { publishComposerUpdate, publishPiExtensionUiUpdate } from './live-thread-publisher.ts'
 
 export { abortRuntimeExtensionCommand, isRuntimeExtensionCommandRunning }
 
@@ -34,6 +34,11 @@ const liveRuntimeFactoryHandlers = {
   reloadRuntimeSettingsIfSafe,
   scheduleRuntimeDisposal,
   suspendRuntimeDisposal,
+}
+
+function clearAndPublishPiExtensionUi(runtime: PiRuntime) {
+  clearPiExtensionUi(runtime)
+  publishPiExtensionUiUpdate(runtime)
 }
 
 export async function refreshRuntimeExtensionBindings(runtime: PiRuntime) {
@@ -59,7 +64,7 @@ async function disposeRuntimeIfIdle(runtimeKey: string, record: RuntimeRecord) {
       scheduleRuntimeDisposal(runtimeKey)
       return
     }
-    clearPiExtensionUi(runtime)
+    clearAndPublishPiExtensionUi(runtime)
     runtime.session.dispose()
     if (runtimeRecords.get(runtimeKey) === record) runtimeRecords.delete(runtimeKey)
     staleRuntimeGenerations.delete(runtimeKey)
@@ -130,7 +135,7 @@ export async function getOrCreateRuntimeForSessionPath(
       return await existingRuntime.runtimePromise
     } else {
       const runtime = await existingRuntime.runtimePromise
-      clearPiExtensionUi(runtime)
+      clearAndPublishPiExtensionUi(runtime)
       runtime.session.dispose()
       runtimeRecords.delete(persistedSessionPath)
     }
@@ -320,7 +325,7 @@ async function disposeRuntimeRecord(runtimeKey: string, record: RuntimeRecord, r
     // Continue disposal; the workspace is being torn down.
   }
   try {
-    clearPiExtensionUi(runtime)
+    clearAndPublishPiExtensionUi(runtime)
     runtime.session.dispose()
   } catch {
     // Ignore shutdown races.
@@ -369,7 +374,7 @@ export async function disposeAllRuntimeHosts() {
       clearRuntimeDisposeTimeout(runtimeKey)
       try {
         const runtime = await record.runtimePromise
-        clearPiExtensionUi(runtime)
+        clearAndPublishPiExtensionUi(runtime)
         runtime.session.dispose()
       } catch {
         // Ignore shutdown races.

--- a/desktop/runtime-host/live-runtime-service.ts
+++ b/desktop/runtime-host/live-runtime-service.ts
@@ -47,7 +47,11 @@ import {
   scheduleRuntimeDisposal,
   withRuntimeMutationLock,
 } from './live-runtime-registry.ts'
-import { publishComposerUpdate, publishThreadUpdate } from './live-thread-publisher.ts'
+import {
+  publishComposerUpdate,
+  publishPiExtensionUiUpdate,
+  publishThreadUpdate,
+} from './live-thread-publisher.ts'
 import { mapSessionCommands } from './slash-command-service.ts'
 
 async function emitComposerUpdate(request: ComposerStateRequest = {}) {
@@ -350,6 +354,7 @@ export async function answerPiExtensionDialog(
       confirmed: request.confirmed,
       value: request.value,
     })
+    publishPiExtensionUiUpdate(runtime)
     await emitComposerUpdate({ ...request, sessionPath: persistedSessionPath })
     return { ok }
   } finally {

--- a/desktop/runtime-host/live-thread-publisher.ts
+++ b/desktop/runtime-host/live-thread-publisher.ts
@@ -7,6 +7,7 @@ import {
 import { buildThreadHistorySlice, type SessionPathEntry } from '../../shared/thread-history.ts'
 import { isChatSessionPath } from '../chat-state-db.ts'
 import { buildComposerState } from '../runtime/composer-state.ts'
+import { getPiExtensionUiState } from '../runtime/pi-extension-ui-state.ts'
 import type { PiRuntime, RuntimeThreadReason } from '../runtime/types.ts'
 import { emitDesktopEvent } from './host-events.ts'
 import { getLiveToolProgressMessages } from './live-tool-progress.ts'
@@ -77,6 +78,17 @@ export function publishComposerUpdate(
     composer,
     projectId: context.projectId ?? null,
     sessionPath: context.sessionPath ?? null,
+  })
+}
+
+export function publishPiExtensionUiUpdate(runtime: PiRuntime) {
+  const sessionPath = runtime.session.sessionFile
+  if (!sessionPath) return
+  emitDesktopEvent({
+    type: 'pi-extension-ui-update',
+    projectId: runtime.cwd,
+    sessionPath,
+    extensionUi: getPiExtensionUiState(runtime),
   })
 }
 

--- a/desktop/runtime-host/runtime-extension-bindings.ts
+++ b/desktop/runtime-host/runtime-extension-bindings.ts
@@ -10,12 +10,19 @@ import { buildComposerState } from '../runtime/composer-state.ts'
 import { createPiExtensionUiContext } from '../runtime/pi-extension-ui-state.ts'
 import type { PiRuntime } from '../runtime/types.ts'
 import { emitDesktopEvent } from './host-events.ts'
-import { publishComposerUpdate, publishThreadUpdate } from './live-thread-publisher.ts'
+import {
+  publishComposerUpdate,
+  publishPiExtensionUiUpdate,
+  publishThreadUpdate,
+} from './live-thread-publisher.ts'
 
 type RuntimeExtensionBindingHandlers = {
   isRuntimeExtensionCommandRunning: (runtime: PiRuntime) => boolean
   reloadRuntimeSettingsIfSafe: (runtimeKey: string) => Promise<boolean>
 }
+
+const PI_EXTENSION_UI_UPDATE_FRAME_MS = 16
+const piExtensionUiUpdateTimers = new WeakMap<PiRuntime, ReturnType<typeof setTimeout>>()
 
 function getRuntimeDiagnosticExtensionLabel(extensionPath: string) {
   if (extensionPath.startsWith('command:')) return `/${extensionPath.slice('command:'.length)}`
@@ -49,13 +56,24 @@ function publishRuntimeExtensionCommandState(
   }
 }
 
+function scheduleRuntimeExtensionUiUpdate(runtime: PiRuntime) {
+  if (piExtensionUiUpdateTimers.has(runtime)) return
+  const timer = setTimeout(() => {
+    piExtensionUiUpdateTimers.delete(runtime)
+    publishPiExtensionUiUpdate(runtime)
+  }, PI_EXTENSION_UI_UPDATE_FRAME_MS)
+  piExtensionUiUpdateTimers.set(runtime, timer)
+}
+
 export async function bindRuntimeExtensionHandlers(
   runtime: PiRuntime,
   handlers: RuntimeExtensionBindingHandlers,
 ) {
   await bindHeadlessAgentSessionExtensions(runtime.session, {
-    uiContext: createPiExtensionUiContext(runtime, () =>
-      publishRuntimeExtensionCommandState(runtime, handlers),
+    uiContext: createPiExtensionUiContext(
+      runtime,
+      () => scheduleRuntimeExtensionUiUpdate(runtime),
+      () => publishRuntimeExtensionCommandState(runtime, handlers),
     ),
     onExtensionCommandStateChange: () => publishRuntimeExtensionCommandState(runtime, handlers),
     onExtensionError: (error) => {

--- a/desktop/runtime/pi-extension-ui-state.ts
+++ b/desktop/runtime/pi-extension-ui-state.ts
@@ -7,6 +7,7 @@ import type {
   PiExtensionDialogRequest,
   PiExtensionShortcut,
   PiExtensionStatus,
+  PiExtensionUiState,
   PiExtensionWidget,
 } from '../../shared/desktop-contracts.ts'
 import type { PiRuntime } from './types.ts'
@@ -114,6 +115,15 @@ function normalizeWidgetContent(content: unknown) {
   return ['Component-based widgets are not yet compatible with Howcode.']
 }
 
+function widgetLinesEqual(left: string[], right: string[]) {
+  return left.length === right.length && left.every((line, index) => line === right[index])
+}
+
+function widgetEqual(left: PiExtensionWidget | undefined, right: PiExtensionWidget | undefined) {
+  if (!(left && right)) return left === right
+  return left.placement === right.placement && widgetLinesEqual(left.lines, right.lines)
+}
+
 export function getPiExtensionWidgets(runtime: PiRuntime): PiExtensionWidget[] {
   const sessionPath = getSessionPath(runtime)
   if (!sessionPath) return []
@@ -143,6 +153,14 @@ export function getPiExtensionDialog(runtime: PiRuntime): PiExtensionDialogReque
   if (!dialog) return null
   const { cleanup: _cleanup, resolve: _resolve, ...request } = dialog
   return request
+}
+
+export function getPiExtensionUiState(runtime: PiRuntime): PiExtensionUiState {
+  return {
+    piExtensionWidgets: getPiExtensionWidgets(runtime),
+    piExtensionStatuses: getPiExtensionStatuses(runtime),
+    piExtensionDialogRequest: getPiExtensionDialog(runtime),
+  }
 }
 
 export function hasPendingPiExtensionDialog(runtime: PiRuntime) {
@@ -242,14 +260,15 @@ function replaceEditorSelection(state: PiExtensionEditorState, text: string) {
 
 export function createPiExtensionUiContext(
   runtime: PiRuntime,
-  onStateChange: () => void,
+  onUiStateChange: () => void,
+  onSessionStateChange: () => void,
 ): ExtensionUIContext {
   return {
     select: async (title, options, dialogOptions) => {
       const answer = await createDialogRequest(
         runtime,
         { method: 'select', title, options },
-        onStateChange,
+        onUiStateChange,
         dialogOptions,
       )
       return answer.cancelled ? undefined : answer.value
@@ -258,7 +277,7 @@ export function createPiExtensionUiContext(
       const answer = await createDialogRequest(
         runtime,
         { method: 'confirm', title, message },
-        onStateChange,
+        onUiStateChange,
         dialogOptions,
       )
       return answer.cancelled ? false : answer.confirmed === true
@@ -267,7 +286,7 @@ export function createPiExtensionUiContext(
       const answer = await createDialogRequest(
         runtime,
         { method: 'input', title, placeholder },
-        onStateChange,
+        onUiStateChange,
         dialogOptions,
       )
       return answer.cancelled ? undefined : answer.value
@@ -277,7 +296,7 @@ export function createPiExtensionUiContext(
         source: 'extension-notify',
         severity: type ?? 'info',
       })
-      onStateChange()
+      onSessionStateChange()
     },
     onTerminalInput: () => () => undefined,
     setStatus: (key, text) => {
@@ -286,9 +305,15 @@ export function createPiExtensionUiContext(
       const statuses = getSessionStatuses(sessionPath)
       const normalizedText =
         text === undefined ? '' : stripStyleMarkers(stripAnsi(String(text))).trim()
-      if (normalizedText) statuses.set(key, { key, text: normalizedText })
-      else statuses.delete(key)
-      onStateChange()
+      const current = statuses.get(key)
+      if (normalizedText) {
+        if (current?.text === normalizedText) return
+        statuses.set(key, { key, text: normalizedText })
+      } else {
+        if (!current) return
+        statuses.delete(key)
+      }
+      onUiStateChange()
     },
     setWorkingMessage: () => undefined,
     setWorkingVisible: () => undefined,
@@ -299,9 +324,15 @@ export function createPiExtensionUiContext(
       if (!sessionPath) return
       const widgets = getSessionWidgets(sessionPath)
       const lines = normalizeWidgetContent(content)
-      if (lines) widgets.set(key, { key, lines, placement: options?.placement })
-      else widgets.delete(key)
-      onStateChange()
+      if (lines) {
+        const nextWidget = { key, lines, placement: options?.placement }
+        if (widgetEqual(widgets.get(key), nextWidget)) return
+        widgets.set(key, nextWidget)
+      } else {
+        if (!widgets.has(key)) return
+        widgets.delete(key)
+      }
+      onUiStateChange()
     },
     setFooter: () => undefined,
     setHeader: () => undefined,
@@ -324,7 +355,7 @@ export function createPiExtensionUiContext(
       const answer = await createDialogRequest(
         runtime,
         { method: 'editor', title, prefill },
-        onStateChange,
+        onUiStateChange,
       )
       return answer.cancelled ? undefined : answer.value
     },

--- a/desktop/thread-state-db-queries.test.ts
+++ b/desktop/thread-state-db-queries.test.ts
@@ -52,11 +52,20 @@ describe('thread state db branch queries', () => {
       1,
       'feature',
     )
+    insertThread.run(
+      'inferred-worktree-thread',
+      '/repo/.worktrees/feature',
+      '/sessions/inferred-worktree.jsonl',
+      'Inferred worktree',
+      1,
+      '',
+    )
     insertThread.run('other-branch', '/repo', '/sessions/other.jsonl', 'Other', 1, 'main')
 
     expect(listProjectFamilyBranchThreadIds('/repo', 'feature')).toEqual([
       'root-thread',
       'worktree-thread',
+      'inferred-worktree-thread',
     ])
   })
 

--- a/desktop/thread-state-db-queries.test.ts
+++ b/desktop/thread-state-db-queries.test.ts
@@ -92,7 +92,7 @@ describe('thread state db branch queries', () => {
       inferredWorktreeSessionPath,
       'Inferred worktree chat',
       4,
-      null,
+      '',
     )
     db.prepare('INSERT INTO chat_threads (session_path, group_id) VALUES (?, ?)').run(
       chatSessionPath,

--- a/desktop/thread-state-db-queries.test.ts
+++ b/desktop/thread-state-db-queries.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 let userDataPath = ''
 
@@ -19,6 +19,7 @@ describe('thread state db branch queries', () => {
   afterEach(async () => {
     const { closeThreadStateDatabaseForTests } = await import('./thread-state-db/db.ts')
     closeThreadStateDatabaseForTests()
+    vi.resetModules()
     // biome-ignore lint/complexity/useLiteralKeys: ProcessEnv is an index-signature type.
     delete process.env['HOWCODE_USER_DATA_PATH']
     if (userDataPath) rmSync(userDataPath, { recursive: true, force: true })
@@ -56,6 +57,77 @@ describe('thread state db branch queries', () => {
     expect(listProjectFamilyBranchThreadIds('/repo', 'feature')).toEqual([
       'root-thread',
       'worktree-thread',
+    ])
+  })
+
+  it('treats branch-assigned chat-path sessions as code/worktree threads', async () => {
+    const { getChatSessionDir } = await import('./chat-session-dir.ts')
+    const { getThreadStateDatabase } = await import('./thread-state-db/db.ts')
+    const { listInboxThreads, listProjectThreads } = await loadThreadStateDb()
+    const db = getThreadStateDatabase()
+    const chatSessionDir = getChatSessionDir()
+    const chatSessionPath = path.join(chatSessionDir, 'chat.jsonl')
+    const worktreeSessionPath = path.join(chatSessionDir, 'worktree-chat.jsonl')
+    const inferredWorktreeSessionPath = path.join(chatSessionDir, 'inferred-worktree-chat.jsonl')
+
+    db.prepare('INSERT INTO projects (cwd, name) VALUES (?, ?)').run('/repo', 'Repo')
+    db.prepare('INSERT INTO projects (cwd, name) VALUES (?, ?)').run(
+      '/repo/.worktrees/feature',
+      'Feature',
+    )
+    db.prepare(
+      `INSERT INTO project_worktrees (cwd, root_cwd, branch_name, is_main, source)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('/repo/.worktrees/feature', '/repo', 'feature', 0, 'howcode')
+    const insertThread = db.prepare(
+      `INSERT INTO threads (id, cwd, session_path, title, last_modified_ms, branch_name)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    insertThread.run('plain-code', '/repo', '/sessions/code.jsonl', 'Code', 1, null)
+    insertThread.run('plain-chat', '/repo', chatSessionPath, 'Chat', 2, null)
+    insertThread.run('worktree-chat', '/repo', worktreeSessionPath, 'Worktree chat', 3, 'feature')
+    insertThread.run(
+      'inferred-worktree-chat',
+      '/repo/.worktrees/feature',
+      inferredWorktreeSessionPath,
+      'Inferred worktree chat',
+      4,
+      null,
+    )
+    db.prepare('INSERT INTO chat_threads (session_path, group_id) VALUES (?, ?)').run(
+      chatSessionPath,
+      null,
+    )
+    db.prepare('INSERT INTO chat_threads (session_path, group_id) VALUES (?, ?)').run(
+      worktreeSessionPath,
+      null,
+    )
+    db.prepare('INSERT INTO chat_threads (session_path, group_id) VALUES (?, ?)').run(
+      inferredWorktreeSessionPath,
+      null,
+    )
+    db.prepare(
+      `INSERT INTO inbox_items (session_path, unread, last_user_prompt, last_assistant_at_ms)
+       VALUES (?, ?, ?, ?)`,
+    ).run(worktreeSessionPath, 1, 'Prompt', 4)
+    db.prepare(
+      `INSERT INTO inbox_items (session_path, unread, last_user_prompt, last_assistant_at_ms)
+       VALUES (?, ?, ?, ?)`,
+    ).run(inferredWorktreeSessionPath, 1, 'Prompt', 5)
+
+    expect(listProjectThreads('/repo').map((thread) => thread.id)).toEqual([
+      'worktree-chat',
+      'plain-code',
+    ])
+    expect(listProjectThreads('/repo', { chat: true }).map((thread) => thread.id)).toEqual([
+      'plain-chat',
+    ])
+    expect(listProjectThreads('/repo/.worktrees/feature').map((thread) => thread.id)).toEqual([
+      'inferred-worktree-chat',
+    ])
+    expect(listInboxThreads()).toMatchObject([
+      { threadId: 'inferred-worktree-chat', branchName: 'feature', isChat: true },
+      { threadId: 'worktree-chat', branchName: 'feature', isChat: true },
     ])
   })
 })

--- a/desktop/thread-state-db/mappers.ts
+++ b/desktop/thread-state-db/mappers.ts
@@ -109,6 +109,7 @@ export function mapInboxThreadRow(row: InboxThreadRow): InboxThread {
     preview: row.lastAssistantPreview,
     running: Boolean(row.running),
     unread: Boolean(row.unread),
+    branchName: row.branchName ?? undefined,
     isChat: Boolean(row.isChat),
   }
 }

--- a/desktop/thread-state-db/queries.ts
+++ b/desktop/thread-state-db/queries.ts
@@ -31,8 +31,13 @@ import type {
 } from './types.ts'
 import { ensureProject } from './writes.ts'
 
-function matchesThreadScope(sessionPath: string, options: { chat?: boolean | undefined } = {}) {
-  return options.chat ? isChatSessionPath(sessionPath) : !isChatSessionPath(sessionPath)
+function matchesThreadScope(
+  row: { branchName?: string | null | undefined; sessionPath: string },
+  options: { chat?: boolean | undefined } = {},
+) {
+  const isChat = isChatSessionPath(row.sessionPath)
+  if (options.chat) return isChat && !row.branchName?.trim()
+  return !isChat || Boolean(row.branchName?.trim())
 }
 
 function getChatSessionLikePattern() {
@@ -72,9 +77,25 @@ export function listProjects(cwd: string): Project[] {
         LEFT JOIN threads
           ON threads.cwd = projects.cwd
           AND threads.archived = 0
-          AND threads.session_path NOT LIKE ?
-          AND NOT EXISTS (
-            SELECT 1 FROM chat_threads WHERE chat_threads.session_path = threads.session_path
+          AND (
+            (
+              threads.branch_name IS NOT NULL
+              AND TRIM(threads.branch_name) != ''
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM project_worktrees AS thread_worktrees
+              WHERE thread_worktrees.cwd = threads.cwd
+                AND thread_worktrees.is_main = 0
+                AND thread_worktrees.branch_name IS NOT NULL
+                AND TRIM(thread_worktrees.branch_name) != ''
+            )
+            OR (
+              threads.session_path NOT LIKE ?
+              AND NOT EXISTS (
+                SELECT 1 FROM chat_threads WHERE chat_threads.session_path = threads.session_path
+              )
+            )
           )
         WHERE projects.hidden = 0
         GROUP BY
@@ -233,10 +254,11 @@ export function listProjectThreads(
           threads.running AS running,
           COALESCE(inbox_items.unread, 0) AS unread,
           threads.pinned AS pinned,
-          threads.branch_name AS branchName,
+          COALESCE(threads.branch_name, project_worktrees.branch_name) AS branchName,
           threads.last_modified_ms AS lastModifiedMs
         FROM threads
         LEFT JOIN inbox_items ON inbox_items.session_path = threads.session_path
+        LEFT JOIN project_worktrees ON project_worktrees.cwd = threads.cwd AND project_worktrees.is_main = 0
         WHERE threads.cwd = ? AND threads.archived = 0
         ORDER BY threads.pinned DESC, threads.last_modified_ms DESC, threads.title COLLATE NOCASE ASC
       `,
@@ -244,7 +266,7 @@ export function listProjectThreads(
     .all(projectId) as ThreadRow[]
 
   return rows
-    .filter((row) => matchesThreadScope(row.sessionPath, options))
+    .filter((row) => matchesThreadScope(row, options))
     .map((row) =>
       mapThreadRow({
         ...row,
@@ -271,10 +293,11 @@ export function listArchivedProjectThreads(
           threads.running AS running,
           COALESCE(inbox_items.unread, 0) AS unread,
           threads.pinned AS pinned,
-          threads.branch_name AS branchName,
+          COALESCE(threads.branch_name, project_worktrees.branch_name) AS branchName,
           threads.last_modified_ms AS lastModifiedMs
         FROM threads
         LEFT JOIN inbox_items ON inbox_items.session_path = threads.session_path
+        LEFT JOIN project_worktrees ON project_worktrees.cwd = threads.cwd AND project_worktrees.is_main = 0
         WHERE threads.cwd = ? AND threads.archived = 1
         ORDER BY threads.last_modified_ms DESC, threads.title COLLATE NOCASE ASC
       `,
@@ -282,7 +305,7 @@ export function listArchivedProjectThreads(
     .all(projectId) as ThreadRow[]
 
   return rows
-    .filter((row) => matchesThreadScope(row.sessionPath, options))
+    .filter((row) => matchesThreadScope(row, options))
     .map((row) =>
       mapThreadRow({
         ...row,
@@ -309,11 +332,13 @@ export function listInboxThreads(): InboxThread[] {
           inbox_items.last_assistant_preview AS lastAssistantPreview,
           threads.running AS running,
           inbox_items.unread AS unread,
+          COALESCE(threads.branch_name, project_worktrees.branch_name) AS branchName,
           COALESCE(inbox_items.last_assistant_at_ms, threads.last_modified_ms) AS lastActivityMs,
           CASE WHEN chat_threads.session_path IS NULL THEN 0 ELSE 1 END AS isChat
         FROM inbox_items
         INNER JOIN threads ON threads.session_path = inbox_items.session_path
         INNER JOIN projects ON projects.cwd = threads.cwd
+        LEFT JOIN project_worktrees ON project_worktrees.cwd = threads.cwd AND project_worktrees.is_main = 0
         LEFT JOIN chat_threads ON chat_threads.session_path = threads.session_path
         WHERE
           projects.hidden = 0

--- a/desktop/thread-state-db/queries.ts
+++ b/desktop/thread-state-db/queries.ts
@@ -481,10 +481,11 @@ export function listProjectFamilyBranchThreadIds(projectId: string, branchName: 
       `
         SELECT id AS id, session_path AS sessionPath
         FROM threads
-        WHERE branch_name = ?
+        LEFT JOIN project_worktrees ON project_worktrees.cwd = threads.cwd AND project_worktrees.is_main = 0
+        WHERE COALESCE(NULLIF(TRIM(threads.branch_name), ''), project_worktrees.branch_name) = ?
           AND (
-            cwd = ?
-            OR cwd IN (
+            threads.cwd = ?
+            OR threads.cwd IN (
               SELECT cwd
               FROM project_worktrees
               WHERE root_cwd = ? AND is_main = 0

--- a/desktop/thread-state-db/queries.ts
+++ b/desktop/thread-state-db/queries.ts
@@ -254,7 +254,7 @@ export function listProjectThreads(
           threads.running AS running,
           COALESCE(inbox_items.unread, 0) AS unread,
           threads.pinned AS pinned,
-          COALESCE(threads.branch_name, project_worktrees.branch_name) AS branchName,
+          COALESCE(NULLIF(TRIM(threads.branch_name), ''), project_worktrees.branch_name) AS branchName,
           threads.last_modified_ms AS lastModifiedMs
         FROM threads
         LEFT JOIN inbox_items ON inbox_items.session_path = threads.session_path
@@ -293,7 +293,7 @@ export function listArchivedProjectThreads(
           threads.running AS running,
           COALESCE(inbox_items.unread, 0) AS unread,
           threads.pinned AS pinned,
-          COALESCE(threads.branch_name, project_worktrees.branch_name) AS branchName,
+          COALESCE(NULLIF(TRIM(threads.branch_name), ''), project_worktrees.branch_name) AS branchName,
           threads.last_modified_ms AS lastModifiedMs
         FROM threads
         LEFT JOIN inbox_items ON inbox_items.session_path = threads.session_path
@@ -332,7 +332,7 @@ export function listInboxThreads(): InboxThread[] {
           inbox_items.last_assistant_preview AS lastAssistantPreview,
           threads.running AS running,
           inbox_items.unread AS unread,
-          COALESCE(threads.branch_name, project_worktrees.branch_name) AS branchName,
+          COALESCE(NULLIF(TRIM(threads.branch_name), ''), project_worktrees.branch_name) AS branchName,
           COALESCE(inbox_items.last_assistant_at_ms, threads.last_modified_ms) AS lastActivityMs,
           CASE WHEN chat_threads.session_path IS NULL THEN 0 ELSE 1 END AS isChat
         FROM inbox_items

--- a/desktop/thread-state-db/types.ts
+++ b/desktop/thread-state-db/types.ts
@@ -49,6 +49,7 @@ export type InboxThreadRow = {
   lastAssistantPreview: string | null
   running: number
   unread: number
+  branchName: string | null
   lastActivityMs: number
   isChat: number
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,5 +4,6 @@
 - Do not use robotic product-speak, corporate filler, or polished AI brochure language.
 - Prefer blunt bullets, plain English, and "probably / maybe / unsure" when that is the honest state.
 - Keep roadmap notes lightweight unless the user asks for a full spec.
-- Try to match lengths of other bullet points - avoid long ones.
+- Changelog bullets should be short, user-facing, and snappy.
+- Aim for one-line bullets around 50–70 chars; avoid >90 chars unless needed.
 - Do NOT use American date formats.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 - Reworked widgets, dialogs, attachments, `/commands` to feel like a coherent stack.
 - Extension status/widgets now refresh separately and clear cleanly, so animated statuslines should stop shaking the thread view.
 - Code/worktree sessions now survive Chat/Inbox/sidebar detours, and Inbox keeps branch-assigned threads in the right code/worktree context.
+- Thread URLs now follow the persisted session after a local draft is saved, instead of getting stuck on stale draft ids.
 - Rebuilt the workspace rails around the composer/thread. Better responsiveness.
 - Fixed the empty composer being taller than a composer with text in it.
 - Fixed Past sessions count alignment in the sidebar.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@
 - Added Pi project trust prompts in desktop, backed by Pi's trust store.
 - Reworked widgets, dialogs, attachments, `/commands` to feel like a coherent stack.
 - Extension status/widgets now refresh separately, so animated statuslines should stop shaking the thread view.
+- Code/worktree sessions now survive Chat/Inbox/sidebar detours, and Inbox keeps branch-assigned threads in the right code/worktree context.
 - Rebuilt the workspace rails around the composer/thread. Better responsiveness.
 - Fixed the empty composer being taller than a composer with text in it.
 - Fixed Past sessions count alignment in the sidebar.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@
 - Resolved an annoying bug that didn't allow typing into Pi TUI.
 - Added Pi project trust prompts in desktop, backed by Pi's trust store.
 - Reworked widgets, dialogs, attachments, `/commands` to feel like a coherent stack.
-- Extension status/widgets now refresh separately, so animated statuslines should stop shaking the thread view.
+- Extension status/widgets now refresh separately and clear cleanly, so animated statuslines should stop shaking the thread view.
 - Code/worktree sessions now survive Chat/Inbox/sidebar detours, and Inbox keeps branch-assigned threads in the right code/worktree context.
 - Rebuilt the workspace rails around the composer/thread. Better responsiveness.
 - Fixed the empty composer being taller than a composer with text in it.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,9 +12,9 @@
 - Resolved an annoying bug that didn't allow typing into Pi TUI.
 - Added Pi project trust prompts in desktop, backed by Pi's trust store.
 - Reworked widgets, dialogs, attachments, `/commands` to feel like a coherent stack.
-- Extension status/widgets now refresh separately and clear cleanly, so animated statuslines should stop shaking the thread view.
-- Code/worktree sessions now survive Chat/Inbox/sidebar detours, and Inbox keeps branch-assigned threads in the right code/worktree context.
-- Thread URLs now follow the persisted session after a local draft is saved, instead of getting stuck on stale draft ids.
+- Extension widgets no longer shake the thread view.
+- Inbox keeps branch-assigned threads in Code context.
+- Thread URLs no longer stick to local draft ids.
 - Rebuilt the workspace rails around the composer/thread. Better responsiveness.
 - Fixed the empty composer being taller than a composer with text in it.
 - Fixed Past sessions count alignment in the sidebar.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
 - Resolved an annoying bug that didn't allow typing into Pi TUI.
 - Added Pi project trust prompts in desktop, backed by Pi's trust store.
 - Reworked widgets, dialogs, attachments, `/commands` to feel like a coherent stack.
+- Extension status/widgets now refresh separately, so animated statuslines should stop shaking the thread view.
 - Rebuilt the workspace rails around the composer/thread. Better responsiveness.
 - Fixed the empty composer being taller than a composer with text in it.
 - Fixed Past sessions count alignment in the sidebar.

--- a/shared/desktop-action-contracts.ts
+++ b/shared/desktop-action-contracts.ts
@@ -175,6 +175,8 @@ export type DesktopActionPayloadMap = {
     projectId?: string | undefined | null | undefined
     sessionPath?: string | undefined | null | undefined
     threadId?: string | undefined
+    composerMode?: 'chat' | 'code' | null
+    branchName?: string | undefined | null | undefined
   }
   'thread.archive': { threadId: string }
   'thread.archive-many': { projectId?: string | undefined | null | undefined; threadIds: string[] }

--- a/shared/desktop-composer-contracts.ts
+++ b/shared/desktop-composer-contracts.ts
@@ -37,6 +37,12 @@ export type PiExtensionDialogRequest = {
   prefill?: string | undefined
 }
 
+export type PiExtensionUiState = {
+  piExtensionWidgets: PiExtensionWidget[]
+  piExtensionStatuses: PiExtensionStatus[]
+  piExtensionDialogRequest: PiExtensionDialogRequest | null
+}
+
 export type ProjectTrustRequest = {
   cwd: string
 }

--- a/shared/desktop-contracts.ts
+++ b/shared/desktop-contracts.ts
@@ -41,6 +41,7 @@ export type {
   PiExtensionDialogRequest,
   PiExtensionShortcut,
   PiExtensionStatus,
+  PiExtensionUiState,
   PiExtensionWidget,
   ProjectTrustRequest,
 } from './desktop-composer-contracts'

--- a/shared/desktop-event-contracts.ts
+++ b/shared/desktop-event-contracts.ts
@@ -1,6 +1,6 @@
 import type { AppUpdateState } from './desktop-app-update-contracts'
 import type { Artifact } from './desktop-artifact-contracts'
-import type { ComposerState } from './desktop-composer-contracts'
+import type { ComposerState, PiExtensionUiState } from './desktop-composer-contracts'
 import type { DictationModelId } from './desktop-dictation-contracts'
 import type { ProjectDiffStreamEvent } from './desktop-project-git-contracts'
 import type { ThreadData } from './desktop-thread-contracts'
@@ -69,4 +69,10 @@ export type DesktopEvent =
       projectId: string | null
       sessionPath: string | null
       composer: ComposerState
+    }
+  | {
+      type: 'pi-extension-ui-update'
+      projectId: string | null
+      sessionPath: string
+      extensionUi: PiExtensionUiState
     }

--- a/shared/desktop-thread-contracts.ts
+++ b/shared/desktop-thread-contracts.ts
@@ -35,6 +35,7 @@ export type InboxThread = {
   preview: string | null
   running: boolean
   unread: boolean
+  branchName?: string | null | undefined
   isChat?: boolean | undefined
 }
 

--- a/src/app/app-shell/app-shell-layout-view.tsx
+++ b/src/app/app-shell/app-shell-layout-view.tsx
@@ -30,6 +30,7 @@ type AppShellLayoutViewProps = {
   mainSectionRef: RefObject<HTMLElement | null>
   takeoverVisible: boolean
   activeComposerState: AppShellController['activeComposerState']
+  activePiExtensionUiState: AppShellController['activePiExtensionUiState']
   activeThreadData: AppShellController['activeThreadData']
   composerProjectId: string
   currentProjectName: string
@@ -232,6 +233,7 @@ function AppShellWorkspaceSection(props: AppShellLayoutViewProps) {
           <AppShellWorkspace
             controller={controller}
             activeComposerState={activeComposerState}
+            activePiExtensionUiState={props.activePiExtensionUiState}
             activeThreadData={activeThreadData}
             composerProjectId={composerProjectId}
             currentProjectName={currentProjectName}

--- a/src/app/app-shell/app-shell-layout.tsx
+++ b/src/app/app-shell/app-shell-layout.tsx
@@ -103,6 +103,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
   const [terminalHiddenByCompactResize, setTerminalHiddenByCompactResize] = useState(false)
   const {
     activeComposerState,
+    activePiExtensionUiState,
     activeThreadData,
     collapsedProjectIds,
     composerProjectId,
@@ -281,6 +282,7 @@ export function AppShellLayout({ controller }: AppShellLayoutProps) {
       mainSectionRef={mainSectionRef}
       takeoverVisible={takeoverVisible}
       activeComposerState={activeComposerState}
+      activePiExtensionUiState={activePiExtensionUiState}
       activeThreadData={activeThreadData}
       composerProjectId={composerProjectId}
       currentProjectName={currentProjectName}

--- a/src/app/app-shell/app-shell-workspace.tsx
+++ b/src/app/app-shell/app-shell-workspace.tsx
@@ -8,6 +8,7 @@ import type { AppShellController } from './useAppShellController'
 type AppShellWorkspaceProps = {
   controller: AppShellController
   activeComposerState: AppShellController['activeComposerState']
+  activePiExtensionUiState: AppShellController['activePiExtensionUiState']
   activeThreadData: AppShellController['activeThreadData']
   composerProjectId: string
   currentProjectName: string
@@ -31,6 +32,7 @@ type AppShellWorkspaceProps = {
 export function AppShellWorkspace({
   controller,
   activeComposerState,
+  activePiExtensionUiState,
   activeThreadData,
   composerProjectId,
   currentProjectName,
@@ -55,6 +57,7 @@ export function AppShellWorkspace({
       <ChatWorkspaceView
         controller={controller}
         activeComposerState={activeComposerState}
+        activePiExtensionUiState={activePiExtensionUiState}
         activeThreadData={activeThreadData}
         composerProjectId={composerProjectId}
         diffBaseline={diffBaseline}
@@ -89,6 +92,7 @@ export function AppShellWorkspace({
     <CodeWorkspaceView
       controller={controller}
       activeComposerState={activeComposerState}
+      activePiExtensionUiState={activePiExtensionUiState}
       activeThreadData={activeThreadData}
       composerProjectId={composerProjectId}
       currentProjectName={currentProjectName}

--- a/src/app/app-shell/desktop-event-handlers.ts
+++ b/src/app/app-shell/desktop-event-handlers.ts
@@ -6,6 +6,7 @@ import type {
   ChatSidebarState,
   ComposerState,
   DesktopEvent,
+  PiExtensionUiState,
   ProjectGitState,
   ThreadData,
 } from '../desktop/types'
@@ -45,6 +46,7 @@ type UseDesktopEventSyncInput = {
   setComposerState: Dispatch<SetStateAction<ComposerState | null>>
   setChatSidebarState: Dispatch<SetStateAction<ChatSidebarState | null>>
   setLiveThreadData: Dispatch<SetStateAction<ThreadData | null>>
+  setPiExtensionUiStateBySession: Dispatch<SetStateAction<Record<string, PiExtensionUiState>>>
   setProjectGitState: Dispatch<SetStateAction<ProjectGitState | null>>
   setThreadHistoryCompactions: Dispatch<SetStateAction<number>>
 }
@@ -85,6 +87,84 @@ function shouldApplyComposerUpdate(input: {
   )
 }
 
+function extensionWidgetListsEqual(
+  left: PiExtensionUiState['piExtensionWidgets'],
+  right: PiExtensionUiState['piExtensionWidgets'],
+) {
+  return (
+    left.length === right.length &&
+    left.every((widget, index) => {
+      const other = right[index]
+      return (
+        other?.key === widget.key &&
+        other.placement === widget.placement &&
+        other.lines.length === widget.lines.length &&
+        other.lines.every((line, lineIndex) => line === widget.lines[lineIndex])
+      )
+    })
+  )
+}
+
+function extensionStatusListsEqual(
+  left: PiExtensionUiState['piExtensionStatuses'],
+  right: PiExtensionUiState['piExtensionStatuses'],
+) {
+  return (
+    left.length === right.length &&
+    left.every((status, index) => {
+      const other = right[index]
+      return other?.key === status.key && other.text === status.text
+    })
+  )
+}
+
+function extensionDialogsEqual(
+  left: PiExtensionUiState['piExtensionDialogRequest'],
+  right: PiExtensionUiState['piExtensionDialogRequest'],
+) {
+  if (!(left && right)) return left === right
+  return (
+    left.id === right.id &&
+    left.method === right.method &&
+    left.title === right.title &&
+    left.message === right.message &&
+    left.placeholder === right.placeholder &&
+    left.prefill === right.prefill &&
+    (left.options ?? []).length === (right.options ?? []).length &&
+    (left.options ?? []).every((option, index) => option === right.options?.[index])
+  )
+}
+
+function extensionUiStatesEqual(left: PiExtensionUiState, right: PiExtensionUiState) {
+  return (
+    extensionWidgetListsEqual(left.piExtensionWidgets, right.piExtensionWidgets) &&
+    extensionStatusListsEqual(left.piExtensionStatuses, right.piExtensionStatuses) &&
+    extensionDialogsEqual(left.piExtensionDialogRequest, right.piExtensionDialogRequest)
+  )
+}
+
+function composerExtensionUi(composer: ComposerState): PiExtensionUiState {
+  return {
+    piExtensionWidgets: composer.piExtensionWidgets,
+    piExtensionStatuses: composer.piExtensionStatuses,
+    piExtensionDialogRequest: composer.piExtensionDialogRequest,
+  }
+}
+
+function applyPiExtensionUiState(input: {
+  extensionUi: PiExtensionUiState
+  sessionPath: string | null
+  setPiExtensionUiStateBySession: Dispatch<SetStateAction<Record<string, PiExtensionUiState>>>
+}) {
+  if (!input.sessionPath) return
+  const sessionPath = input.sessionPath
+  input.setPiExtensionUiStateBySession((current) => {
+    const currentUi = current[sessionPath]
+    if (currentUi && extensionUiStatesEqual(currentUi, input.extensionUi)) return current
+    return { ...current, [sessionPath]: input.extensionUi }
+  })
+}
+
 function handleComposerUpdateEvent(
   runtime: DesktopEventSyncRuntime,
   event: Extract<DesktopEvent, { type: 'composer-update' }>,
@@ -103,6 +183,11 @@ function handleComposerUpdateEvent(
     })
   )
     runtime.setComposerState(event.composer)
+  applyPiExtensionUiState({
+    extensionUi: composerExtensionUi(event.composer),
+    sessionPath: event.sessionPath,
+    setPiExtensionUiStateBySession: runtime.setPiExtensionUiStateBySession,
+  })
 }
 
 function mergeThreadPreferences(input: {
@@ -324,6 +409,12 @@ function handleThreadUpdateEvent(
       aliasedLocalDraftSessionPath === latestWorkspaceState.selectedSessionPath)
   )
     runtime.setComposerState(event.composer)
+  if (event.composer)
+    applyPiExtensionUiState({
+      extensionUi: composerExtensionUi(event.composer),
+      sessionPath: event.sessionPath,
+      setPiExtensionUiStateBySession: runtime.setPiExtensionUiStateBySession,
+    })
   if (
     event.reason === 'start' ||
     event.reason === 'end' ||
@@ -367,6 +458,17 @@ function handleSessionTreeRefreshEvent(
   })
 }
 
+function handlePiExtensionUiUpdateEvent(
+  runtime: DesktopEventSyncRuntime,
+  event: Extract<DesktopEvent, { type: 'pi-extension-ui-update' }>,
+) {
+  applyPiExtensionUiState({
+    extensionUi: event.extensionUi,
+    sessionPath: event.sessionPath,
+    setPiExtensionUiStateBySession: runtime.setPiExtensionUiStateBySession,
+  })
+}
+
 export function handleDesktopEvent(runtime: DesktopEventSyncRuntime, event: DesktopEvent) {
   if (event.type === 'shell-state-refresh') {
     runtime.scheduleShellStateRefresh()
@@ -386,6 +488,10 @@ export function handleDesktopEvent(runtime: DesktopEventSyncRuntime, event: Desk
   }
   if (event.type === 'composer-update') {
     handleComposerUpdateEvent(runtime, event)
+    return
+  }
+  if (event.type === 'pi-extension-ui-update') {
+    handlePiExtensionUiUpdateEvent(runtime, event)
     return
   }
   if (event.type === 'thread-update') handleThreadUpdateEvent(runtime, event)

--- a/src/app/app-shell/post-effects/new-thread.ts
+++ b/src/app/app-shell/post-effects/new-thread.ts
@@ -66,9 +66,15 @@ function shouldShowCodeDashboard(input: NewThreadPostEffectInput) {
   return input.action === 'project.add'
 }
 
-function getComposerModeForNextView(input: NewThreadPostEffectInput): 'chat' | 'code' {
+function getRequestedComposerMode(input: NewThreadPostEffectInput): 'chat' | 'code' {
   if (input.action === 'project.add') return 'code'
+  if (input.contextualPayload.composerMode === 'chat') return 'chat'
+  if (input.contextualPayload.composerMode === 'code') return 'code'
   return input.workspaceState.activeView === 'chat' ? 'chat' : 'code'
+}
+
+function getComposerModeForNextView(input: NewThreadPostEffectInput): 'chat' | 'code' {
+  return getRequestedComposerMode(input)
 }
 
 function applyOptimisticThread(
@@ -96,6 +102,7 @@ function openOptimisticThread(
     projectId: thread.projectId,
     threadId: thread.threadId,
     sessionPath: thread.sessionPath,
+    view: getRequestedComposerMode(input) === 'chat' ? 'chat' : 'thread',
   })
   return optimisticThread
 }
@@ -134,7 +141,7 @@ async function handleNewThreadBridgeResult(
     sessionPath: result.sessionPath,
   })
   await input.loadProjectThreads(nextProjectId, {
-    chat: input.workspaceState.activeView === 'chat',
+    chat: getRequestedComposerMode(input) === 'chat',
   })
   applyProjectThreadToShellState(input.queryClient, nextProjectId, optimisticThread, {
     revealProject: true,

--- a/src/app/app-shell/useAppShellCommands.ts
+++ b/src/app/app-shell/useAppShellCommands.ts
@@ -124,11 +124,12 @@ export function useAppShellCommands({
     threadId: string,
     sessionPath: string,
     view?: 'chat' | 'thread' | undefined,
+    branchName?: string | null | undefined,
   ) => {
     clearSelectedUnstartedDraft()
     setThreadHistoryCompactions(0)
     dispatch({ type: 'open-thread', projectId, threadId, sessionPath, view })
-    scheduleThreadOpenAction({ projectId, threadId, sessionPath, view })
+    scheduleThreadOpenAction({ projectId, threadId, sessionPath, view, branchName })
   }
 
   const handleThreadCycle = (

--- a/src/app/app-shell/useAppShellController.ts
+++ b/src/app/app-shell/useAppShellController.ts
@@ -5,6 +5,7 @@ import { useDesktopInbox } from '../hooks/useDesktopInbox'
 import { useDesktopShell } from '../hooks/useDesktopShell'
 import { useToast } from '../hooks/useToast'
 import { deriveControllerViewModel } from './controller-view-model'
+import { getVisibleDesktopSessionPath } from './desktop-event-sync'
 import { useAppShellChatSidebar } from './useAppShellChatSidebar'
 import { useAppShellCommands } from './useAppShellCommands'
 import { useAppShellEffects } from './useAppShellEffects'
@@ -42,6 +43,10 @@ export function useAppShellController() {
     [inboxThreads, bundle.state.selectedInboxSessionPath],
   )
   const terminals = useRunningTerminalSessions()
+  const visibleExtensionUiSessionPath = getVisibleDesktopSessionPath(bundle.state)
+  const activePiExtensionUiState = visibleExtensionUiSessionPath
+    ? (bundle.piExtensionUiStateBySession[visibleExtensionUiSessionPath] ?? null)
+    : null
   const viewModel = useMemo(
     () =>
       deriveControllerViewModel({
@@ -80,6 +85,7 @@ export function useAppShellController() {
     setComposerState: bundle.setComposerState,
     setChatSidebarState: chatSidebar.setChatSidebarState,
     setLiveThreadData: bundle.setLiveThreadData,
+    setPiExtensionUiStateBySession: bundle.setPiExtensionUiStateBySession,
     setProjectGitState: bundle.setProjectGitState,
     setProjectGitLoading: bundle.setProjectGitLoading,
     setThreadHistoryCompactions: bundle.setThreadHistoryCompactions,
@@ -163,6 +169,7 @@ export function useAppShellController() {
     skillsProjectScopeActive: bundle.skillsProjectScopeActive,
     state: bundle.state,
     selectedInboxThread,
+    activePiExtensionUiState,
     terminalRunningWorkspaceIds: terminals.terminalRunningWorkspaceIds,
     terminalRunningSessionPaths: terminals.terminalRunningSessionPaths,
     toast,

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -5,6 +5,7 @@ import type {
   ChatSidebarState,
   ComposerState,
   InboxThread,
+  PiExtensionUiState,
   ProjectGitState,
   ThreadData,
 } from '../desktop/types'
@@ -50,6 +51,7 @@ export function useAppShellEffects({
   setComposerState,
   setChatSidebarState,
   setLiveThreadData,
+  setPiExtensionUiStateBySession,
   setProjectGitState,
   setProjectGitLoading,
   setThreadHistoryCompactions,
@@ -83,6 +85,7 @@ export function useAppShellEffects({
   setComposerState: Dispatch<SetStateAction<ComposerState | null>>
   setChatSidebarState: Dispatch<SetStateAction<ChatSidebarState | null>>
   setLiveThreadData: Dispatch<SetStateAction<ThreadData | null>>
+  setPiExtensionUiStateBySession: Dispatch<SetStateAction<Record<string, PiExtensionUiState>>>
   setProjectGitState: Dispatch<SetStateAction<ProjectGitState | null>>
   setProjectGitLoading: Dispatch<SetStateAction<boolean>>
   setThreadHistoryCompactions: Dispatch<SetStateAction<number>>
@@ -132,6 +135,7 @@ export function useAppShellEffects({
     setComposerState,
     setChatSidebarState,
     setLiveThreadData,
+    setPiExtensionUiStateBySession,
     setProjectGitState,
     setThreadHistoryCompactions,
   })

--- a/src/app/app-shell/useAppShellEffects.ts
+++ b/src/app/app-shell/useAppShellEffects.ts
@@ -97,6 +97,7 @@ export function useAppShellEffects({
     selectedProjectId: workspaceState.selectedProjectId,
     selectedThreadId: workspaceState.selectedThreadId,
     selectedSessionPath: workspaceState.selectedSessionPath,
+    lastCodeThreadSelection: workspaceState.lastCodeThreadSelection,
     takeoverVisible: workspaceState.takeoverVisible,
     loadProjectThreads,
     loadArchivedThreads,

--- a/src/app/app-shell/useAppShellStateBundle.ts
+++ b/src/app/app-shell/useAppShellStateBundle.ts
@@ -1,6 +1,12 @@
 import type { SettingsOpenTarget } from '@howcode/settings/settingsTypes'
 import { useReducer, useState } from 'react'
-import type { ArchivedThread, ComposerState, ProjectGitState, ThreadData } from '../desktop/types'
+import type {
+  ArchivedThread,
+  ComposerState,
+  PiExtensionUiState,
+  ProjectGitState,
+  ThreadData,
+} from '../desktop/types'
 import { createInitialWorkspaceState, workspaceReducer } from '../state/workspace'
 
 export function useAppShellStateBundle() {
@@ -8,6 +14,9 @@ export function useAppShellStateBundle() {
   const [state, dispatch] = useReducer(workspaceReducer, [], createInitialWorkspaceState)
   const [archivedThreads, setArchivedThreads] = useState<ArchivedThread[]>([])
   const [composerState, setComposerState] = useState<ComposerState | null>(null)
+  const [piExtensionUiStateBySession, setPiExtensionUiStateBySession] = useState<
+    Record<string, PiExtensionUiState>
+  >({})
   const [liveThreadData, setLiveThreadData] = useState<ThreadData | null>(null)
   const [projectGitState, setProjectGitState] = useState<ProjectGitState | null>(null)
   const [projectGitLoading, setProjectGitLoading] = useState(false)
@@ -25,12 +34,14 @@ export function useAppShellStateBundle() {
     dispatch,
     extensionsProjectScopeActive,
     liveThreadData,
+    piExtensionUiStateBySession,
     projectGitLoading,
     projectGitState,
     setArchivedThreads,
     setComposerState,
     setExtensionsProjectScopeActive,
     setLiveThreadData,
+    setPiExtensionUiStateBySession,
     setProjectGitLoading,
     setProjectGitState,
     setSettingsOpenTarget,

--- a/src/app/app-shell/useAppShellUrlSync.ts
+++ b/src/app/app-shell/useAppShellUrlSync.ts
@@ -7,7 +7,7 @@ type NonGitOpsView = Exclude<View, 'gitops'>
 
 type AppRouteSearch = Record<string, unknown>
 
-type AppRouteSnapshot = {
+export type AppRouteSnapshot = {
   pathname: string
   search: AppRouteSearch
 }
@@ -174,6 +174,16 @@ function getRouteKey(snapshot: AppRouteSnapshot) {
   return JSON.stringify(snapshot)
 }
 
+export function shouldDeferStateRouteNavigation(input: {
+  projects: Project[]
+  routeChanged: boolean
+  routeSnapshot: AppRouteSnapshot
+  stateChanged: boolean
+}) {
+  if (!input.stateChanged) return true
+  return input.routeChanged && isWaitingForRouteData(input.routeSnapshot, input.projects)
+}
+
 export function useAppShellUrlSync({ dispatch, projects, state }: AppShellUrlSyncInput) {
   const router = useRouter()
   const snapshot = useRouterState({
@@ -212,7 +222,7 @@ export function useAppShellUrlSync({ dispatch, projects, state }: AppShellUrlSyn
       return
     }
 
-    if (!stateChanged || isWaitingForRouteData(routeSnapshot, projects)) {
+    if (shouldDeferStateRouteNavigation({ projects, routeChanged, routeSnapshot, stateChanged })) {
       return
     }
 

--- a/src/app/app-shell/useComposerGitStateSync.ts
+++ b/src/app/app-shell/useComposerGitStateSync.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useEffect } from 'react'
+import { getInboxThreadComposerMode } from '../common/inbox-thread-scope'
 import type { AppSettings, ComposerState, InboxThread, ProjectGitState } from '../desktop/types'
 import type { WorkspaceState } from '../state/workspace'
 
@@ -20,6 +21,34 @@ type UseComposerGitStateSyncInput = {
   setProjectGitLoading: Dispatch<SetStateAction<boolean>>
 }
 
+function getComposerStateSyncTarget(input: {
+  activeView: WorkspaceState['activeView']
+  composerProjectId: string
+  inboxComposerMode: 'chat' | 'code'
+  inboxProjectId: string | null
+  inboxSessionPath: string | null
+  selectedSessionPath: string | null
+}) {
+  if (input.activeView === 'inbox') {
+    return {
+      composerMode: input.inboxComposerMode,
+      projectId: input.inboxProjectId,
+      sessionPath: input.inboxSessionPath,
+    }
+  }
+
+  const sessionPath =
+    input.activeView === 'chat' || input.activeView === 'thread' || input.activeView === 'gitops'
+      ? input.selectedSessionPath
+      : null
+
+  return {
+    composerMode: input.activeView === 'chat' ? ('chat' as const) : ('code' as const),
+    projectId: input.composerProjectId,
+    sessionPath,
+  }
+}
+
 export function useComposerGitStateSync({
   workspaceState,
   selectedInboxThread,
@@ -32,6 +61,10 @@ export function useComposerGitStateSync({
   setProjectGitState,
   setProjectGitLoading,
 }: UseComposerGitStateSyncInput) {
+  const inboxComposerMode = getInboxThreadComposerMode(selectedInboxThread)
+  const inboxProjectId = selectedInboxThread?.projectId ?? null
+  const inboxSessionPath = selectedInboxThread?.sessionPath ?? null
+
   useEffect(() => {
     if (!shellComposerState) {
       return
@@ -46,20 +79,16 @@ export function useComposerGitStateSync({
     void shellAppSettings?.codeModel
     void shellAppSettings?.codeThinkingLevel
 
-    const inboxProjectId = selectedInboxThread?.projectId ?? null
-    const inboxSessionPath = selectedInboxThread?.sessionPath ?? null
-    const composerStateProjectId =
-      workspaceState.activeView === 'inbox' ? inboxProjectId : composerProjectId
-    const composerStateSessionPath =
-      workspaceState.activeView === 'chat' ||
-      workspaceState.activeView === 'thread' ||
-      workspaceState.activeView === 'gitops'
-        ? workspaceState.selectedSessionPath
-        : workspaceState.activeView === 'inbox'
-          ? inboxSessionPath
-          : null
+    const target = getComposerStateSyncTarget({
+      activeView: workspaceState.activeView,
+      composerProjectId,
+      inboxComposerMode,
+      inboxProjectId,
+      inboxSessionPath,
+      selectedSessionPath: workspaceState.selectedSessionPath,
+    })
 
-    if (!composerStateProjectId) {
+    if (!target.projectId) {
       return
     }
 
@@ -67,9 +96,9 @@ export function useComposerGitStateSync({
 
     const syncComposerState = async () => {
       const nextComposerState = await loadComposerState({
-        projectId: composerStateProjectId,
-        sessionPath: composerStateSessionPath,
-        composerMode: workspaceState.activeView === 'chat' ? 'chat' : 'code',
+        projectId: target.projectId,
+        sessionPath: target.sessionPath,
+        composerMode: target.composerMode,
       })
 
       if (!cancelled && nextComposerState) {
@@ -85,8 +114,9 @@ export function useComposerGitStateSync({
   }, [
     loadComposerState,
     composerProjectId,
-    selectedInboxThread?.projectId,
-    selectedInboxThread?.sessionPath,
+    inboxComposerMode,
+    inboxProjectId,
+    inboxSessionPath,
     setComposerState,
     shellAppSettings?.chatModel,
     shellAppSettings?.chatThinkingLevel,

--- a/src/app/app-shell/useDesktopEventSync.ts
+++ b/src/app/app-shell/useDesktopEventSync.ts
@@ -4,6 +4,7 @@ import type {
   ChatSidebarState,
   ComposerState,
   DesktopEvent,
+  PiExtensionUiState,
   ProjectGitState,
   ThreadData,
 } from '../desktop/types'
@@ -34,6 +35,7 @@ type UseDesktopEventSyncInput = {
   setComposerState: Dispatch<SetStateAction<ComposerState | null>>
   setChatSidebarState: Dispatch<SetStateAction<ChatSidebarState | null>>
   setLiveThreadData: Dispatch<SetStateAction<ThreadData | null>>
+  setPiExtensionUiStateBySession: Dispatch<SetStateAction<Record<string, PiExtensionUiState>>>
   setProjectGitState: Dispatch<SetStateAction<ProjectGitState | null>>
   setThreadHistoryCompactions: Dispatch<SetStateAction<number>>
 }
@@ -50,6 +52,7 @@ export function useDesktopEventSync({
   setComposerState,
   setChatSidebarState,
   setLiveThreadData,
+  setPiExtensionUiStateBySession,
   setProjectGitState,
   setThreadHistoryCompactions,
 }: UseDesktopEventSyncInput) {
@@ -101,6 +104,7 @@ export function useDesktopEventSync({
       setChatSidebarState,
       setComposerState,
       setLiveThreadData,
+      setPiExtensionUiStateBySession,
       setProjectGitState,
       setThreadHistoryCompactions,
       desktopEventStateRef,
@@ -117,6 +121,7 @@ export function useDesktopEventSync({
     setChatSidebarState,
     setComposerState,
     setLiveThreadData,
+    setPiExtensionUiStateBySession,
     setProjectGitState,
     setThreadHistoryCompactions,
   ])

--- a/src/app/app-shell/useProjectShellSync.ts
+++ b/src/app/app-shell/useProjectShellSync.ts
@@ -2,7 +2,8 @@ import { isLocalSessionPath } from '@howcode/shared/session-paths'
 import type { Dispatch } from 'react'
 import { useEffect } from 'react'
 import type { ArchivedThread } from '../desktop/types'
-import type { WorkspaceAction, WorkspaceState } from '../state/workspace'
+import type { CodeThreadSelection, WorkspaceAction, WorkspaceState } from '../state/workspace'
+import { resolveCodeThreadSelection } from '../state/workspace-action-handlers'
 import type { Project } from '../types'
 
 type UseProjectShellSyncInput = {
@@ -12,6 +13,7 @@ type UseProjectShellSyncInput = {
   selectedProjectId: WorkspaceState['selectedProjectId']
   selectedThreadId: WorkspaceState['selectedThreadId']
   selectedSessionPath: WorkspaceState['selectedSessionPath']
+  lastCodeThreadSelection: CodeThreadSelection | null
   takeoverVisible: WorkspaceState['takeoverVisible']
   loadProjectThreads: (
     projectId: string,
@@ -29,6 +31,7 @@ export function useProjectShellSync({
   selectedProjectId,
   selectedThreadId,
   selectedSessionPath,
+  lastCodeThreadSelection,
   takeoverVisible,
   loadProjectThreads,
   loadArchivedThreads,
@@ -51,12 +54,33 @@ export function useProjectShellSync({
         project.threads.some((thread) => thread.sessionPath === selectedSessionPath),
       )
 
-    if (hasSelectedProject && hasSelectedThread && hasSelectedSession) {
+    const resolvedLastCodeThreadSelection = resolveCodeThreadSelection(
+      projects,
+      lastCodeThreadSelection,
+    )
+    const hasSyncedRememberedCodeThread =
+      resolvedLastCodeThreadSelection?.projectId === lastCodeThreadSelection?.projectId &&
+      resolvedLastCodeThreadSelection?.threadId === lastCodeThreadSelection?.threadId &&
+      resolvedLastCodeThreadSelection?.sessionPath === lastCodeThreadSelection?.sessionPath
+
+    if (
+      hasSelectedProject &&
+      hasSelectedThread &&
+      hasSelectedSession &&
+      hasSyncedRememberedCodeThread
+    ) {
       return
     }
 
     dispatch({ type: 'sync-projects', projects })
-  }, [dispatch, projects, selectedProjectId, selectedSessionPath, selectedThreadId])
+  }, [
+    dispatch,
+    lastCodeThreadSelection,
+    projects,
+    selectedProjectId,
+    selectedSessionPath,
+    selectedThreadId,
+  ])
 
   useEffect(() => {
     const threadsScope = activeView === 'chat' ? 'chat' : 'code'

--- a/src/app/app-shell/useScheduledThreadOpen.ts
+++ b/src/app/app-shell/useScheduledThreadOpen.ts
@@ -16,9 +16,20 @@ export type ScheduledThreadOpenInput = {
   threadId: string
   sessionPath: string
   view?: 'chat' | 'thread' | undefined
+  branchName?: string | null | undefined
   delayMs?: number | undefined
   deferThreadQuery?: boolean | undefined
   commitLocally?: boolean | undefined
+}
+
+export function getScheduledThreadOpenActionPayload(input: ScheduledThreadOpenInput) {
+  return {
+    projectId: input.projectId,
+    threadId: input.threadId,
+    sessionPath: input.sessionPath,
+    composerMode: input.view === 'chat' ? 'chat' : 'code',
+    branchName: input.branchName,
+  }
 }
 
 function shouldCommitScheduledThreadOpen(input: ScheduledThreadOpenInput, state: WorkspaceState) {
@@ -77,12 +88,7 @@ export function useScheduledThreadOpen(input: {
             view: scheduledThreadOpen.view,
           })
         }
-        void handleAction('thread.open', {
-          projectId: scheduledThreadOpen.projectId,
-          threadId: scheduledThreadOpen.threadId,
-          sessionPath: scheduledThreadOpen.sessionPath,
-          composerMode: scheduledThreadOpen.view === 'chat' ? 'chat' : 'code',
-        })
+        void handleAction('thread.open', getScheduledThreadOpenActionPayload(scheduledThreadOpen))
       }, scheduledThreadOpen.delayMs ?? THREAD_OPEN_ACTION_DELAY_MS)
     },
     [dispatch, handleAction, setThreadQueryDeferred],

--- a/src/app/chat-workspace/chat-workspace-composer.tsx
+++ b/src/app/chat-workspace/chat-workspace-composer.tsx
@@ -48,6 +48,7 @@ const FALLBACK_APP_SETTINGS = {
 
 export type ChatWorkspaceComposerProps = {
   activeComposerState: AppShellController['activeComposerState']
+  activePiExtensionUiState: AppShellController['activePiExtensionUiState']
   activeThreadData: AppShellController['activeThreadData']
   artifactDrawer: ChatArtifactDrawerState
   composerProjectId: string
@@ -158,6 +159,7 @@ function ChatQueuedPrompts({
 
 function getComposerRuntimeProps(
   activeComposerState: ChatWorkspaceComposerProps['activeComposerState'],
+  activePiExtensionUiState: ChatWorkspaceComposerProps['activePiExtensionUiState'],
 ) {
   return {
     availableModels: activeComposerState?.availableModels ?? [],
@@ -167,10 +169,17 @@ function getComposerRuntimeProps(
     currentThinkingLevel: activeComposerState?.currentThinkingLevel ?? 'off',
     isCompacting: activeComposerState?.isCompacting ?? false,
     isExtensionCommandRunning: activeComposerState?.isExtensionCommandRunning ?? false,
-    piExtensionDialogRequest: activeComposerState?.piExtensionDialogRequest ?? null,
+    piExtensionDialogRequest:
+      activePiExtensionUiState?.piExtensionDialogRequest ??
+      activeComposerState?.piExtensionDialogRequest ??
+      null,
     piExtensionShortcuts: activeComposerState?.piExtensionShortcuts ?? [],
-    piExtensionStatuses: activeComposerState?.piExtensionStatuses ?? [],
-    piExtensionWidgets: activeComposerState?.piExtensionWidgets ?? [],
+    piExtensionStatuses:
+      activePiExtensionUiState?.piExtensionStatuses ??
+      activeComposerState?.piExtensionStatuses ??
+      [],
+    piExtensionWidgets:
+      activePiExtensionUiState?.piExtensionWidgets ?? activeComposerState?.piExtensionWidgets ?? [],
     projectTrustRequest: activeComposerState?.projectTrustRequest ?? null,
   }
 }
@@ -178,6 +187,7 @@ function getComposerRuntimeProps(
 function ChatComposer(props: ChatWorkspaceComposerProps) {
   const {
     activeComposerState,
+    activePiExtensionUiState,
     state,
     activeThreadData,
     scopedRestoredQueuedPrompt,
@@ -204,7 +214,7 @@ function ChatComposer(props: ChatWorkspaceComposerProps) {
     controller,
   } = props
   const appSettings = shellState?.appSettings ?? FALLBACK_APP_SETTINGS
-  const composerRuntime = getComposerRuntimeProps(activeComposerState)
+  const composerRuntime = getComposerRuntimeProps(activeComposerState, activePiExtensionUiState)
   return (
     <Composer
       activeView={state.activeView}

--- a/src/app/chat-workspace/chat-workspace-view.tsx
+++ b/src/app/chat-workspace/chat-workspace-view.tsx
@@ -19,6 +19,7 @@ const ArtifactPanel = lazy(() =>
 type ChatWorkspaceViewProps = {
   controller: AppShellController
   activeComposerState: AppShellController['activeComposerState']
+  activePiExtensionUiState: AppShellController['activePiExtensionUiState']
   activeThreadData: AppShellController['activeThreadData']
   composerProjectId: string
   diffBaseline: ProjectDiffBaseline
@@ -175,6 +176,7 @@ function ChatWorkspaceViewContent(props: ChatWorkspaceContentProps) {
 export function ChatWorkspaceView({
   controller,
   activeComposerState,
+  activePiExtensionUiState,
   activeThreadData,
   composerProjectId,
   diffBaseline,
@@ -248,6 +250,7 @@ export function ChatWorkspaceView({
       onToggleSidebar={onToggleSidebar}
       sidebarCollapsed={sidebarCollapsed}
       activeComposerState={activeComposerState}
+      activePiExtensionUiState={activePiExtensionUiState}
       pendingQueuedPromptIdsForSession={pendingQueuedPromptIdsForSession}
       handleEditQueuedPrompt={handleEditQueuedPrompt}
       handleRemoveQueuedPrompt={handleRemoveQueuedPrompt}

--- a/src/app/code-workspace/code-workspace-footer.tsx
+++ b/src/app/code-workspace/code-workspace-footer.tsx
@@ -138,6 +138,7 @@ function CodeQueuedPrompts(props: CodeWorkspaceContentProps) {
 
 function getComposerRuntimeProps(
   activeComposerState: CodeWorkspaceContentProps['activeComposerState'],
+  activePiExtensionUiState: CodeWorkspaceContentProps['activePiExtensionUiState'],
 ) {
   return {
     availableModels: activeComposerState?.availableModels ?? [],
@@ -147,10 +148,17 @@ function getComposerRuntimeProps(
     currentThinkingLevel: activeComposerState?.currentThinkingLevel ?? 'off',
     isCompacting: activeComposerState?.isCompacting ?? false,
     isExtensionCommandRunning: activeComposerState?.isExtensionCommandRunning ?? false,
-    piExtensionDialogRequest: activeComposerState?.piExtensionDialogRequest ?? null,
+    piExtensionDialogRequest:
+      activePiExtensionUiState?.piExtensionDialogRequest ??
+      activeComposerState?.piExtensionDialogRequest ??
+      null,
     piExtensionShortcuts: activeComposerState?.piExtensionShortcuts ?? [],
-    piExtensionStatuses: activeComposerState?.piExtensionStatuses ?? [],
-    piExtensionWidgets: activeComposerState?.piExtensionWidgets ?? [],
+    piExtensionStatuses:
+      activePiExtensionUiState?.piExtensionStatuses ??
+      activeComposerState?.piExtensionStatuses ??
+      [],
+    piExtensionWidgets:
+      activePiExtensionUiState?.piExtensionWidgets ?? activeComposerState?.piExtensionWidgets ?? [],
     projectTrustRequest: activeComposerState?.projectTrustRequest ?? null,
   }
 }
@@ -159,6 +167,7 @@ function CodeThreadComposer(props: CodeWorkspaceContentProps) {
   const {
     state,
     activeComposerState,
+    activePiExtensionUiState,
     activeThreadData,
     scopedRestoredQueuedPrompt,
     shellState,
@@ -190,7 +199,7 @@ function CodeThreadComposer(props: CodeWorkspaceContentProps) {
     handleAction,
   } = props
   const appSettings = shellState?.appSettings ?? FALLBACK_APP_SETTINGS
-  const composerRuntime = getComposerRuntimeProps(activeComposerState)
+  const composerRuntime = getComposerRuntimeProps(activeComposerState, activePiExtensionUiState)
   return (
     <Composer
       activeView={state.activeView}

--- a/src/app/code-workspace/code-workspace-view.tsx
+++ b/src/app/code-workspace/code-workspace-view.tsx
@@ -12,6 +12,7 @@ import { useWorkspaceFooterHeight } from './useWorkspaceFooterHeight'
 type CodeWorkspaceViewProps = {
   controller: AppShellController
   activeComposerState: AppShellController['activeComposerState']
+  activePiExtensionUiState: AppShellController['activePiExtensionUiState']
   activeThreadData: AppShellController['activeThreadData']
   composerProjectId: string
   currentProjectName: string
@@ -138,6 +139,7 @@ function getCodeWorkspaceFlags(input: {
 export function CodeWorkspaceView({
   controller,
   activeComposerState,
+  activePiExtensionUiState,
   activeThreadData,
   composerProjectId,
   currentProjectName,
@@ -296,6 +298,7 @@ export function CodeWorkspaceView({
       controller={controller}
       shellState={shellState}
       activeComposerState={activeComposerState}
+      activePiExtensionUiState={activePiExtensionUiState}
       currentProjectName={currentProjectName}
       workspaceContentClass={workspaceContentClass}
       activeThreadData={activeThreadData}

--- a/src/app/common/inbox-thread-scope.ts
+++ b/src/app/common/inbox-thread-scope.ts
@@ -1,0 +1,13 @@
+import type { InboxThread } from '../desktop/types'
+
+export function getInboxThreadComposerMode(
+  thread: Pick<InboxThread, 'branchName' | 'isChat'> | null | undefined,
+): 'chat' | 'code' {
+  return thread?.isChat && !thread.branchName?.trim() ? 'chat' : 'code'
+}
+
+export function getInboxThreadOpenView(
+  thread: Pick<InboxThread, 'branchName' | 'isChat'>,
+): 'chat' | 'thread' {
+  return getInboxThreadComposerMode(thread) === 'chat' ? 'chat' : 'thread'
+}

--- a/src/app/desktop/types.ts
+++ b/src/app/desktop/types.ts
@@ -52,6 +52,7 @@ export type {
   PiExtensionDialogRequest,
   PiExtensionShortcut,
   PiExtensionStatus,
+  PiExtensionUiState,
   PiExtensionWidget,
   PiPackageCatalogItem,
   PiPackageCatalogPage,

--- a/src/app/inbox/components/inbox-composer.tsx
+++ b/src/app/inbox/components/inbox-composer.tsx
@@ -1,6 +1,7 @@
 import type { SettingsOpenTarget } from '@howcode/settings/settingsTypes'
 import { type Dispatch, type SetStateAction, useRef, useState } from 'react'
 import { useHowcodeKeybindingCommand } from '../../app-shell/keybinding-events'
+import { getInboxThreadComposerMode } from '../../common/inbox-thread-scope'
 import { ComposerPromptInputPanel } from '../../composer/composer-prompt-input-panel'
 import { useComposerAttachmentPicker } from '../../composer/useComposerAttachmentPicker'
 import { useComposerClipboardHandlers } from '../../composer/useComposerClipboardHandlers'
@@ -105,6 +106,7 @@ export function InboxComposer({
   const skillMentionPanelRef = useRef<HTMLDivElement>(null)
   const sendLockRef = useRef(false)
   const [localActionPending, setLocalActionPending] = useState(false)
+  const composerMode = getInboxThreadComposerMode(thread)
   const { attachmentsRef, draftValueRef, setAttachmentValue, setDraftValue } =
     useInboxComposerStateRefs({
       attachments,
@@ -196,6 +198,7 @@ export function InboxComposer({
     sessionPath: thread.sessionPath,
     setDraft: setDraftValue,
     send: () => void send(),
+    composerMode,
     onOpenSettingsView,
     onStartNewSession,
   })
@@ -207,6 +210,7 @@ export function InboxComposer({
     draft,
     projectId: thread.projectId,
     sessionPath: thread.sessionPath,
+    composerMode,
     setDraft: setDraftValue,
   })
   const skillMentionListSignature = skillMentions.skills
@@ -270,7 +274,8 @@ export function InboxComposer({
         text: '/compact',
         attachments: [],
         streamingBehavior: appSettings.composerStreamingBehavior,
-        composerMode: thread.isChat ? 'chat' : 'code',
+        composerMode,
+        branchName: thread.branchName,
       })
 
       const actionErrorMessage = getDesktopActionErrorMessage(result, 'Could not compact context.')
@@ -404,6 +409,7 @@ export function InboxComposer({
                 modelId: availableModel.id,
                 projectId: thread.projectId,
                 sessionPath: thread.sessionPath,
+                composerMode,
               })
             }}
             onSelectThinkingLevel={(level) => {
@@ -411,6 +417,7 @@ export function InboxComposer({
                 level,
                 projectId: thread.projectId,
                 sessionPath: thread.sessionPath,
+                composerMode,
               })
             }}
             onToggleModelMenu={() =>

--- a/src/app/inbox/inbox-view.tsx
+++ b/src/app/inbox/inbox-view.tsx
@@ -3,6 +3,7 @@ import { isCompactSlashCommand } from '@howcode/shared/composer-slash-commands'
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useState } from 'react'
 import { EmptyStateCard } from '../common/empty-state-card'
+import { getInboxThreadComposerMode, getInboxThreadOpenView } from '../common/inbox-thread-scope'
 import { MarkdownContent } from '../common/markdown-content'
 import { getDesktopActionErrorMessage } from '../desktop/action-results'
 import { getErrorMessage } from '../desktop/error-messages'
@@ -50,7 +51,12 @@ type InboxViewProps = {
     path?: string | null
     rootPath?: string | null
   }) => Promise<ComposerFilePickerState | null>
-  onOpenThread: (projectId: string, threadId: string, sessionPath: string) => void
+  onOpenThread: (
+    projectId: string,
+    threadId: string,
+    sessionPath: string,
+    view?: 'chat' | 'thread' | undefined,
+  ) => void
   onOpenSettingsView: (target?: SettingsOpenTarget) => void
   sidebarCollapsed: boolean
   sidebarCompactMode: boolean
@@ -74,7 +80,8 @@ function getInboxSendPayload(input: {
       attachments: isCompactCommand ? [] : input.attachments,
       suppressInbox: true,
       streamingBehavior: input.appSettings.composerStreamingBehavior,
-      composerMode: input.thread.isChat ? 'chat' : 'code',
+      composerMode: getInboxThreadComposerMode(input.thread),
+      branchName: input.thread.branchName,
     } as const,
   }
 }
@@ -186,6 +193,12 @@ function InboxThreadHeader({ thread }: { thread: InboxThread }) {
           className={`flex min-w-0 items-center gap-2 ${appTypeMetaClass} ${appToneSubtleClass}`}
         >
           <span className="truncate">{thread.projectName}</span>
+          {thread.branchName ? (
+            <>
+              <span aria-hidden="true">•</span>
+              <span className="truncate">{thread.branchName}</span>
+            </>
+          ) : null}
           <span aria-hidden="true">•</span>
           <span className="shrink-0 tabular-nums">{thread.age}</span>
           {thread.running ? (
@@ -379,13 +392,19 @@ export function InboxView({
               onDismiss={() => onDismissThread(thread)}
               onListAttachmentEntries={onListAttachmentEntries}
               onOpenThread={() =>
-                onOpenThread(thread.projectId, thread.threadId, thread.sessionPath)
+                onOpenThread(
+                  thread.projectId,
+                  thread.threadId,
+                  thread.sessionPath,
+                  getInboxThreadOpenView(thread),
+                )
               }
               onOpenSettingsView={onOpenSettingsView}
               onStartNewSession={() =>
                 void onAction('thread.new', {
                   projectId: thread.projectId,
-                  composerMode: thread.isChat ? 'chat' : 'code',
+                  composerMode: getInboxThreadComposerMode(thread),
+                  branchName: thread.branchName,
                 })
               }
               onSend={(sendInput) => handleSend(sendInput)}

--- a/src/app/inbox/inbox-view.tsx
+++ b/src/app/inbox/inbox-view.tsx
@@ -56,6 +56,7 @@ type InboxViewProps = {
     threadId: string,
     sessionPath: string,
     view?: 'chat' | 'thread' | undefined,
+    branchName?: string | null | undefined,
   ) => void
   onOpenSettingsView: (target?: SettingsOpenTarget) => void
   sidebarCollapsed: boolean
@@ -397,6 +398,7 @@ export function InboxView({
                   thread.threadId,
                   thread.sessionPath,
                   getInboxThreadOpenView(thread),
+                  thread.branchName,
                 )
               }
               onOpenSettingsView={onOpenSettingsView}

--- a/src/app/state/workspace-action-handlers.ts
+++ b/src/app/state/workspace-action-handlers.ts
@@ -94,6 +94,47 @@ function getScopedCodeThreadSelection(
     : null
 }
 
+function isProjectLoadedForCodeThreads(project: Project) {
+  return project.threadsLoaded === true && project.threadsScope !== 'chat'
+}
+
+function getThreadCodeSelection(
+  project: Project,
+  thread: Project['threads'][number],
+  fallbackSessionPath: string,
+): CodeThreadSelection {
+  return {
+    projectId: project.id,
+    threadId: thread.id,
+    sessionPath: thread.sessionPath ?? fallbackSessionPath,
+  }
+}
+
+export function resolveCodeThreadSelection(
+  projects: Project[],
+  selection: CodeThreadSelection | null,
+): CodeThreadSelection | null {
+  if (!selection) return null
+
+  for (const project of projects) {
+    if (!isProjectLoadedForCodeThreads(project)) continue
+    const thread = project.threads.find(
+      (candidate) => candidate.sessionPath === selection.sessionPath,
+    )
+    if (thread) return getThreadCodeSelection(project, thread, selection.sessionPath)
+  }
+
+  for (const project of projects) {
+    if (!isProjectLoadedForCodeThreads(project)) continue
+    const thread = project.threads.find((candidate) => candidate.id === selection.threadId)
+    if (thread) return getThreadCodeSelection(project, thread, selection.sessionPath)
+  }
+
+  const rememberedProject = projects.find((project) => project.id === selection.projectId)
+  if (!rememberedProject) return null
+  return isProjectLoadedForCodeThreads(rememberedProject) ? null : selection
+}
+
 function withCodeThreadSelection(
   state: WorkspaceState,
   selection: CodeThreadSelection,
@@ -165,6 +206,10 @@ function syncProjectsState(
   state: WorkspaceState,
   action: Extract<WorkspaceAction, { type: 'sync-projects' }>,
 ): WorkspaceState {
+  const lastCodeThreadSelection = resolveCodeThreadSelection(
+    action.projects,
+    state.lastCodeThreadSelection,
+  )
   const hasSelectedProject = action.projects.some(
     (project) => project.id === state.selectedProjectId,
   )
@@ -224,6 +269,7 @@ function syncProjectsState(
       shouldPreserveProjectSelection,
       state.utilityViewReturnState,
     ),
+    lastCodeThreadSelection,
     collapsedProjectIds,
   }
 }

--- a/src/app/state/workspace-action-handlers.ts
+++ b/src/app/state/workspace-action-handlers.ts
@@ -1,5 +1,6 @@
 import type { Project, View } from '../types'
 import type {
+  CodeThreadSelection,
   UtilityView,
   UtilityViewReturnState,
   WorkspaceAction,
@@ -60,9 +61,52 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     utilityViewReturnState: null,
     settingsOpen: false,
     settingsPanelOpen: false,
+    lastCodeThreadSelection: null,
     collapsedProjectIds: Object.fromEntries(
       projects.map((project) => [project.id, project.collapsed ?? true]),
     ),
+  }
+}
+
+function getCurrentCodeThreadSelection(state: WorkspaceState): CodeThreadSelection | null {
+  if (
+    state.activeView !== 'chat' &&
+    state.selectedProjectId &&
+    state.selectedThreadId &&
+    state.selectedSessionPath
+  ) {
+    return {
+      projectId: state.selectedProjectId,
+      threadId: state.selectedThreadId,
+      sessionPath: state.selectedSessionPath,
+    }
+  }
+
+  return state.lastCodeThreadSelection
+}
+
+function withCodeThreadSelection(
+  state: WorkspaceState,
+  selection: CodeThreadSelection,
+): WorkspaceState {
+  return {
+    ...state,
+    activeView: 'thread',
+    selectedProjectId: selection.projectId,
+    hasSelectedProject: true,
+    landingVisible: false,
+    selectedThreadId: selection.threadId,
+    selectedSessionPath: selection.sessionPath,
+    terminalVisible: getTerminalVisibilityForSession(
+      state.terminalVisibleBySession,
+      selection.sessionPath,
+    ),
+    selectedDiffFilePath: null,
+    takeoverVisible: false,
+    gitOpsReturnView: 'thread',
+    utilityViewReturnState: null,
+    collapsedProjectIds: { ...state.collapsedProjectIds, [selection.projectId]: false },
+    lastCodeThreadSelection: selection,
   }
 }
 
@@ -179,6 +223,11 @@ function showViewState(
   state: WorkspaceState,
   action: Extract<WorkspaceAction, { type: 'show-view' }>,
 ): WorkspaceState {
+  const lastCodeThreadSelection = getCurrentCodeThreadSelection(state)
+  if (action.view === 'code' && lastCodeThreadSelection) {
+    return withCodeThreadSelection(state, lastCodeThreadSelection)
+  }
+
   const utilityViewReturnState = isUtilityView(action.view)
     ? isUtilityView(state.activeView)
       ? state.utilityViewReturnState
@@ -191,6 +240,7 @@ function showViewState(
     landingVisible: action.view === 'code' ? state.landingVisible : false,
     settingsOpen: false,
     settingsPanelOpen: false,
+    lastCodeThreadSelection,
     selectedThreadId:
       action.view === 'thread' || (action.view === 'chat' && state.activeView === 'chat')
         ? state.selectedThreadId
@@ -209,6 +259,7 @@ function openThreadState(
   state: WorkspaceState,
   action: Extract<WorkspaceAction, { type: 'open-thread' }>,
 ): WorkspaceState {
+  const activeView = action.view ?? (state.activeView === 'chat' ? 'chat' : 'thread')
   const nextTerminalVisibleBySession = shouldMigrateTerminalVisibilityForOpenedThread(state, action)
     ? {
         ...state.terminalVisibleBySession,
@@ -223,7 +274,7 @@ function openThreadState(
     : state.terminalVisibleBySession
   return {
     ...state,
-    activeView: action.view ?? (state.activeView === 'chat' ? 'chat' : 'thread'),
+    activeView,
     selectedProjectId: action.projectId,
     hasSelectedProject: true,
     landingVisible: false,
@@ -243,6 +294,14 @@ function openThreadState(
     gitOpsReturnView: 'thread',
     utilityViewReturnState: null,
     collapsedProjectIds: { ...state.collapsedProjectIds, [action.projectId]: false },
+    lastCodeThreadSelection:
+      activeView === 'chat'
+        ? state.lastCodeThreadSelection
+        : {
+            projectId: action.projectId,
+            threadId: action.threadId,
+            sessionPath: action.sessionPath,
+          },
   }
 }
 
@@ -278,6 +337,11 @@ function startProjectThreadState(
     gitOpsReturnView: 'project',
     utilityViewReturnState: null,
     collapsedProjectIds: { ...state.collapsedProjectIds, [action.projectId]: false },
+    lastCodeThreadSelection: {
+      projectId: action.projectId,
+      threadId: action.threadId,
+      sessionPath: action.sessionPath,
+    },
   }
 }
 
@@ -388,6 +452,7 @@ export const workspaceActionHandlers = {
     selectedSessionPath: null,
     selectedDiffFilePath: null,
     takeoverVisible: false,
+    lastCodeThreadSelection: null,
   }),
   'select-inbox-thread': (
     state: WorkspaceState,

--- a/src/app/state/workspace-action-handlers.ts
+++ b/src/app/state/workspace-action-handlers.ts
@@ -437,6 +437,7 @@ export const workspaceActionHandlers = {
     selectedThreadId: null,
     selectedSessionPath: null,
     selectedDiffFilePath: null,
+    lastCodeThreadSelection: null,
     takeoverVisible: false,
     settingsOpen: false,
     settingsPanelOpen: false,

--- a/src/app/state/workspace-action-handlers.ts
+++ b/src/app/state/workspace-action-handlers.ts
@@ -70,7 +70,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
 
 function getCurrentCodeThreadSelection(state: WorkspaceState): CodeThreadSelection | null {
   if (
-    state.activeView !== 'chat' &&
+    (state.activeView === 'thread' || state.activeView === 'project') &&
     state.selectedProjectId &&
     state.selectedThreadId &&
     state.selectedSessionPath
@@ -83,6 +83,15 @@ function getCurrentCodeThreadSelection(state: WorkspaceState): CodeThreadSelecti
   }
 
   return state.lastCodeThreadSelection
+}
+
+function getScopedCodeThreadSelection(
+  state: WorkspaceState,
+  projectId: string,
+): CodeThreadSelection | null {
+  return state.lastCodeThreadSelection?.projectId === projectId
+    ? state.lastCodeThreadSelection
+    : null
 }
 
 function withCodeThreadSelection(
@@ -475,6 +484,7 @@ export const workspaceActionHandlers = {
     takeoverVisible: false,
     gitOpsReturnView: 'project',
     utilityViewReturnState: null,
+    lastCodeThreadSelection: getScopedCodeThreadSelection(state, action.projectId),
   }),
   'set-selected-project': (
     state: WorkspaceState,
@@ -484,6 +494,7 @@ export const workspaceActionHandlers = {
     selectedProjectId: action.projectId,
     hasSelectedProject: true,
     landingVisible: false,
+    lastCodeThreadSelection: getScopedCodeThreadSelection(state, action.projectId),
   }),
   'start-project-thread': startProjectThreadState,
   'preview-thread': previewThreadState,

--- a/src/app/state/workspace.ts
+++ b/src/app/state/workspace.ts
@@ -4,6 +4,12 @@ import { workspaceActionHandlers } from './workspace-action-handlers'
 export type NonGitOpsView = Exclude<View, 'gitops'>
 export type UtilityView = Extract<View, 'settings' | 'extensions' | 'skills' | 'sessions'>
 
+export type CodeThreadSelection = {
+  projectId: string
+  threadId: string
+  sessionPath: string
+}
+
 export type UtilityViewReturnState = {
   activeView: View
   selectedProjectId: string
@@ -40,6 +46,7 @@ export type WorkspaceState = {
   settingsOpen: boolean
   settingsPanelOpen: boolean
   collapsedProjectIds: Record<string, boolean>
+  lastCodeThreadSelection: CodeThreadSelection | null
 }
 
 export type WorkspaceAction =
@@ -112,6 +119,7 @@ export function createInitialWorkspaceState(projects: Project[]): WorkspaceState
     collapsedProjectIds: Object.fromEntries(
       projects.map((project) => [project.id, project.collapsed ?? true]),
     ),
+    lastCodeThreadSelection: null,
   }
 }
 

--- a/src/test/app-shell-hardening.test.ts
+++ b/src/test/app-shell-hardening.test.ts
@@ -62,6 +62,7 @@ function createWorkspaceState(overrides: Partial<WorkspaceState> = {}): Workspac
     settingsOpen: false,
     settingsPanelOpen: false,
     collapsedProjectIds: {},
+    lastCodeThreadSelection: null,
     ...overrides,
   }
 }

--- a/src/test/app-shell-hardening.test.ts
+++ b/src/test/app-shell-hardening.test.ts
@@ -11,6 +11,7 @@ import {
 import { applyDiffPreferencesToThread } from '../app/app-shell/controller-post-action-effects'
 import { deriveControllerViewModel } from '../app/app-shell/controller-view-model'
 import { getDiffPreferencesPatch } from '../app/app-shell/post-effects/diff-preferences'
+import { getScheduledThreadOpenActionPayload } from '../app/app-shell/useScheduledThreadOpen'
 import type { ThreadData } from '../app/desktop/types'
 import type { WorkspaceState } from '../app/state/workspace'
 
@@ -137,6 +138,24 @@ describe('app shell hardening helpers', () => {
       projectId: '/repo/a',
       shouldSwitch: true,
       targetBranch: 'feature-a',
+    })
+  })
+
+  it('keeps branch metadata when opening an inbox thread', () => {
+    expect(
+      getScheduledThreadOpenActionPayload({
+        projectId: '/repo/a',
+        threadId: 'thread-a',
+        sessionPath: '/sessions/a.jsonl',
+        view: 'thread',
+        branchName: 'feature-a',
+      }),
+    ).toMatchObject({
+      branchName: 'feature-a',
+      composerMode: 'code',
+      projectId: '/repo/a',
+      sessionPath: '/sessions/a.jsonl',
+      threadId: 'thread-a',
     })
   })
 

--- a/src/test/app-shell-url-sync.test.ts
+++ b/src/test/app-shell-url-sync.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type AppRouteSnapshot,
+  shouldDeferStateRouteNavigation,
+} from '../app/app-shell/useAppShellUrlSync'
+import type { Project } from '../app/types'
+
+function createProject(threadIds: string[] = []): Project {
+  return {
+    id: '/repo/project-a',
+    name: 'project-a',
+    threads: threadIds.map((id) => ({
+      id,
+      title: id,
+      age: 'now',
+      sessionPath: `/sessions/${id}.jsonl`,
+    })),
+  }
+}
+
+function route(threadId: string): AppRouteSnapshot {
+  return {
+    pathname: '/thread',
+    search: { projectId: '/repo/project-a', threadId },
+  }
+}
+
+describe('app shell URL sync', () => {
+  it('does not let a stale missing thread route block state-driven URL replacement', () => {
+    expect(
+      shouldDeferStateRouteNavigation({
+        projects: [createProject(['persisted-thread'])],
+        routeChanged: false,
+        routeSnapshot: route('local-thread-stale'),
+        stateChanged: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('still waits when the browser navigates to a missing thread route', () => {
+    expect(
+      shouldDeferStateRouteNavigation({
+        projects: [createProject(['persisted-thread'])],
+        routeChanged: true,
+        routeSnapshot: route('missing-thread'),
+        stateChanged: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not navigate when state did not change', () => {
+    expect(
+      shouldDeferStateRouteNavigation({
+        projects: [createProject(['persisted-thread'])],
+        routeChanged: false,
+        routeSnapshot: route('persisted-thread'),
+        stateChanged: false,
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/test/desktop-event-handlers.test.ts
+++ b/src/test/desktop-event-handlers.test.ts
@@ -75,6 +75,7 @@ function createRuntime(input: {
       setChatSidebarState: vi.fn(),
       setComposerState: vi.fn(),
       setLiveThreadData: vi.fn(),
+      setPiExtensionUiStateBySession: vi.fn(),
       setProjectGitState: vi.fn(),
       setThreadHistoryCompactions: vi.fn(),
       localDraftSessionPathByPersistedSessionPathRef: { current: new Map<string, string>() },

--- a/src/test/new-thread-post-effect.test.ts
+++ b/src/test/new-thread-post-effect.test.ts
@@ -24,6 +24,7 @@ function createWorkspaceState(overrides: Partial<WorkspaceState> = {}): Workspac
     settingsOpen: false,
     settingsPanelOpen: false,
     collapsedProjectIds: {},
+    lastCodeThreadSelection: null,
     ...overrides,
   }
 }

--- a/src/test/new-thread-post-effect.test.ts
+++ b/src/test/new-thread-post-effect.test.ts
@@ -64,6 +64,14 @@ function createProjectAddResult(): DesktopActionResult {
   }
 }
 
+function createThreadNewResultWithoutComposer(): DesktopActionResult {
+  const result = createThreadNewResult()
+  if (!result.result) return result
+  const resultData = { ...result.result }
+  delete resultData.composer
+  return { ...result, result: resultData }
+}
+
 describe('new thread post effect', () => {
   it('opens code new-thread actions into a clean thread composer instead of the dashboard', async () => {
     const dispatch = vi.fn()
@@ -91,6 +99,7 @@ describe('new thread post effect', () => {
       projectId: '/repo/project-a',
       threadId: 'draft-1',
       sessionPath: 'local://%2Frepo%2Fproject-a/draft-1',
+      view: 'thread',
     })
     expect(dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({
@@ -126,9 +135,42 @@ describe('new thread post effect', () => {
       expect.objectContaining({
         type: 'open-thread',
         sessionPath: 'local://%2Frepo%2Fproject-a/draft-1',
+        view: 'chat',
       }),
     )
     expect(setQueryData).toHaveBeenCalled()
+  })
+
+  it('honors explicit chat mode when starting a new inbox session', async () => {
+    const dispatch = vi.fn()
+    const loadProjectThreads = vi.fn()
+    const loadComposerState = vi.fn(async () => createThreadNewResult().result?.composer ?? null)
+
+    await applyNewThreadPostEffect({
+      action: 'thread.new',
+      contextualPayload: { projectId: '/repo/project-a', composerMode: 'chat' },
+      actionResult: createThreadNewResultWithoutComposer(),
+      workspaceState: createWorkspaceState({ activeView: 'inbox' }),
+      composerProjectId: '/repo/project-a',
+      queryClient: { setQueryData: vi.fn() } as never,
+      dispatch,
+      refreshShellState: vi.fn(),
+      loadProjectThreads,
+      loadComposerState,
+      setComposerState: vi.fn(),
+    })
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'open-thread',
+        view: 'chat',
+      }),
+    )
+    expect(loadProjectThreads).toHaveBeenCalledWith('/repo/project-a', { chat: true })
+    expect(loadComposerState).toHaveBeenCalledWith({
+      projectId: '/repo/project-a',
+      composerMode: 'chat',
+    })
   })
 
   it('loads code composer defaults after adding a project from chat', async () => {

--- a/src/test/workspace-start-project-thread.test.ts
+++ b/src/test/workspace-start-project-thread.test.ts
@@ -112,4 +112,37 @@ describe('start-project-thread state', () => {
     expect(chatThreadState.selectedThreadId).toBe('chat-thread-1')
     expect(chatThreadState.lastCodeThreadSelection).toEqual(codeSelection)
   })
+
+  it('does not remember a chat thread as code while visiting git ops', () => {
+    const next = workspaceReducer(
+      createWorkspaceState({
+        activeView: 'gitops',
+        selectedThreadId: 'chat-thread-1',
+        selectedSessionPath: '/chat-sessions/chat-thread.jsonl',
+      }),
+      { type: 'show-view', view: 'code' },
+    )
+
+    expect(next.activeView).toBe('code')
+    expect(next.selectedThreadId).toBeNull()
+    expect(next.selectedSessionPath).toBeNull()
+    expect(next.lastCodeThreadSelection).toBeNull()
+  })
+
+  it('clears remembered code threads when selecting another project', () => {
+    const next = workspaceReducer(
+      createWorkspaceState({
+        activeView: 'chat',
+        lastCodeThreadSelection: {
+          projectId: '/repo/project-a',
+          threadId: 'code-thread-1',
+          sessionPath: '/sessions/project-a/code-thread.jsonl',
+        },
+      }),
+      { type: 'select-project', projectId: '/repo/project-b' },
+    )
+
+    expect(next.selectedProjectId).toBe('/repo/project-b')
+    expect(next.lastCodeThreadSelection).toBeNull()
+  })
 })

--- a/src/test/workspace-start-project-thread.test.ts
+++ b/src/test/workspace-start-project-thread.test.ts
@@ -145,4 +145,22 @@ describe('start-project-thread state', () => {
     expect(next.selectedProjectId).toBe('/repo/project-b')
     expect(next.lastCodeThreadSelection).toBeNull()
   })
+
+  it('clears remembered code threads when returning to landing', () => {
+    const next = workspaceReducer(
+      createWorkspaceState({
+        activeView: 'chat',
+        lastCodeThreadSelection: {
+          projectId: '/repo/project-a',
+          threadId: 'code-thread-1',
+          sessionPath: '/sessions/project-a/code-thread.jsonl',
+        },
+      }),
+      { type: 'show-landing' },
+    )
+
+    expect(next.activeView).toBe('landing')
+    expect(next.selectedProjectId).toBe('')
+    expect(next.lastCodeThreadSelection).toBeNull()
+  })
 })

--- a/src/test/workspace-start-project-thread.test.ts
+++ b/src/test/workspace-start-project-thread.test.ts
@@ -163,4 +163,69 @@ describe('start-project-thread state', () => {
     expect(next.selectedProjectId).toBe('')
     expect(next.lastCodeThreadSelection).toBeNull()
   })
+
+  it('clears remembered code threads when loaded project data no longer contains them', () => {
+    const next = workspaceReducer(
+      createWorkspaceState({
+        activeView: 'chat',
+        lastCodeThreadSelection: {
+          projectId: '/repo/project-a',
+          threadId: 'deleted-thread',
+          sessionPath: '/sessions/project-a/deleted.jsonl',
+        },
+      }),
+      {
+        type: 'sync-projects',
+        projects: [
+          {
+            id: '/repo/project-a',
+            name: 'Project A',
+            threads: [],
+            threadsLoaded: true,
+            threadsScope: 'code',
+          },
+        ],
+      },
+    )
+
+    expect(next.lastCodeThreadSelection).toBeNull()
+  })
+
+  it('updates remembered code threads when loaded project data moved them', () => {
+    const next = workspaceReducer(
+      createWorkspaceState({
+        activeView: 'chat',
+        lastCodeThreadSelection: {
+          projectId: '/repo/project-a',
+          threadId: 'thread-a',
+          sessionPath: '/sessions/shared.jsonl',
+        },
+      }),
+      {
+        type: 'sync-projects',
+        projects: [
+          {
+            id: '/repo/project-b',
+            name: 'Project B',
+            threads: [
+              {
+                id: 'thread-b',
+                title: 'Moved',
+                age: 'now',
+                sessionPath: '/sessions/shared.jsonl',
+              },
+            ],
+            threadsLoaded: true,
+            threadsScope: 'code',
+          },
+        ],
+      },
+    )
+
+    expect(next.lastCodeThreadSelection).toEqual({
+      projectId: '/repo/project-b',
+      threadId: 'thread-b',
+      sessionPath: '/sessions/shared.jsonl',
+    })
+  })
 })

--- a/src/test/workspace-start-project-thread.test.ts
+++ b/src/test/workspace-start-project-thread.test.ts
@@ -23,6 +23,7 @@ function createWorkspaceState(overrides: Partial<WorkspaceState> = {}): Workspac
     settingsOpen: false,
     settingsPanelOpen: false,
     collapsedProjectIds: {},
+    lastCodeThreadSelection: null,
     ...overrides,
   }
 }
@@ -55,5 +56,60 @@ describe('start-project-thread state', () => {
     expect(next.terminalVisibleBySession[persistedSessionPath]).toBe(true)
     expect(next.takeoverVisible).toBe(true)
     expect(next.takeoverOverrides[persistedSessionPath]).toBe(true)
+    expect(next.lastCodeThreadSelection).toEqual({
+      projectId: draft.projectId,
+      threadId: 'persisted-thread-1',
+      sessionPath: persistedSessionPath,
+    })
+  })
+
+  it('remembers a code thread while visiting chat and restores it from the Code tab', () => {
+    const codeSessionPath = '/sessions/project-a/code-thread.jsonl'
+    const chatState = workspaceReducer(
+      createWorkspaceState({
+        activeView: 'thread',
+        selectedThreadId: 'code-thread-1',
+        selectedSessionPath: codeSessionPath,
+      }),
+      { type: 'show-view', view: 'chat' },
+    )
+
+    expect(chatState.activeView).toBe('chat')
+    expect(chatState.selectedThreadId).toBeNull()
+    expect(chatState.selectedSessionPath).toBeNull()
+    expect(chatState.lastCodeThreadSelection).toEqual({
+      projectId: '/repo/project-a',
+      threadId: 'code-thread-1',
+      sessionPath: codeSessionPath,
+    })
+
+    const restored = workspaceReducer(chatState, { type: 'show-view', view: 'code' })
+
+    expect(restored.activeView).toBe('thread')
+    expect(restored.selectedProjectId).toBe('/repo/project-a')
+    expect(restored.selectedThreadId).toBe('code-thread-1')
+    expect(restored.selectedSessionPath).toBe(codeSessionPath)
+  })
+
+  it('does not replace the remembered code thread when opening a chat thread', () => {
+    const codeSelection = {
+      projectId: '/repo/project-a',
+      threadId: 'code-thread-1',
+      sessionPath: '/sessions/project-a/code-thread.jsonl',
+    }
+    const chatThreadState = workspaceReducer(
+      createWorkspaceState({ activeView: 'chat', lastCodeThreadSelection: codeSelection }),
+      {
+        type: 'open-thread',
+        projectId: '/repo/project-a',
+        threadId: 'chat-thread-1',
+        sessionPath: '/chat-sessions/chat-thread.jsonl',
+        view: 'chat',
+      },
+    )
+
+    expect(chatThreadState.activeView).toBe('chat')
+    expect(chatThreadState.selectedThreadId).toBe('chat-thread-1')
+    expect(chatThreadState.lastCodeThreadSelection).toEqual(codeSelection)
   })
 })


### PR DESCRIPTION
## Summary

- Isolate Pi extension status/widget/dialog refreshes from full thread updates.
- Preserve Code/worktree session context across Chat, Inbox, and sidebar detours.
- Make Inbox open/send branch-linked threads in Code context instead of treating them as detached chat sessions.
- Keep stale local-draft URLs moving to persisted thread URLs after save.

## Notes

- Added a separate `pi-extension-ui-update` lane with 16ms batching for extension UI state.
- Inbox thread routing now carries branch metadata through open/send/new-session flows.
- Remembered Code thread selections are scoped and invalidated when project/thread data changes.
- Updated `docs/changelog.md` and added local docs guidance for short changelog bullets.

## Validation

- `bunx vitest run src/test/app-shell-hardening.test.ts src/test/workspace-start-project-thread.test.ts desktop/thread-state-db-queries.test.ts`
- commit hook full `bun run ai:check`: 56 files / 227 tests

Closes #294
Closes #295
