### PR TITLE
Isolate updater staging retries

### DIFF
--- a/src/electron/main/updater/update-installer.ts
+++ b/src/electron/main/updater/update-installer.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, rename, rm } from 'node:fs/promises'
 import path from 'node:path'
@@ -77,7 +78,7 @@ async function installUpdateBundleUnderLock(
     (await isValidInstall(paths, target))
   if (!existingCacheTrusted) {
     temporaryPaths.root = path.join(paths.cacheRoot, `.tmp-update-${Date.now()}-${process.pid}`)
-    temporaryPaths.installDir = `${paths.installDir}.partial`
+    temporaryPaths.installDir = `${paths.installDir}.partial-${process.pid}-${randomUUID()}`
     const archivePath = path.join(temporaryPaths.root, `howcode-${target.os}-${target.arch}.tar.gz`)
     await rm(temporaryPaths.root, { recursive: true, force: true })
     await rm(temporaryPaths.installDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- give each in-app update attempt a unique staging directory
- prevent a failed installer cleanup from deleting a waiting retry

## Why
The update lock was released before outer cleanup removed the shared `.partial` directory. A waiting retry could acquire the lock and begin staging while the previous attempt was still recursively deleting that same path. Unique staging directories remove the cross-attempt collision.

## Validation
- identified during review of #313
- included in the final full gate on the main fix branch: 47 test files / 114 tests, React Doctor 100