### PR TITLE
Fix Windows Electron archive extraction

### DIFF
--- a/scripts/install-electron.cjs
+++ b/scripts/install-electron.cjs
@@ -79,17 +79,24 @@ async function extractZip(zipPath, distPath) {
   // the first entry under Node 26. The Electron archives are ordinary zip files,
   // so use OS-provided archive tools and verify the executable afterward.
   if (process.platform === 'win32') {
+    const archivePathEnv = 'HOWCODE_ELECTRON_ARCHIVE_PATH'
+    const destinationPathEnv = 'HOWCODE_ELECTRON_DESTINATION_PATH'
     childProcess.execFileSync(
       'powershell.exe',
       [
         '-NoProfile',
         '-NonInteractive',
         '-Command',
-        'Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force',
-        zipPath,
-        distPath,
+        `$ErrorActionPreference = 'Stop'; Expand-Archive -LiteralPath $env:${archivePathEnv} -DestinationPath $env:${destinationPathEnv} -Force`,
       ],
-      { stdio: 'inherit' },
+      {
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          [archivePathEnv]: zipPath,
+          [destinationPathEnv]: distPath,
+        },
+      },
     )
     return
   }


### PR DESCRIPTION
## Summary

- Fixes both Windows release jobs failing during Electron installation.
- Passes the archive and destination paths through child-process environment variables instead of appending them after PowerShell's `-Command`, where `$args` was empty.
- Makes PowerShell archive errors terminating so extraction failures remain visible.

## Validation

- `bun run ai:check`
- 45 test files / 111 tests passed
- React Doctor: 100/100
- Manual release dispatch [32294794463](https://github.com/IgorWarzocha/howcode/actions/runs/32294794463): Windows x64 and Windows ARM64 builds passed.

The changelog is unchanged because this repairs pre-release CI rather than shipped product behaviour.