### PR TITLE
Remove obsolete Linux launcher wrapper

### DIFF
--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -14,6 +14,7 @@ import { getRelaunchArguments, shouldTakeoverAtStartup } from './runtime/relaunc
 import { registerDesktopRuntimeShutdown } from './runtime/shutdown'
 import { AppUpdater } from './updater/app-updater'
 import { startRunningVersionLease } from './updater/update-active-lease'
+import { removeLegacyLinuxCommandLauncher } from './updater/update-legacy-integration'
 import { getCacheRoot, getRunningCachedVersionDir } from './updater/update-storage'
 
 let currentMainWindow: BrowserWindow | null = null
@@ -46,6 +47,7 @@ async function openMainWindow() {
 
 async function bootstrap() {
   await app.whenReady()
+  if (app.isPackaged) await removeLegacyLinuxCommandLauncher()
   const stopRunningVersionLease = await startRunningVersionLease(
     getCacheRoot(),
     getRunningCachedVersionDir(),

--- a/src/electron/main/updater/update-legacy-integration.test.ts
+++ b/src/electron/main/updater/update-legacy-integration.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { isLegacyLinuxCommandLauncher } from './update-legacy-integration'
+
+const executable = "'/home/test/.cache/howcode/versions/dev-0.1.67-abc/howcode/howcode'"
+const generatedWrapper = [
+  '#!/bin/sh',
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: Reproduces the generated legacy shell syntax.
+  'export HOWCODE_REPO_ROOT=${HOWCODE_REPO_ROOT:-$(pwd)}',
+  'if [ "$1" = "--headless" ] || [ "$HOWCODE_HEADLESS" = "1" ]; then',
+  '  if [ "$1" = "--headless" ]; then',
+  '    shift',
+  `    exec ${executable} --howcode-headless --ozone-platform=headless "$@"`,
+  '  fi',
+  `  exec ${executable} --ozone-platform=headless "$@"`,
+  'fi',
+  'if command -v setsid >/dev/null 2>&1; then',
+  `  setsid -f ${executable} "$@" >/dev/null 2>&1 </dev/null`,
+  'else',
+  `  nohup ${executable} "$@" >/dev/null 2>&1 </dev/null &`,
+  'fi',
+  'exit 0',
+].join('\n')
+
+describe('legacy Linux command launcher detection', () => {
+  it('recognizes the exact generated wrapper', () => {
+    expect(isLegacyLinuxCommandLauncher(generatedWrapper)).toBe(true)
+  })
+
+  it('rejects partial matches and modified commands', () => {
+    expect(isLegacyLinuxCommandLauncher(`${generatedWrapper}\necho custom`)).toBe(false)
+    expect(isLegacyLinuxCommandLauncher(generatedWrapper.replace('setsid -f', 'exec'))).toBe(false)
+  })
+})

--- a/src/electron/main/updater/update-legacy-integration.ts
+++ b/src/electron/main/updater/update-legacy-integration.ts
@@ -1,0 +1,60 @@
+import { lstat, readFile, rm } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+function getProcessEnvironmentVariable(name: string) {
+  return process.env[name]
+}
+
+export function isLegacyLinuxCommandLauncher(launcherContents: string) {
+  const lines = launcherContents.trimEnd().split('\n')
+  const executablePrefix = '    exec '
+  const executableSuffix = ' --howcode-headless --ozone-platform=headless "$@"'
+  const headlessCommand = lines[5]
+  if (
+    !(headlessCommand?.startsWith(executablePrefix) && headlessCommand.endsWith(executableSuffix))
+  )
+    return false
+  const executable = headlessCommand.slice(executablePrefix.length, -executableSuffix.length)
+  if (!(executable.includes('/versions/') && executable.endsWith("/howcode/howcode'"))) return false
+
+  const expectedLines = [
+    '#!/bin/sh',
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Matches the generated legacy shell syntax.
+    'export HOWCODE_REPO_ROOT=${HOWCODE_REPO_ROOT:-$(pwd)}',
+    'if [ "$1" = "--headless" ] || [ "$HOWCODE_HEADLESS" = "1" ]; then',
+    '  if [ "$1" = "--headless" ]; then',
+    '    shift',
+    `${executablePrefix}${executable}${executableSuffix}`,
+    '  fi',
+    `  exec ${executable} --ozone-platform=headless "$@"`,
+    'fi',
+    'if command -v setsid >/dev/null 2>&1; then',
+    `  setsid -f ${executable} "$@" >/dev/null 2>&1 </dev/null`,
+    'else',
+    `  nohup ${executable} "$@" >/dev/null 2>&1 </dev/null &`,
+    'fi',
+    'exit 0',
+  ]
+  return (
+    lines.length === expectedLines.length &&
+    lines.every((line, index) => line === expectedLines[index])
+  )
+}
+
+export async function removeLegacyLinuxCommandLauncher() {
+  if (process.platform !== 'linux') return
+  const launcherPath = path.join(
+    getProcessEnvironmentVariable('XDG_BIN_HOME') ?? path.join(homedir(), '.local', 'bin'),
+    'howcode',
+  )
+  try {
+    const launcherStats = await lstat(launcherPath)
+    if (!launcherStats.isFile()) return
+    if (!isLegacyLinuxCommandLauncher(await readFile(launcherPath, 'utf8'))) return
+    await rm(launcherPath, { force: true })
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return
+    console.warn(`[howcode updater] could not remove legacy command launcher: ${String(error)}`)
+  }
+}


### PR DESCRIPTION
## Summary
- remove only the exact Linux command wrapper generated by older Howcode launchers
- run the migration from the packaged app as well as the npm launcher
- restore `bunx howcode` as the canonical entry point after the repaired app starts

## Safety
The migration requires the exact generated 15-line wrapper and one repeated cached executable. Modified user commands and package-manager symlinks are retained.

## Validation
- exact-wrapper and partial-match contracts
- full gate: 48 test files / 116 tests, React Doctor 100