### PR TITLE
Align isolated loader with Pi SDK

### DIFF
--- a/desktop/runtime/isolated-settings-manager.ts
+++ b/desktop/runtime/isolated-settings-manager.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import type { ResourceLoader, SettingsManager } from '@earendil-works/pi-coding-agent'
+import type { SettingsManager } from '@earendil-works/pi-coding-agent'
 import type { PiDefaultProjectTrust } from '../../shared/desktop-settings-contracts.ts'
 
 type SettingsManagerFactory = {
@@ -10,6 +10,9 @@ type SettingsManagerFactory = {
   ) => SettingsManager
   inMemory: (settings?: Record<string, unknown>) => SettingsManager
 }
+
+type DefaultResourceLoaderFactory =
+  typeof import('@earendil-works/pi-coding-agent').DefaultResourceLoader
 
 export function getRuntimeDefaultProjectTrust(options: {
   SettingsManager: SettingsManagerFactory
@@ -106,14 +109,7 @@ export function createRuntimeSettingsManager(options: {
 }
 
 export async function createIsolatedRuntimeResourceLoader(options: {
-  DefaultResourceLoader: new (loaderOptions: {
-    cwd: string
-    agentDir: string
-    settingsManager: SettingsManager
-    noSkills?: boolean
-    additionalSkillPaths?: string[]
-    systemPrompt?: string
-  }) => ResourceLoader
+  DefaultResourceLoader: DefaultResourceLoaderFactory
   cwd: string
   agentDir: string
   settingsCwd?: string | null | undefined


### PR DESCRIPTION
## Summary

- Align Howcode's isolated runtime loader factory with Pi's `DefaultResourceLoader` constructor type instead of maintaining a local subset.
- Keeps `SYSTEM.md`, `APPEND_SYSTEM.md`, and `AGENTS.md` behavior owned by the Pi SDK.
- Verified trusted project `.pi/APPEND_SYSTEM.md` is already loaded by the existing factory path on current `dev`.

## Validation

- Commit hook ran `bun run ai:check`.
- Smoke-checked `createIsolatedRuntimeResourceLoader` with real Pi `DefaultResourceLoader` and a trusted project `.pi/APPEND_SYSTEM.md` marker.

## Changelog

Skipped. This is SDK alignment/type cleanup with no runtime behavior change.

Closes #302
