### PR TITLE
Fix packaged updater ASAR extraction handoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "deadcode": "bun run doctor",
     "react-doctor": "bun run doctor",
     "typography:audit": "bun ./scripts/audit-typography.ts",
-    "pack:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev pack 0.1.71-dev.0",
-    "publish:howcode:dev:dry-run": "bun ./scripts/pack-howcode-launcher.ts dev publish-dry-run 0.1.71-dev.0",
+    "pack:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev pack 0.1.72-dev.0",
+    "publish:howcode:dev:dry-run": "bun ./scripts/pack-howcode-launcher.ts dev publish-dry-run 0.1.72-dev.0",
     "publish:howcode": "bun ./scripts/pack-howcode-launcher.ts main publish",
-    "publish:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev publish 0.1.71-dev.0",
+    "publish:howcode:dev": "bun ./scripts/pack-howcode-launcher.ts dev publish 0.1.72-dev.0",
     "typography:generate": "bun ./scripts/generate-typography-css.ts",
     "polls:deploy": "cd workers/polls && bunx wrangler deploy",
     "polls:migrate": "cd workers/polls && bunx wrangler d1 migrations apply howcode_polls --remote"

--- a/packages/howcode/lib/integration.js
+++ b/packages/howcode/lib/integration.js
@@ -41,35 +41,65 @@ function getLinuxCommandLauncherPath() {
   return path.join(process.env.XDG_BIN_HOME || path.join(os.homedir(), '.local', 'bin'), APP_NAME)
 }
 
-async function writeLinuxCommandLauncher(paths) {
-  const launcherPath = getLinuxCommandLauncherPath()
-  const launcherContents = [
+function isLegacyLinuxCommandLauncher(launcherContents) {
+  const lines = launcherContents.trimEnd().split('\n')
+  const executablePrefix = '    exec '
+  const executableSuffix = ' --howcode-headless --ozone-platform=headless "$@"'
+  const headlessCommand = lines[5]
+  if (
+    !(headlessCommand?.startsWith(executablePrefix) && headlessCommand.endsWith(executableSuffix))
+  )
+    return false
+  const executable = headlessCommand.slice(executablePrefix.length, -executableSuffix.length)
+  if (!(executable.includes('/versions/') && executable.endsWith("/howcode/howcode'"))) return false
+
+  const expectedLines = [
     '#!/bin/sh',
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: This is a shell parameter expansion.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Matches the generated legacy shell syntax.
     'export HOWCODE_REPO_ROOT=${HOWCODE_REPO_ROOT:-$(pwd)}',
     'if [ "$1" = "--headless" ] || [ "$HOWCODE_HEADLESS" = "1" ]; then',
     '  if [ "$1" = "--headless" ]; then',
     '    shift',
-    `    exec ${shellSingleQuote(paths.executablePath)} --howcode-headless --ozone-platform=headless "$@"`,
+    `${executablePrefix}${executable}${executableSuffix}`,
     '  fi',
-    `  exec ${shellSingleQuote(paths.executablePath)} --ozone-platform=headless "$@"`,
+    `  exec ${executable} --ozone-platform=headless "$@"`,
     'fi',
     'if command -v setsid >/dev/null 2>&1; then',
-    `  setsid -f ${shellSingleQuote(paths.executablePath)} "$@" >/dev/null 2>&1 </dev/null`,
+    `  setsid -f ${executable} "$@" >/dev/null 2>&1 </dev/null`,
     'else',
-    `  nohup ${shellSingleQuote(paths.executablePath)} "$@" >/dev/null 2>&1 </dev/null &`,
+    `  nohup ${executable} "$@" >/dev/null 2>&1 </dev/null &`,
     'fi',
     'exit 0',
-    '',
-  ].join('\n')
-  await fsp.mkdir(path.dirname(launcherPath), { recursive: true })
-  await fsp.writeFile(launcherPath, launcherContents, { encoding: 'utf8', mode: 0o755 })
-  await fsp.chmod(launcherPath, 0o755)
-  const pathEntries = (process.env.PATH || '').split(path.delimiter).filter(Boolean)
-  if (!pathEntries.includes(path.dirname(launcherPath))) {
-    console.warn(
-      `howcode: created ${launcherPath}, but ${path.dirname(launcherPath)} is not in PATH.`,
-    )
+  ]
+  return (
+    lines.length === expectedLines.length &&
+    lines.every((line, index) => line === expectedLines[index])
+  )
+}
+
+async function removeLegacyLinuxCommandLauncher() {
+  const launcherPath = getLinuxCommandLauncherPath()
+  let launcherStats
+  try {
+    launcherStats = await fsp.lstat(launcherPath)
+  } catch (error) {
+    if (error?.code === 'ENOENT') return
+    throw error
+  }
+  if (!launcherStats.isFile()) return
+  const launcherContents = await fsp.readFile(launcherPath, 'utf8')
+  if (!isLegacyLinuxCommandLauncher(launcherContents)) return
+  await fsp.rm(launcherPath, { force: true })
+}
+
+async function removeObsoleteCommandLaunchIntegration(target) {
+  if (target.os !== 'linux') return true
+  try {
+    await removeLegacyLinuxCommandLauncher()
+    return true
+  } catch (error) {
+    console.warn(`howcode: could not remove legacy command launcher: ${error.message || error}`)
+    return false
   }
 }
 
@@ -160,15 +190,7 @@ async function createWindowsStartMenuShortcut(paths) {
 }
 
 async function ensureCommandLaunchIntegration(target, paths) {
-  if (target.os === 'linux') {
-    try {
-      await writeLinuxCommandLauncher(paths)
-      return true
-    } catch (error) {
-      console.warn(`howcode: could not create command launcher: ${error.message || error}`)
-      return false
-    }
-  }
+  if (target.os === 'linux') return true
   if (target.os !== 'win') return true
   try {
     await writeWindowsCommandLauncher(paths)
@@ -180,4 +202,8 @@ async function ensureCommandLaunchIntegration(target, paths) {
   }
 }
 
-module.exports = { ensureCommandLaunchIntegration, spawnLinuxDetachedLauncher }
+module.exports = {
+  ensureCommandLaunchIntegration,
+  removeObsoleteCommandLaunchIntegration,
+  spawnLinuxDetachedLauncher,
+}

--- a/packages/howcode/lib/main.js
+++ b/packages/howcode/lib/main.js
@@ -2,7 +2,10 @@ const path = require('node:path')
 const fsp = require('node:fs/promises')
 const { getReleaseChannel, getTarget } = require('./config')
 const { getCacheRoot, getPaths, isValidInstall, readJsonIfPresent } = require('./cache')
-const { ensureCommandLaunchIntegration } = require('./integration')
+const {
+  ensureCommandLaunchIntegration,
+  removeObsoleteCommandLaunchIntegration,
+} = require('./integration')
 const { resolveLatestRelease } = require('./release')
 const { ensureInstalled } = require('./installer')
 const { launch } = require('./process-launcher')
@@ -13,6 +16,7 @@ async function main() {
   const cacheRoot = getCacheRoot()
   const channel = getReleaseChannel()
   await fsp.mkdir(cacheRoot, { recursive: true })
+  await removeObsoleteCommandLaunchIntegration(target)
 
   const currentFile = path.join(cacheRoot, `current-${channel}.json`)
   const current =

--- a/packages/howcode/package.json
+++ b/packages/howcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "howcode",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "Desktop coding app for Pi with projects, terminal, git, and diff workflows.",
   "license": "MIT",
   "author": "Igor Warzocha",

--- a/packages/howcode/test/integration.test.ts
+++ b/packages/howcode/test/integration.test.ts
@@ -1,0 +1,80 @@
+import { lstat, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const { removeObsoleteCommandLaunchIntegration } = require('../lib/integration.js') as {
+  removeObsoleteCommandLaunchIntegration: (target: { os: string }) => Promise<boolean>
+}
+
+const originalXdgBinHome = process.env.XDG_BIN_HOME
+let temporaryRoot: string | null = null
+
+afterEach(async () => {
+  if (originalXdgBinHome === undefined) delete process.env.XDG_BIN_HOME
+  else process.env.XDG_BIN_HOME = originalXdgBinHome
+  if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true })
+  temporaryRoot = null
+})
+
+async function setTemporaryBinHome() {
+  temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'howcode-launcher-test-'))
+  process.env.XDG_BIN_HOME = temporaryRoot
+  return path.join(temporaryRoot, 'howcode')
+}
+
+describe('Linux command launcher cleanup', () => {
+  it('removes only the obsolete generated wrapper', async () => {
+    const launcherPath = await setTemporaryBinHome()
+    const executable = "'/home/test/.cache/howcode/versions/dev-0.1.67-abc/howcode/howcode'"
+    await writeFile(
+      launcherPath,
+      [
+        '#!/bin/sh',
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: Reproduces the generated legacy shell syntax.
+        'export HOWCODE_REPO_ROOT=${HOWCODE_REPO_ROOT:-$(pwd)}',
+        'if [ "$1" = "--headless" ] || [ "$HOWCODE_HEADLESS" = "1" ]; then',
+        '  if [ "$1" = "--headless" ]; then',
+        '    shift',
+        `    exec ${executable} --howcode-headless --ozone-platform=headless "$@"`,
+        '  fi',
+        `  exec ${executable} --ozone-platform=headless "$@"`,
+        'fi',
+        'if command -v setsid >/dev/null 2>&1; then',
+        `  setsid -f ${executable} "$@" >/dev/null 2>&1 </dev/null`,
+        'else',
+        `  nohup ${executable} "$@" >/dev/null 2>&1 </dev/null &`,
+        'fi',
+        'exit 0',
+      ].join('\n'),
+    )
+
+    await expect(removeObsoleteCommandLaunchIntegration({ os: 'linux' })).resolves.toBe(true)
+    await expect(lstat(launcherPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('preserves unrelated files and package-manager symlinks', async () => {
+    const launcherPath = await setTemporaryBinHome()
+    await writeFile(
+      launcherPath,
+      [
+        '#!/bin/sh',
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: Exercises a partial legacy-wrapper match.
+        'export HOWCODE_REPO_ROOT=${HOWCODE_REPO_ROOT:-$(pwd)}',
+        'if [ "$1" = "--headless" ] || [ "$HOWCODE_HEADLESS" = "1" ]; then',
+        'echo --howcode-headless --ozone-platform=headless',
+      ].join('\n'),
+    )
+    await removeObsoleteCommandLaunchIntegration({ os: 'linux' })
+    await expect(readFile(launcherPath, 'utf8')).resolves.toContain('echo --howcode-headless')
+
+    await rm(launcherPath)
+    const packageBin = path.join(temporaryRoot ?? '', 'package-howcode')
+    await writeFile(packageBin, '#!/usr/bin/env node\n')
+    await symlink(packageBin, launcherPath)
+    await removeObsoleteCommandLaunchIntegration({ os: 'linux' })
+    await expect(lstat(launcherPath).then((stats) => stats.isSymbolicLink())).resolves.toBe(true)
+  })
+})

--- a/src/electron/main/updater/update-archive.test.ts
+++ b/src/electron/main/updater/update-archive.test.ts
@@ -1,0 +1,33 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { c as createTar } from 'tar'
+import { afterEach, describe, expect, it } from 'vitest'
+import { extractUpdateArchive } from './update-archive'
+
+let temporaryRoot: string | null = null
+
+afterEach(async () => {
+  if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true })
+  temporaryRoot = null
+})
+
+describe('update archive extraction', () => {
+  it('extracts an app.asar as an ordinary file', async () => {
+    temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'howcode-update-archive-test-'))
+    const sourceRoot = path.join(temporaryRoot, 'source')
+    const resourcesPath = path.join(sourceRoot, 'howcode', 'resources')
+    const destinationPath = path.join(temporaryRoot, 'destination')
+    const archivePath = path.join(temporaryRoot, 'update.tar.gz')
+    await mkdir(resourcesPath, { recursive: true })
+    await mkdir(destinationPath)
+    await writeFile(path.join(resourcesPath, 'app.asar'), 'packaged-app')
+    await createTar({ cwd: sourceRoot, file: archivePath, gzip: true }, ['howcode'])
+
+    await extractUpdateArchive(archivePath, destinationPath)
+
+    await expect(
+      readFile(path.join(destinationPath, 'howcode', 'resources', 'app.asar'), 'utf8'),
+    ).resolves.toBe('packaged-app')
+  })
+})

--- a/src/electron/main/updater/update-archive.ts
+++ b/src/electron/main/updater/update-archive.ts
@@ -1,0 +1,55 @@
+import { execFile } from 'node:child_process'
+import { accessSync, constants } from 'node:fs'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+function getProcessEnvironmentVariable(name: string) {
+  return process.env[name]
+}
+
+function getSystemTarPath() {
+  const candidates =
+    process.platform === 'win32' ? getWindowsTarCandidates() : getUnixTarCandidates()
+  const executablePath = candidates.find((candidate) => {
+    try {
+      accessSync(candidate, constants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  })
+  if (!executablePath) {
+    throw new Error(`Could not find the system tar executable. Checked ${candidates.join(', ')}.`)
+  }
+  return executablePath
+}
+
+function getWindowsTarCandidates() {
+  return [
+    path.join(
+      getProcessEnvironmentVariable('SystemRoot') ??
+        getProcessEnvironmentVariable('SYSTEMROOT') ??
+        'C:\\Windows',
+      'System32',
+      'tar.exe',
+    ),
+  ]
+}
+
+function getUnixTarCandidates() {
+  const pathCandidates = (getProcessEnvironmentVariable('PATH') ?? '')
+    .split(path.delimiter)
+    .filter((entry) => path.isAbsolute(entry))
+    .map((entry) => path.join(entry, 'tar'))
+  return [...new Set(['/usr/bin/tar', '/bin/tar', ...pathCandidates])]
+}
+
+export async function extractUpdateArchive(archivePath: string, destinationPath: string) {
+  // Electron's fs shim treats an output path ending in app.asar as an archive. Extract out of
+  // process so the packaged app bundle is written as an ordinary file.
+  await execFileAsync(getSystemTarPath(), ['-xzf', archivePath, '-C', destinationPath], {
+    windowsHide: true,
+  })
+}

--- a/src/electron/main/updater/update-installer.ts
+++ b/src/electron/main/updater/update-installer.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, rename, rm } from 'node:fs/promises'
 import path from 'node:path'
-import { x as extractTar } from 'tar'
+import { extractUpdateArchive } from './update-archive'
 import { withUpdateLock } from './update-lock'
 import {
   getAppResourcesPath,
@@ -89,7 +89,7 @@ async function installUpdateBundleUnderLock(
     }
     onInstalling()
     await mkdir(temporaryPaths.installDir, { recursive: true })
-    await extractTar({ file: archivePath, cwd: temporaryPaths.installDir })
+    await extractUpdateArchive(archivePath, temporaryPaths.installDir)
     const extractedExecutablePath = path.join(temporaryPaths.installDir, target.executable)
     if (!existsSync(extractedExecutablePath)) {
       throw new Error(`Downloaded archive did not contain ${target.executable}.`)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,12 @@ import viteConfig from './vite.config'
 
 export default mergeConfig(viteConfig, {
   test: {
-    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'desktop/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+      'desktop/**/*.test.ts',
+      'packages/howcode/test/**/*.test.ts',
+    ],
     exclude: ['node_modules/**', 'dist/**', 'build/**', 'Frameworks/**'],
   },
 })


### PR DESCRIPTION
## Summary
- extract update archives out of process with the OS tar executable so Electron does not swallow `app.asar`
- remove only the exact obsolete Linux wrapper that shadows npm/Bun launchers
- bump launcher publish versions to `0.1.72` and `0.1.72-dev.0`
- add updater archive and legacy-wrapper migration contracts to the umbrella test suite

## Root cause
Electron patches Node filesystem handling for paths ending in `app.asar`. The in-app updater used the JavaScript tar library inside Electron, which extracted the executable but silently omitted the packaged `app.asar`. Separately, old Linux installs generated `~/.local/bin/howcode` as a frozen direct-app wrapper, shadowing `bunx` and global package launchers.

## Validation
- exact released Linux archive and old tar package extract correctly under stock Node
- exact archive under Electron + JavaScript tar reproduces `{ executable: true, asar: false }`
- committed OS-tar helper under Electron produces `{ executable: true, asar: true }`
- full gate: 47 test files / 114 tests, React Doctor 100
- launcher dry-runs clean for `0.1.72` and `0.1.72-dev.0`