### PR TITLE
Make Linux release dependency installation deterministic

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -56,8 +56,41 @@ jobs:
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          architecture=$(dpkg --print-architecture)
+          codename=$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")
+          sources_file=$(mktemp)
+
+          case "$architecture" in
+            amd64)
+              cat >"$sources_file" <<EOF
+          deb [arch=amd64] https://archive.ubuntu.com/ubuntu $codename main universe
+          deb [arch=amd64] https://archive.ubuntu.com/ubuntu $codename-updates main universe
+          deb [arch=amd64] https://security.ubuntu.com/ubuntu $codename-security main universe
+          EOF
+              ;;
+            arm64)
+              cat >"$sources_file" <<EOF
+          deb [arch=arm64] https://ports.ubuntu.com/ubuntu-ports $codename main universe
+          deb [arch=arm64] https://ports.ubuntu.com/ubuntu-ports $codename-updates main universe
+          deb [arch=arm64] https://ports.ubuntu.com/ubuntu-ports $codename-security main universe
+          EOF
+              ;;
+            *)
+              echo "Unsupported Linux build architecture: $architecture" >&2
+              exit 1
+              ;;
+          esac
+
+          apt_options=(
+            -o "Dir::Etc::sourcelist=$sources_file"
+            -o "Dir::Etc::sourceparts=-"
+            -o "Acquire::ForceIPv4=true"
+            -o "Acquire::Retries=2"
+            -o "Acquire::https::Timeout=20"
+          )
+
+          sudo timeout 180 apt-get "${apt_options[@]}" update
+          sudo timeout 180 apt-get "${apt_options[@]}" install -y --no-install-recommends \
             build-essential \
             cmake \
             pkg-config \


### PR DESCRIPTION
## Summary
- bypass GitHub runner mirror lists and third-party APT sources
- select Ubuntu canonical archives explicitly for x64 and ARM64
- force IPv4 and bound mirror retries and each APT command to three minutes
- retain the same Linux build dependency set

## Why
Two release runs spent more than 20 minutes retrying the hosted runner's unhealthy Azure Ubuntu mirror. The build only needs Ubuntu archive packages, so unrelated runner mirrors should not be part of the release path.

## Validation
- all six configured canonical Ubuntu pocket URLs return HTTP 200 over IPv4
- `git diff --check`
- release workflow run after merge is the end-to-end validation