### PR TITLE
Install Bun in release publisher jobs

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -240,6 +240,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+          no-cache: true
+
       - name: Download built artifacts
         uses: actions/download-artifact@v8
         with:
@@ -346,6 +351,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+          no-cache: true
 
       - name: Download built artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- install the pinned Bun version before validating channel release assets
- apply the same fix to versioned release publication

## Evidence
- dev release run 32297852394 built all six platform artifacts successfully
- publication then failed at `bun run validate:release-assets` with `bun: command not found`
- both affected publisher jobs now use the same pinned Bun setup as build jobs

## Validation
- `git diff --check`
- workflow-only change; the next dev push is the end-to-end validation